### PR TITLE
fix: Make OG image URLs absolute for social media crawlers

### DIFF
--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,4 +1,6 @@
 import { Title, Meta } from "@solidjs/meta";
+import { isServer } from "solid-js/web";
+import { getRequestEvent } from "solid-js/web";
 
 interface MetaProps {
 	title: string | number;
@@ -11,7 +13,19 @@ export default function Metadata(props: MetaProps) {
 		props.metaContent ||
 		"Tom Hackshaw is a design engineer from Aotearoa New Zealand.";
 
-	const ogImageUrl = `/api/og?title=${encodeURIComponent(props.title.toString())}&summary=${encodeURIComponent(description)}`;
+	let baseUrl = "https://tom.so";
+	
+	if (isServer) {
+		const event = getRequestEvent();
+		if (event?.request) {
+			const url = new URL(event.request.url);
+			baseUrl = `${url.protocol}//${url.host}`;
+		}
+	} else if (typeof window !== "undefined") {
+		baseUrl = `${window.location.protocol}//${window.location.host}`;
+	}
+
+	const ogImageUrl = `${baseUrl}/api/og?title=${encodeURIComponent(props.title.toString())}&summary=${encodeURIComponent(description)}`;
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

- Fixed OG preview images not working for dynamic routes (posts/work)
- Made OG image URLs absolute instead of relative
- Social media crawlers now receive proper meta tags with absolute URLs

## Changes

- Updated `Meta.tsx` to generate absolute URLs using request context on the server and window.location on the client
- Falls back to production URL (https://tom.so) when needed
- Preserves title and summary parameters in OG image generation

Fixes issue where dynamic routes loaded from Strapi weren't generating proper social media previews.