### PR TITLE
feat(effect): migrate to modern Effect patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,20 @@
 ## [1.79.9](https://github.com/et0and/wwwtom/compare/v1.79.8...v1.79.9) (2026-03-13)
 
-
 ### Bug Fixes
 
-* **packages:** use type safe const obj, not loose enums ([70dcb4c](https://github.com/et0and/wwwtom/commit/70dcb4c5bc3c7d441992c03c777075d2b55eb23e))
+- **packages:** use type safe const obj, not loose enums ([70dcb4c](https://github.com/et0and/wwwtom/commit/70dcb4c5bc3c7d441992c03c777075d2b55eb23e))
 
 ## [1.79.8](https://github.com/et0and/wwwtom/compare/v1.79.7...v1.79.8) (2026-03-09)
 
-
 ### Bug Fixes
 
-* **web:** fetch from client if ss fetch fails ([2b4a6ea](https://github.com/et0and/wwwtom/commit/2b4a6eaa9c717b8aade45fd36b68c8bfd90a1b2f))
+- **web:** fetch from client if ss fetch fails ([2b4a6ea](https://github.com/et0and/wwwtom/commit/2b4a6eaa9c717b8aade45fd36b68c8bfd90a1b2f))
 
 ## [1.79.7](https://github.com/et0and/wwwtom/compare/v1.79.6...v1.79.7) (2026-03-09)
 
-
 ### Bug Fixes
 
-* 😔 ([0bebb3e](https://github.com/et0and/wwwtom/commit/0bebb3ea50c8ae274dc5e3315b0a9acb0a7c481f))
+- 😔 ([0bebb3e](https://github.com/et0and/wwwtom/commit/0bebb3ea50c8ae274dc5e3315b0a9acb0a7c481f))
 
 ## [1.79.6](https://github.com/et0and/wwwtom/compare/v1.79.5...v1.79.6) (2026-03-09)
 

--- a/apps/api/src/config/effect.ts
+++ b/apps/api/src/config/effect.ts
@@ -1,5 +1,5 @@
 import { Effect, Layer, Logger, LogLevel } from "effect";
-import { TelegramService, TelegramServiceLive, makeAppConfigLayer } from "@tom/utils/services";
+import { TelegramService, makeAppConfigLayer } from "@tom/utils/services";
 import type { CloudflareEnv } from "@tom/utils/services";
 
 export type Env = CloudflareEnv;
@@ -15,7 +15,7 @@ export const createApiLayer = (env: Env) => {
     TELEGRAM_BOT_TOKEN: env.TELEGRAM_BOT_TOKEN,
     TELEGRAM_CHAT_ID: env.TELEGRAM_CHAT_ID,
   });
-  return Layer.provide(TelegramServiceLive, configLayer);
+  return Layer.provide(TelegramService.Default, configLayer);
 };
 
 export const sendErrorAlert = (env: Env, message: string, error?: unknown) => {

--- a/apps/web/src/libs/actions/arena/blocks.integration.spec.ts
+++ b/apps/web/src/libs/actions/arena/blocks.integration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { Effect, Layer, Redacted } from "effect";
-import { ArenaService, ArenaServiceLive } from "@tom/arena/service";
+import { Effect, Layer } from "effect";
+import { ArenaService } from "@tom/arena/service";
 import { AppConfig } from "@tom/utils/services";
 import { fetchArena } from "~/libs/actions/arena/client";
 
@@ -13,15 +13,13 @@ function getArenaToken(): string | undefined {
 
 function createTestLayer() {
   const token = getArenaToken() ?? "";
-  const configLayer = Layer.succeed(AppConfig, {
-    arenaToken: Redacted.make(token),
-    payloadUrl: Redacted.make(""),
-    databaseUrl: Redacted.make(""),
-    telegramBotToken: undefined,
-    telegramChatId: undefined,
-    isDev: true,
+  const configLayer = AppConfig.fromEnv({
+    ARENA_TOKEN: token,
+    PAYLOAD_URL: "",
+    DATABASE_URL: "",
+    NODE_ENV: "development",
   });
-  return Layer.provideMerge(ArenaServiceLive, configLayer);
+  return Layer.provideMerge(ArenaService.Default, configLayer);
 }
 
 function runTestEffect<A, E>(effect: Effect.Effect<A, E, ArenaService>): Promise<A> {

--- a/apps/web/src/libs/actions/arena/channels.integration.spec.ts
+++ b/apps/web/src/libs/actions/arena/channels.integration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { Effect, Layer, Redacted } from "effect";
-import { ArenaService, ArenaServiceLive } from "@tom/arena/service";
+import { Effect, Layer } from "effect";
+import { ArenaService } from "@tom/arena/service";
 import { AppConfig } from "@tom/utils/services";
 import { fetchArena } from "~/libs/actions/arena/client";
 
@@ -13,15 +13,13 @@ function getArenaToken(): string | undefined {
 
 function createTestLayer() {
   const token = getArenaToken() ?? "";
-  const configLayer = Layer.succeed(AppConfig, {
-    arenaToken: Redacted.make(token),
-    payloadUrl: Redacted.make(""),
-    databaseUrl: Redacted.make(""),
-    telegramBotToken: undefined,
-    telegramChatId: undefined,
-    isDev: true,
+  const configLayer = AppConfig.fromEnv({
+    ARENA_TOKEN: token,
+    PAYLOAD_URL: "",
+    DATABASE_URL: "",
+    NODE_ENV: "development",
   });
-  return Layer.provideMerge(ArenaServiceLive, configLayer);
+  return Layer.provideMerge(ArenaService.Default, configLayer);
 }
 
 function runTestEffect<A, E>(effect: Effect.Effect<A, E, ArenaService>): Promise<A> {

--- a/apps/web/src/libs/actions/arena/users.integration.spec.ts
+++ b/apps/web/src/libs/actions/arena/users.integration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { Effect, Layer, Redacted } from "effect";
-import { ArenaService, ArenaServiceLive } from "@tom/arena/service";
+import { Effect, Layer } from "effect";
+import { ArenaService } from "@tom/arena/service";
 import { AppConfig } from "@tom/utils/services";
 import { fetchArena } from "~/libs/actions/arena/client";
 
@@ -13,15 +13,13 @@ function getArenaToken(): string | undefined {
 
 function createTestLayer() {
   const token = getArenaToken() ?? "";
-  const configLayer = Layer.succeed(AppConfig, {
-    arenaToken: Redacted.make(token),
-    payloadUrl: Redacted.make(""),
-    databaseUrl: Redacted.make(""),
-    telegramBotToken: undefined,
-    telegramChatId: undefined,
-    isDev: true,
+  const configLayer = AppConfig.fromEnv({
+    ARENA_TOKEN: token,
+    PAYLOAD_URL: "",
+    DATABASE_URL: "",
+    NODE_ENV: "development",
   });
-  return Layer.provideMerge(ArenaServiceLive, configLayer);
+  return Layer.provideMerge(ArenaService.Default, configLayer);
 }
 
 function runTestEffect<A, E>(effect: Effect.Effect<A, E, ArenaService>): Promise<A> {

--- a/apps/web/src/libs/runtime.ts
+++ b/apps/web/src/libs/runtime.ts
@@ -3,19 +3,23 @@
 import { Effect, Layer, Logger, LogLevel } from "effect";
 import { getRequestEvent } from "solid-js/web";
 import type { CloudflareEnv } from "@tom/utils/services";
-import { AppConfig, makeAppConfigLayer } from "@tom/utils/services";
-import { DatabaseService, DatabaseServiceLive } from "@tom/db/service";
-import { PayloadService, PayloadServiceLive } from "@tom/payload/service";
-import { ArenaService, ArenaServiceLive } from "@tom/arena/service";
+import { AppConfig } from "@tom/utils/services";
+import { DatabaseService } from "@tom/db/service";
+import { PayloadService } from "@tom/payload/service";
+import { ArenaService } from "@tom/arena/service";
 
 export type AllServices = AppConfig | DatabaseService | PayloadService | ArenaService;
 
-const AllServicesLive = Layer.mergeAll(DatabaseServiceLive, PayloadServiceLive, ArenaServiceLive);
+const AllServicesLive = Layer.mergeAll(
+  DatabaseService.Default,
+  PayloadService.Default,
+  ArenaService.Default,
+);
 
 export type CompositeLayer = Layer.Layer<AllServices>;
 
 export const createServicesLayer = (env: CloudflareEnv): CompositeLayer => {
-  const configLayer = makeAppConfigLayer(env);
+  const configLayer = AppConfig.fromEnv(env);
   const servicesWithConfig = Layer.provide(AllServicesLive, configLayer);
   return Layer.merge(configLayer, servicesWithConfig) as CompositeLayer;
 };

--- a/packages/@tom/arena/src/service.ts
+++ b/packages/@tom/arena/src/service.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Effect, Redacted } from "effect";
 import { AppConfig } from "@tom/utils/services";
 import { ArenaClient, type ArenaApi } from "./client";
 
@@ -14,11 +14,10 @@ export interface ArenaServiceShape {
   readonly publicClient: ArenaApi;
 }
 
-export class ArenaService extends Context.Tag("ArenaService")<ArenaService, ArenaServiceShape>() {}
-
-export const ArenaServiceLive = Layer.effect(
-  ArenaService,
-  Effect.gen(function* () {
+export class ArenaService extends Effect.Service<ArenaService>()("ArenaService", {
+  accessors: true,
+  dependencies: [AppConfig.Default],
+  effect: Effect.gen(function* () {
     const config = yield* AppConfig;
     const token = config.arenaToken ? Redacted.value(config.arenaToken) : null;
 
@@ -29,4 +28,4 @@ export const ArenaServiceLive = Layer.effect(
 
     return { client, publicClient };
   }),
-);
+}) {}

--- a/packages/@tom/checkout/src/index.ts
+++ b/packages/@tom/checkout/src/index.ts
@@ -11,105 +11,105 @@ export const formatPrice = (product: Product): string => {
   return amt !== undefined && amt !== null ? `$${amt / 100}` : "Free";
 };
 
-export const fetchProducts = (isDev: boolean): Effect.Effect<Product[], HttpError> =>
-  Effect.gen(function* () {
-    const base = getCheckoutApiBase(isDev);
-    const response = yield* Effect.tryPromise({
-      try: () => fetch(`${base}/products`),
-      catch: () => new HttpError({ message: "Network error", status: 0 }),
-    });
+export const fetchProducts = Effect.fn("fetchProducts")(
+  (isDev: boolean): Effect.Effect<Product[], HttpError> =>
+    Effect.gen(function* () {
+      const base = getCheckoutApiBase(isDev);
+      const response = yield* Effect.tryPromise({
+        try: () => fetch(`${base}/products`),
+        catch: () => new HttpError({ message: "Network error", status: 0 }),
+      });
 
-    if (!response.ok) {
-      return yield* Effect.fail(
-        new HttpError({
-          message: "Failed to load products",
-          status: response.status,
-        }),
-      );
-    }
-
-    return yield* Effect.tryPromise({
-      try: () => response.json() as Promise<Product[]>,
-      catch: () =>
-        new HttpError({
-          message: "Failed to parse response",
-          status: HttpStatus.InternalServerError,
-        }),
-    });
-  });
-
-export const fetchProduct = (
-  productId: string,
-  isDev: boolean,
-): Effect.Effect<Product, HttpError> =>
-  Effect.gen(function* () {
-    const base = getCheckoutApiBase(isDev);
-    const response = yield* Effect.tryPromise({
-      try: () => fetch(`${base}/products/${productId}`),
-      catch: () => new HttpError({ message: "Network error", status: 0 }),
-    });
-
-    if (!response.ok) {
-      return yield* Effect.fail(
-        new HttpError({
-          message: "Failed to load product",
-          status: response.status,
-        }),
-      );
-    }
-
-    return yield* Effect.tryPromise({
-      try: () => response.json() as Promise<Product>,
-      catch: () =>
-        new HttpError({
-          message: "Failed to parse response",
-          status: HttpStatus.InternalServerError,
-        }),
-    });
-  });
-
-export const createCustomer = (
-  input: CustomerInput,
-  isDev: boolean,
-): Effect.Effect<Customer, HttpError> =>
-  Effect.gen(function* () {
-    const base = getCheckoutApiBase(isDev);
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(`${base}/customers`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(input),
-        }),
-      catch: () => new HttpError({ message: "Network error", status: 0 }),
-    });
-
-    if (!response.ok) {
-      const errorData = yield* Effect.tryPromise({
-        try: () => response.json() as Promise<{ error?: string }>,
-        catch: () =>
+      if (!response.ok) {
+        return yield* Effect.fail(
           new HttpError({
-            message: "Failed to create customer",
+            message: "Failed to load products",
             status: response.status,
           }),
-      });
-      return yield* Effect.fail(
-        new HttpError({
-          message: errorData.error ?? "Failed to create customer",
-          status: response.status,
-        }),
-      );
-    }
+        );
+      }
 
-    return yield* Effect.tryPromise({
-      try: () => response.json() as Promise<Customer>,
-      catch: () =>
-        new HttpError({
-          message: "Failed to parse response",
-          status: HttpStatus.InternalServerError,
-        }),
-    });
-  });
+      return yield* Effect.tryPromise({
+        try: () => response.json() as Promise<Product[]>,
+        catch: () =>
+          new HttpError({
+            message: "Failed to parse response",
+            status: HttpStatus.InternalServerError,
+          }),
+      });
+    }),
+);
+
+export const fetchProduct = Effect.fn("fetchProduct")(
+  (productId: string, isDev: boolean): Effect.Effect<Product, HttpError> =>
+    Effect.gen(function* () {
+      const base = getCheckoutApiBase(isDev);
+      const response = yield* Effect.tryPromise({
+        try: () => fetch(`${base}/products/${productId}`),
+        catch: () => new HttpError({ message: "Network error", status: 0 }),
+      });
+
+      if (!response.ok) {
+        return yield* Effect.fail(
+          new HttpError({
+            message: "Failed to load product",
+            status: response.status,
+          }),
+        );
+      }
+
+      return yield* Effect.tryPromise({
+        try: () => response.json() as Promise<Product>,
+        catch: () =>
+          new HttpError({
+            message: "Failed to parse response",
+            status: HttpStatus.InternalServerError,
+          }),
+      });
+    }),
+);
+
+export const createCustomer = Effect.fn("createCustomer")(
+  (input: CustomerInput, isDev: boolean): Effect.Effect<Customer, HttpError> =>
+    Effect.gen(function* () {
+      const base = getCheckoutApiBase(isDev);
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          fetch(`${base}/customers`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(input),
+          }),
+        catch: () => new HttpError({ message: "Network error", status: 0 }),
+      });
+
+      if (!response.ok) {
+        const errorData = yield* Effect.tryPromise({
+          try: () => response.json() as Promise<{ error?: string }>,
+          catch: () =>
+            new HttpError({
+              message: "Failed to create customer",
+              status: response.status,
+            }),
+        });
+        return yield* Effect.fail(
+          new HttpError({
+            message: errorData.error ?? "Failed to create customer",
+            status: response.status,
+          }),
+        );
+      }
+
+      return yield* Effect.tryPromise({
+        try: () => response.json() as Promise<Customer>,
+        catch: () =>
+          new HttpError({
+            message: "Failed to parse response",
+            status: HttpStatus.InternalServerError,
+          }),
+      });
+    }),
+);
 
 export const getCheckoutUrl = (productId: string, customerId: string, isDev: boolean): string => {
   const base = getCheckoutApiBase(isDev);

--- a/packages/@tom/constants/src/http.ts
+++ b/packages/@tom/constants/src/http.ts
@@ -17,4 +17,4 @@ export const HttpStatus = {
   FunnyMemeStatus: 67,
 } as const;
 
-export type HttpStatus = typeof HttpStatus[keyof typeof HttpStatus];
+export type HttpStatus = (typeof HttpStatus)[keyof typeof HttpStatus];

--- a/packages/@tom/db/src/index.ts
+++ b/packages/@tom/db/src/index.ts
@@ -3,7 +3,6 @@
 // =============================================================================
 export {
   DatabaseService,
-  DatabaseServiceLive,
   type DatabaseServiceShape,
   type GuestbookEntry,
   type GuestbookEntryParams,

--- a/packages/@tom/db/src/service.ts
+++ b/packages/@tom/db/src/service.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Effect, Redacted } from "effect";
 import postgres from "postgres";
 import { Kysely } from "kysely";
 import { PostgresJSDialect } from "kysely-postgres-js";
@@ -69,11 +69,6 @@ export interface DatabaseServiceShape {
   readonly cleanupExpiredSessions: () => Effect.Effect<number, OAuthSessionError>;
 }
 
-export class DatabaseService extends Context.Tag("DatabaseService")<
-  DatabaseService,
-  DatabaseServiceShape
->() {}
-
 // Create Kysely connection from connection string
 const createConnection = (
   connectionString: string,
@@ -91,26 +86,26 @@ const createConnection = (
       }),
   });
 
-// Implementation using the Effect service pattern
-export const DatabaseServiceLive = Layer.effect(
-  DatabaseService,
-  Effect.gen(function* () {
+export class DatabaseService extends Effect.Service<DatabaseService>()("DatabaseService", {
+  accessors: true,
+  dependencies: [AppConfig.Default],
+  effect: Effect.gen(function* () {
     const config = yield* AppConfig;
     const connectionString = Redacted.value(config.databaseUrl);
 
     if (!connectionString) {
-      return yield* Effect.fail(
-        new DatabaseConnectionError({
-          message: "Database URL not configured",
-        }),
-      );
+      return yield* new DatabaseConnectionError({
+        message: "Database URL not configured",
+      });
     }
 
     const db = yield* createConnection(connectionString);
 
-    const service: DatabaseServiceShape = {
-      createGuestbookEntry: (params) =>
-        Effect.tryPromise({
+    return {
+      createGuestbookEntry: Effect.fn("DatabaseService.createGuestbookEntry")(function* (
+        params: GuestbookEntryParams,
+      ) {
+        return yield* Effect.tryPromise({
           try: async () =>
             await db
               .insertInto("guestbook_entries")
@@ -127,52 +122,57 @@ export const DatabaseServiceLive = Layer.effect(
             new GuestbookValidationError({
               message: `Failed to create guestbook entry: ${error}`,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
 
-      getGuestbookEntries: (params) =>
-        Effect.gen(function* () {
-          const page = params.page ?? 1;
-          const pageSize = params.page_size ?? 100;
-          const offset = (page - 1) * pageSize;
+      getGuestbookEntries: Effect.fn("DatabaseService.getGuestbookEntries")(function* (params: {
+        page?: number;
+        page_size?: number;
+      }) {
+        const page = params.page ?? 1;
+        const pageSize = params.page_size ?? 100;
+        const offset = (page - 1) * pageSize;
 
-          const [results, totalCountResult] = yield* Effect.all([
-            Effect.tryPromise({
-              try: async () =>
-                await db
-                  .selectFrom("guestbook_entries")
-                  .selectAll()
-                  .orderBy("created_at", "desc")
-                  .limit(pageSize)
-                  .offset(offset)
-                  .execute(),
-              catch: (error) =>
-                new GuestbookValidationError({
-                  message: `Failed to get guestbook entries: ${error}`,
-                }),
-            }),
-            Effect.tryPromise({
-              try: async () =>
-                await db
-                  .selectFrom("guestbook_entries")
-                  .select(({ fn }) => [fn.count("id").as("count")])
-                  .executeTakeFirstOrThrow(),
-              catch: (error) =>
-                new GuestbookValidationError({
-                  message: `Failed to get guestbook count: ${error}`,
-                }),
-            }),
-          ]);
+        const [results, totalCountResult] = yield* Effect.all([
+          Effect.tryPromise({
+            try: async () =>
+              await db
+                .selectFrom("guestbook_entries")
+                .selectAll()
+                .orderBy("created_at", "desc")
+                .limit(pageSize)
+                .offset(offset)
+                .execute(),
+            catch: (error) =>
+              new GuestbookValidationError({
+                message: `Failed to get guestbook entries: ${error}`,
+              }),
+          }),
+          Effect.tryPromise({
+            try: async () =>
+              await db
+                .selectFrom("guestbook_entries")
+                .select(({ fn }) => [fn.count("id").as("count")])
+                .executeTakeFirstOrThrow(),
+            catch: (error) =>
+              new GuestbookValidationError({
+                message: `Failed to get guestbook count: ${error}`,
+              }),
+          }),
+        ]).pipe(Effect.retry(retryPolicy));
 
-          return {
-            results,
-            page,
-            page_size: pageSize,
-            total_count: Number(totalCountResult.count),
-          };
-        }).pipe(Effect.retry(retryPolicy)),
+        return {
+          results,
+          page,
+          page_size: pageSize,
+          total_count: Number(totalCountResult.count),
+        };
+      }),
 
-      hasUserSigned: (fediverse_username) =>
-        Effect.tryPromise({
+      hasUserSigned: Effect.fn("DatabaseService.hasUserSigned")(function* (
+        fediverse_username: string,
+      ) {
+        return yield* Effect.tryPromise({
           try: async () => {
             const result = await db
               .selectFrom("guestbook_entries")
@@ -185,10 +185,13 @@ export const DatabaseServiceLive = Layer.effect(
             new GuestbookValidationError({
               message: `Failed to check if user signed: ${error}`,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
 
-      createOAuthSession: (params) =>
-        Effect.tryPromise({
+      createOAuthSession: Effect.fn("DatabaseService.createOAuthSession")(function* (
+        params: OAuthSessionParams,
+      ) {
+        return yield* Effect.tryPromise({
           try: async () =>
             await db
               .insertInto("oauth_sessions")
@@ -208,10 +211,13 @@ export const DatabaseServiceLive = Layer.effect(
               message: `Failed to create OAuth session: ${error}`,
               sessionToken: params.session_token,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
 
-      getOAuthSession: (session_token) =>
-        Effect.tryPromise({
+      getOAuthSession: Effect.fn("DatabaseService.getOAuthSession")(function* (
+        session_token: string,
+      ) {
+        return yield* Effect.tryPromise({
           try: async () => {
             const result = await db
               .selectFrom("oauth_sessions")
@@ -227,10 +233,13 @@ export const DatabaseServiceLive = Layer.effect(
               message: `Failed to get OAuth session: ${error}`,
               sessionToken: session_token,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
 
-      deleteOAuthSession: (session_token) =>
-        Effect.tryPromise({
+      deleteOAuthSession: Effect.fn("DatabaseService.deleteOAuthSession")(function* (
+        session_token: string,
+      ) {
+        return yield* Effect.tryPromise({
           try: async () => {
             const result = await db
               .deleteFrom("oauth_sessions")
@@ -243,10 +252,11 @@ export const DatabaseServiceLive = Layer.effect(
               message: `Failed to delete OAuth session: ${error}`,
               sessionToken: session_token,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
 
-      cleanupExpiredSessions: () =>
-        Effect.tryPromise({
+      cleanupExpiredSessions: Effect.fn("DatabaseService.cleanupExpiredSessions")(function* () {
+        return yield* Effect.tryPromise({
           try: async () => {
             const result = await db
               .deleteFrom("oauth_sessions")
@@ -258,9 +268,8 @@ export const DatabaseServiceLive = Layer.effect(
             new OAuthSessionError({
               message: `Failed to cleanup expired sessions: ${error}`,
             }),
-        }).pipe(Effect.retry(retryPolicy)),
+        }).pipe(Effect.retry(retryPolicy));
+      }),
     };
-
-    return service;
   }),
-);
+}) {}

--- a/packages/@tom/payload/src/service.ts
+++ b/packages/@tom/payload/src/service.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Effect, Redacted } from "effect";
 import { AppConfig } from "@tom/utils/services";
 import { retryPolicy } from "@tom/utils/retry";
 import type { PayloadPost, PayloadResponse } from "@tom/schemas";
@@ -59,11 +59,6 @@ export interface PayloadServiceShape {
   readonly getWorkBySlug: (slug: string) => Effect.Effect<PayloadPost | null, PayloadError>;
 }
 
-export class PayloadService extends Context.Tag("PayloadService")<
-  PayloadService,
-  PayloadServiceShape
->() {}
-
 // Build query string from params
 const buildQuery = (params?: {
   limit?: number;
@@ -86,9 +81,10 @@ const buildQuery = (params?: {
   return query ? `?${query}` : "";
 };
 
-export const PayloadServiceLive = Layer.effect(
-  PayloadService,
-  Effect.gen(function* () {
+export class PayloadService extends Effect.Service<PayloadService>()("PayloadService", {
+  accessors: true,
+  dependencies: [AppConfig.Default],
+  effect: Effect.gen(function* () {
     const config = yield* AppConfig;
     const baseUrl = Redacted.value(config.payloadUrl);
 
@@ -96,55 +92,63 @@ export const PayloadServiceLive = Layer.effect(
       return yield* Effect.fail(new PayloadError("Payload URL not configured"));
     }
 
-    const doFetch = <T>(
-      endpoint: string,
-      options?: RequestInit & { useCache?: boolean; cacheTTL?: number },
-    ): Effect.Effect<T, PayloadError> =>
-      Effect.gen(function* () {
-        const url = `${baseUrl}/api${endpoint}`;
+    const doFetch = Effect.fn("PayloadService.fetch")(
+      <T>(
+        endpoint: string,
+        options?: RequestInit & { useCache?: boolean; cacheTTL?: number },
+      ): Effect.Effect<T, PayloadError> =>
+        Effect.gen(function* () {
+          const url = `${baseUrl}/api${endpoint}`;
 
-        const headers: HeadersInit = {
-          "Content-Type": "application/json",
-          Origin: baseUrl.replace("/api", ""),
-          Referer: baseUrl.replace("/api", ""),
-          ...options?.headers,
-        };
+          const headers: HeadersInit = {
+            "Content-Type": "application/json",
+            Origin: baseUrl.replace("/api", ""),
+            Referer: baseUrl.replace("/api", ""),
+            ...options?.headers,
+          };
 
-        yield* Effect.logDebug(`Fetching Payload: ${url}`);
+          yield* Effect.logDebug(`Fetching Payload: ${url}`);
 
-        let response: Response;
+          let response: Response;
 
-        if (options?.useCache) {
-          const cacheResult = yield* Effect.tryPromise({
-            try: async () => (await caches.open("payload-cache")) as Cache | null,
-            catch: () => null,
-          }).pipe(Effect.catchAll(() => Effect.succeed(null)));
-
-          if (cacheResult) {
-            const cacheReq = new Request(url);
-            const cached = yield* Effect.tryPromise({
-              try: async () => await cacheResult.match(cacheReq),
+          if (options?.useCache) {
+            const cacheResult = yield* Effect.tryPromise({
+              try: async () => (await caches.open("payload-cache")) as Cache | null,
               catch: () => null,
-            }).pipe(Effect.catchAll(() => Effect.succeed(null as Response | null)));
+            }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
-            if (cached) {
-              yield* Effect.logDebug(`Cache hit: ${url}`);
-              response = cached;
+            if (cacheResult) {
+              const cacheReq = new Request(url);
+              const cached = yield* Effect.tryPromise({
+                try: async () => await cacheResult.match(cacheReq),
+                catch: () => null,
+              }).pipe(Effect.catchAll(() => Effect.succeed(null as Response | null)));
+
+              if (cached) {
+                yield* Effect.logDebug(`Cache hit: ${url}`);
+                response = cached;
+              } else {
+                yield* Effect.logDebug(`Cache miss: ${url}`);
+                response = yield* Effect.tryPromise({
+                  try: () => fetch(url, { ...options, headers }),
+                  catch: (e) =>
+                    new PayloadError(e instanceof Error ? e.message : "Fetch error", endpoint),
+                });
+
+                if (response.ok) {
+                  const clone = response.clone();
+                  yield* Effect.tryPromise({
+                    try: async () => await cacheResult.put(cacheReq, clone),
+                    catch: () => null,
+                  }).pipe(Effect.catchAll(() => Effect.void));
+                }
+              }
             } else {
-              yield* Effect.logDebug(`Cache miss: ${url}`);
               response = yield* Effect.tryPromise({
                 try: () => fetch(url, { ...options, headers }),
                 catch: (e) =>
                   new PayloadError(e instanceof Error ? e.message : "Fetch error", endpoint),
               });
-
-              if (response.ok) {
-                const clone = response.clone();
-                yield* Effect.tryPromise({
-                  try: async () => await cacheResult.put(cacheReq, clone),
-                  catch: () => null,
-                }).pipe(Effect.catchAll(() => Effect.void));
-              }
             }
           } else {
             response = yield* Effect.tryPromise({
@@ -153,32 +157,26 @@ export const PayloadServiceLive = Layer.effect(
                 new PayloadError(e instanceof Error ? e.message : "Fetch error", endpoint),
             });
           }
-        } else {
-          response = yield* Effect.tryPromise({
-            try: () => fetch(url, { ...options, headers }),
+
+          if (!response.ok) {
+            return yield* Effect.fail(
+              new PayloadError(
+                `Payload API error: ${response.status} ${response.statusText}`,
+                endpoint,
+                response.status,
+              ),
+            );
+          }
+
+          const data = yield* Effect.tryPromise({
+            try: () => response.json(),
             catch: (e) =>
-              new PayloadError(e instanceof Error ? e.message : "Fetch error", endpoint),
+              new PayloadError(e instanceof Error ? e.message : "JSON parse error", endpoint),
           });
-        }
 
-        if (!response.ok) {
-          return yield* Effect.fail(
-            new PayloadError(
-              `Payload API error: ${response.status} ${response.statusText}`,
-              endpoint,
-              response.status,
-            ),
-          );
-        }
-
-        const data = yield* Effect.tryPromise({
-          try: () => response.json(),
-          catch: (e) =>
-            new PayloadError(e instanceof Error ? e.message : "JSON parse error", endpoint),
-        });
-
-        return data as T;
-      }).pipe(Effect.retry(retryPolicy));
+          return data as T;
+        }).pipe(Effect.retry(retryPolicy)),
+    );
 
     const service: PayloadServiceShape = {
       fetch: doFetch,
@@ -188,40 +186,44 @@ export const PayloadServiceLive = Layer.effect(
         return doFetch<PayloadResponse<PayloadPost>>(endpoint, { useCache: true });
       },
 
-      getPostBySlug: (slug) =>
-        Effect.gen(function* () {
-          const endpoint = `/posts?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
-          const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
-            useCache: true,
-          });
+      getPostBySlug: Effect.fn("PayloadService.getPostBySlug")(
+        (slug: string): Effect.Effect<PayloadPost | null, PayloadError> =>
+          Effect.gen(function* () {
+            const endpoint = `/posts?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
+            const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
+              useCache: true,
+            });
 
-          if (!data.docs || data.docs.length === 0) {
-            return null;
-          }
+            if (!data.docs || data.docs.length === 0) {
+              return null;
+            }
 
-          return data.docs[0] ?? null;
-        }),
+            return data.docs[0] ?? null;
+          }),
+      ),
 
       getWorks: (params) => {
         const endpoint = `/works${buildQuery(params)}`;
         return doFetch<PayloadResponse<PayloadPost>>(endpoint, { useCache: true });
       },
 
-      getWorkBySlug: (slug) =>
-        Effect.gen(function* () {
-          const endpoint = `/works?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
-          const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
-            useCache: true,
-          });
+      getWorkBySlug: Effect.fn("PayloadService.getWorkBySlug")(
+        (slug: string): Effect.Effect<PayloadPost | null, PayloadError> =>
+          Effect.gen(function* () {
+            const endpoint = `/works?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
+            const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
+              useCache: true,
+            });
 
-          if (!data.docs || data.docs.length === 0) {
-            return null;
-          }
+            if (!data.docs || data.docs.length === 0) {
+              return null;
+            }
 
-          return data.docs[0] ?? null;
-        }),
+            return data.docs[0] ?? null;
+          }),
+      ),
     };
 
     return service;
   }),
-);
+}) {}

--- a/packages/@tom/schemas/src/arena.ts
+++ b/packages/@tom/schemas/src/arena.ts
@@ -1,4 +1,12 @@
 import { Schema } from "effect";
+import {
+	ArenaBlockId,
+	ArenaChannelId,
+	ArenaCommentId,
+	ArenaConnectionId,
+	ArenaGroupId,
+	ArenaUserId,
+} from "./branded";
 
 const ArenaImageVersionSchema = Schema.Struct({
   src: Schema.String,
@@ -52,14 +60,14 @@ const ArenaMarkdownContentSchema = Schema.Struct({
 });
 
 const ArenaEmbeddedUserSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaUserId,
   type: Schema.Literal("User"),
   slug: Schema.String,
   full_name: Schema.optional(Schema.String),
 });
 
 const ArenaConnectionSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaConnectionId,
   position: Schema.Number,
   pinned: Schema.Boolean,
   connected_at: Schema.String,
@@ -67,7 +75,7 @@ const ArenaConnectionSchema = Schema.Struct({
 });
 
 const ArenaUserSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaUserId,
   slug: Schema.String,
   username: Schema.String,
   first_name: Schema.String,
@@ -76,7 +84,7 @@ const ArenaUserSchema = Schema.Struct({
   avatar_image: Schema.NullOr(Schema.Array(ArenaImageSchema)),
   channel_count: Schema.Number,
   following_count: Schema.Number,
-  profile_id: Schema.Number,
+  profile_id: ArenaUserId,
   follower_count: Schema.Number,
   type: Schema.Literal("User"),
   initials: Schema.String,
@@ -108,7 +116,7 @@ const ArenaUserWithDetailsSchema = ArenaUserSchema.pipe(
 );
 
 const ArenaGroupSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaGroupId,
   type: Schema.Literal("Group"),
   base_type: Schema.Literal("Group"),
   created_at: Schema.String,
@@ -133,7 +141,7 @@ const ArenaChannelCountsSchema = Schema.Struct({
 });
 
 const ArenaChannelSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaChannelId,
   title: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,
@@ -150,13 +158,13 @@ const ArenaChannelSchema = Schema.Struct({
   state: Schema.Literal("available"),
   "nsfw?": Schema.Boolean,
   metadata: Schema.NullOr(Schema.Struct({ description: Schema.NullOr(Schema.String) })),
-  user_id: Schema.Number,
+  user_id: ArenaUserId,
   type: Schema.Literal("Channel"),
   base_type: Schema.Literal("Channel"),
 });
 
 const ArenaBaseBlockSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaBlockId,
   title: Schema.NullOr(Schema.String),
   updated_at: Schema.String,
   created_at: Schema.String,
@@ -279,7 +287,7 @@ const ArenaBlockSchema = Schema.Union(
 
 const ArenaCommentEntitySchema = Schema.Struct({
   type: Schema.Literal("user"),
-  user_id: Schema.Number,
+  user_id: ArenaUserId,
   user_slug: Schema.String,
   user_name: Schema.String,
   start: Schema.Number,
@@ -287,10 +295,10 @@ const ArenaCommentEntitySchema = Schema.Struct({
 });
 
 const ArenaBlockCommentSchema = Schema.Struct({
-  id: Schema.Number,
+  id: ArenaCommentId,
   created_at: Schema.String,
   updated_at: Schema.String,
-  commentable_id: Schema.Number,
+  commentable_id: ArenaBlockId,
   commentable_type: Schema.Literal("Block"),
   body: Schema.String,
   user_id: Schema.String,
@@ -304,50 +312,59 @@ const ConnectionDataSchema = Schema.Struct({
   position: Schema.Number,
   pinned: Schema.Boolean,
   connected_at: Schema.String,
-  connected_by_user_id: Schema.Number,
-  connection_id: Schema.optional(Schema.Number),
+  connected_by_user_id: ArenaUserId,
+  connection_id: Schema.optional(ArenaConnectionId),
   connected_by_username: Schema.optional(Schema.String),
   connected_by_user_slug: Schema.optional(Schema.String),
 });
 
-type ArenaChannelWithDetailsType = Schema.Schema.Type<typeof ArenaOwnerInfoSchema> &
-  Schema.Schema.Type<typeof ArenaChannelSchema> & {
-    readonly user?: Schema.Schema.Type<typeof ArenaUserWithDetailsSchema> | undefined;
-    readonly group?: Schema.Schema.Type<typeof ArenaGroupSchema> | undefined;
-    readonly follower_count: number;
-    readonly can_index: boolean;
-    readonly contents: ReadonlyArray<ArenaChannelContentsType> | null;
-  };
+// Encoded types (input from API) - IDs are plain numbers
+type ArenaChannelContentsEncoded =
+  | (Schema.Schema.Encoded<typeof ArenaBlockSchema> & Schema.Schema.Encoded<typeof ConnectionDataSchema>)
+  | (Schema.Schema.Encoded<typeof ArenaOwnerInfoSchema> &
+      Schema.Schema.Encoded<typeof ArenaChannelSchema> & {
+        readonly user?: Schema.Schema.Encoded<typeof ArenaUserWithDetailsSchema> | undefined;
+        readonly group?: Schema.Schema.Encoded<typeof ArenaGroupSchema> | undefined;
+        readonly follower_count: number;
+        readonly can_index: boolean;
+        readonly contents: ReadonlyArray<ArenaChannelContentsEncoded> | null;
+      } & Schema.Schema.Encoded<typeof ConnectionDataSchema>);
 
-type ArenaChannelContentsType =
+// Decoded types (after transformation) - IDs are branded
+type ArenaChannelContentsDecoded =
   | (Schema.Schema.Type<typeof ArenaBlockSchema> & Schema.Schema.Type<typeof ConnectionDataSchema>)
-  | (ArenaChannelWithDetailsType & Schema.Schema.Type<typeof ConnectionDataSchema>);
+  | (Schema.Schema.Type<typeof ArenaOwnerInfoSchema> &
+      Schema.Schema.Type<typeof ArenaChannelSchema> & {
+        readonly user?: Schema.Schema.Type<typeof ArenaUserWithDetailsSchema> | undefined;
+        readonly group?: Schema.Schema.Type<typeof ArenaGroupSchema> | undefined;
+        readonly follower_count: number;
+        readonly can_index: boolean;
+        readonly contents: ReadonlyArray<ArenaChannelContentsDecoded> | null;
+      } & Schema.Schema.Type<typeof ConnectionDataSchema>);
 
-const ArenaChannelWithDetailsSchema: Schema.Schema<ArenaChannelWithDetailsType> =
-  ArenaOwnerInfoSchema.pipe(
-    Schema.extend(ArenaChannelSchema),
-    Schema.extend(
-      Schema.Struct({
-        user: Schema.optional(ArenaUserWithDetailsSchema),
-        group: Schema.optional(ArenaGroupSchema),
-        follower_count: Schema.Number,
-        can_index: Schema.Boolean,
-        contents: Schema.NullOr(
-          Schema.Array(
-            Schema.suspend(
-              (): Schema.Schema<ArenaChannelContentsType> => ArenaChannelContentsSchema,
-            ),
-          ),
-        ),
-      }),
-    ),
-  );
+// Recursive schemas with explicit types for circular dependency resolution
+const ArenaChannelContentsSchema: Schema.Schema<
+  ArenaChannelContentsDecoded,
+  ArenaChannelContentsEncoded
+> = Schema.suspend(() =>
+  Schema.Union(ArenaBlockSchema, ArenaChannelWithDetailsSchema).pipe(
+    Schema.extend(ConnectionDataSchema),
+  ) as Schema.Schema<ArenaChannelContentsDecoded, ArenaChannelContentsEncoded>,
+);
 
-const ArenaChannelContentsSchema: Schema.Schema<ArenaChannelContentsType> = Schema.suspend(
-  (): Schema.Schema<ArenaChannelContentsType> =>
-    Schema.Union(ArenaBlockSchema, ArenaChannelWithDetailsSchema).pipe(
-      Schema.extend(ConnectionDataSchema),
-    ) as Schema.Schema<ArenaChannelContentsType>,
+const ArenaChannelWithDetailsSchema = ArenaOwnerInfoSchema.pipe(
+  Schema.extend(ArenaChannelSchema),
+  Schema.extend(
+    Schema.Struct({
+      user: Schema.optional(ArenaUserWithDetailsSchema),
+      group: Schema.optional(ArenaGroupSchema),
+      follower_count: Schema.Number,
+      can_index: Schema.Boolean,
+      contents: Schema.NullOr(
+        Schema.Array(ArenaChannelContentsSchema),
+      ),
+    }),
+  ),
 );
 
 const MeApiResponseSchema = ArenaUserWithDetailsSchema.pipe(
@@ -414,8 +431,8 @@ const GetGroupApiResponseSchema = ArenaGroupSchema.pipe(
       title: Schema.String,
       user: ArenaUserWithDetailsSchema,
       users: Schema.Array(ArenaUserWithDetailsSchema),
-      member_ids: Schema.Array(Schema.Number),
-      accessible_by_ids: Schema.Array(Schema.Number),
+      member_ids: Schema.Array(ArenaUserId),
+      accessible_by_ids: Schema.Array(ArenaUserId),
       published: Schema.Boolean,
     }),
   ),

--- a/packages/@tom/schemas/src/branded.ts
+++ b/packages/@tom/schemas/src/branded.ts
@@ -1,0 +1,178 @@
+/**
+ * Branded types for Arena API IDs.
+ *
+ * Branded types create nominal types that prevent accidental mixing of
+ * different ID types (e.g., passing a channel ID where a user ID is expected).
+ *
+ * Usage:
+ * ```typescript
+ * import { ArenaUserId } from "@tom/schemas"
+ *
+ * // Parse and validate
+ * const result = Schema.decodeUnknown(ArenaUserId)(123)
+ * // In case of error, EffectEither will contain the error
+ *
+ * // Encode back to number
+ * const num = Schema.encode(ArenaUserId)(userId)
+ * ```
+ */
+import { Schema } from "effect";
+
+// =============================================================================
+// Arena User ID
+// =============================================================================
+
+/**
+ * Branded type for Arena user IDs.
+ *
+ * Used in:
+ * - ArenaUserSchema.id
+ * - ArenaEmbeddedUserSchema.id
+ * - ArenaCommentEntitySchema.user_id
+ * - ArenaChannelSchema.user_id
+ */
+export const ArenaUserId = Schema.Number.pipe(Schema.brand("ArenaUserId"));
+export type ArenaUserId = Schema.Schema.Type<typeof ArenaUserId>;
+
+// =============================================================================
+// Arena Channel ID
+// =============================================================================
+
+/**
+ * Branded type for Arena channel IDs.
+ *
+ * Used in:
+ * - ArenaChannelSchema.id
+ */
+export const ArenaChannelId = Schema.Number.pipe(Schema.brand("ArenaChannelId"));
+export type ArenaChannelId = Schema.Schema.Type<typeof ArenaChannelId>;
+
+// =============================================================================
+// Arena Block ID
+// =============================================================================
+
+/**
+ * Branded type for Arena block IDs.
+ *
+ * Used in:
+ * - ArenaBaseBlockSchema.id
+ * - ArenaBlockCommentSchema.commentable_id
+ */
+export const ArenaBlockId = Schema.Number.pipe(Schema.brand("ArenaBlockId"));
+export type ArenaBlockId = Schema.Schema.Type<typeof ArenaBlockId>;
+
+// =============================================================================
+// Arena Group ID
+// =============================================================================
+
+/**
+ * Branded type for Arena group IDs.
+ *
+ * Used in:
+ * - ArenaGroupSchema.id
+ */
+export const ArenaGroupId = Schema.Number.pipe(Schema.brand("ArenaGroupId"));
+export type ArenaGroupId = Schema.Schema.Type<typeof ArenaGroupId>;
+
+// =============================================================================
+// Arena Connection ID
+// =============================================================================
+
+/**
+ * Branded type for Arena connection IDs.
+ *
+ * Used in:
+ * - ArenaConnectionSchema.id
+ * - ConnectionDataSchema.connection_id
+ */
+export const ArenaConnectionId = Schema.Number.pipe(
+	Schema.brand("ArenaConnectionId"),
+);
+export type ArenaConnectionId = Schema.Schema.Type<typeof ArenaConnectionId>;
+
+// =============================================================================
+// Arena Comment ID
+// =============================================================================
+
+/**
+ * Branded type for Arena comment IDs.
+ *
+ * Used in:
+ * - ArenaBlockCommentSchema.id
+ */
+export const ArenaCommentId = Schema.Number.pipe(
+	Schema.brand("ArenaCommentId"),
+);
+export type ArenaCommentId = Schema.Schema.Type<typeof ArenaCommentId>;
+
+// =============================================================================
+// Payload IDs
+// =============================================================================
+
+/**
+ * Branded type for Payload post IDs.
+ * Note: Can be either number or string (union type)
+ */
+export const PayloadPostId = Schema.Union(
+	Schema.Number.pipe(Schema.brand("PayloadPostId")),
+	Schema.String.pipe(Schema.brand("PayloadPostId")),
+);
+export type PayloadPostId = Schema.Schema.Type<typeof PayloadPostId>;
+
+/**
+ * Branded type for Payload work IDs.
+ * Note: Can be either number or string (union type)
+ */
+export const PayloadWorkId = Schema.Union(
+	Schema.Number.pipe(Schema.brand("PayloadWorkId")),
+	Schema.String.pipe(Schema.brand("PayloadWorkId")),
+);
+export type PayloadWorkId = Schema.Schema.Type<typeof PayloadWorkId>;
+
+/**
+ * Branded type for Payload media IDs.
+ */
+export const PayloadMediaId = Schema.Number.pipe(Schema.brand("PayloadMediaId"));
+export type PayloadMediaId = Schema.Schema.Type<typeof PayloadMediaId>;
+
+// =============================================================================
+// Parsing Functions
+// =============================================================================
+
+/**
+ * Parse and validate a numeric ID into ArenaUserId.
+ * Use for parsing user IDs atAPI boundaries.
+ */
+export const parseArenaUserId = Schema.decodeUnknown(ArenaUserId);
+
+/**
+ * Parse and validate a numeric ID into ArenaChannelId.
+ */
+export const parseArenaChannelId = Schema.decodeUnknown(ArenaChannelId);
+
+/**
+ * Parse and validate a numeric ID into ArenaBlockId.
+ */
+export const parseArenaBlockId = Schema.decodeUnknown(ArenaBlockId);
+
+/**
+ * Parse and validate a numeric ID into ArenaGroupId.
+ */
+export const parseArenaGroupId = Schema.decodeUnknown(ArenaGroupId);
+
+/**
+ * Parse and validate a numeric ID into ArenaConnectionId.
+ */
+export const parseArenaConnectionId = Schema.decodeUnknown(ArenaConnectionId);
+
+/**
+ * Parse and validate a numeric ID into ArenaCommentId.
+ */
+export const parseArenaCommentId = Schema.decodeUnknown(ArenaCommentId);
+
+/**
+ * Parse and validate a numeric ID into PayloadMediaId.
+ */
+export const parsePayloadMediaId = Schema.decodeUnknown(PayloadMediaId);
+
+// Note: PayloadPostId and PayloadWorkId are unions, parsing may need custom logic

--- a/packages/@tom/schemas/src/index.ts
+++ b/packages/@tom/schemas/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./branded";
 export * from "./health";
 export * from "./arena";
 export * from "./payload";

--- a/packages/@tom/schemas/src/payload.ts
+++ b/packages/@tom/schemas/src/payload.ts
@@ -1,169 +1,178 @@
 import { Schema } from "effect";
+import { PayloadMediaId, PayloadPostId, PayloadWorkId } from "./branded.js";
 
 // =============================================================================
 // Media Schemas
 // =============================================================================
 
 export const PayloadMediaSizeSchema = Schema.Struct({
-  url: Schema.NullOr(Schema.String),
-  width: Schema.NullOr(Schema.Number),
-  height: Schema.NullOr(Schema.Number),
-  mimeType: Schema.NullOr(Schema.String),
-  filesize: Schema.NullOr(Schema.Number),
-  filename: Schema.NullOr(Schema.String),
+	url: Schema.NullOr(Schema.String),
+	width: Schema.NullOr(Schema.Number),
+	height: Schema.NullOr(Schema.Number),
+	mimeType: Schema.NullOr(Schema.String),
+	filesize: Schema.NullOr(Schema.Number),
+	filename: Schema.NullOr(Schema.String),
 });
 
 export const PayloadMediaSizesSchema = Schema.Struct({
-  thumbnail: Schema.NullOr(PayloadMediaSizeSchema),
-  square: Schema.NullOr(PayloadMediaSizeSchema),
-  small: Schema.NullOr(PayloadMediaSizeSchema),
-  medium: Schema.NullOr(PayloadMediaSizeSchema),
-  large: Schema.NullOr(PayloadMediaSizeSchema),
-  xlarge: Schema.NullOr(PayloadMediaSizeSchema),
-  og: Schema.NullOr(PayloadMediaSizeSchema),
+	thumbnail: Schema.NullOr(PayloadMediaSizeSchema),
+	square: Schema.NullOr(PayloadMediaSizeSchema),
+	small: Schema.NullOr(PayloadMediaSizeSchema),
+	medium: Schema.NullOr(PayloadMediaSizeSchema),
+	large: Schema.NullOr(PayloadMediaSizeSchema),
+	xlarge: Schema.NullOr(PayloadMediaSizeSchema),
+	og: Schema.NullOr(PayloadMediaSizeSchema),
 });
 
-// Forward declaration for recursive types
-type PayloadRichContentType = {
-  readonly root: PayloadContentNodeType;
-};
+// =============================================================================
+// Forward declarations for recursive types
+// =============================================================================
 
-type PayloadContentNodeType = {
-  readonly type: string;
-  readonly format?: number | string | undefined;
-  readonly indent?: number | string | undefined;
-  readonly version?: number | undefined;
-  readonly children?: ReadonlyArray<PayloadContentNodeType> | undefined;
-  readonly direction?: string | null | undefined;
-  readonly textStyle?: string | undefined;
-  readonly textFormat?: number | undefined;
-  readonly fields?: PayloadBlockFieldsType | undefined;
-  readonly tag?: string | undefined;
-  readonly mode?: string | undefined;
-  readonly text?: string | undefined;
-  readonly style?: string | undefined;
-  readonly detail?: number | undefined;
-  readonly id?: string | undefined;
-};
+interface PayloadRichContentType {
+	readonly root: PayloadContentNodeType;
+}
 
-type PayloadBlockFieldsType = {
-  readonly id?: string | undefined;
-  readonly media?: PayloadMediaType | undefined;
-  readonly blockName?: string | undefined;
-  readonly blockType?: string | undefined;
-  readonly content?: PayloadRichContentType | undefined;
-  readonly style?: string | undefined;
-  readonly url?: string | undefined;
-  readonly newTab?: boolean | undefined;
-  readonly arenaSlug?: string | undefined;
-  readonly arenaTitle?: string | undefined;
-};
+interface PayloadContentNodeType {
+	readonly type: string;
+	readonly format?: number | string | undefined;
+	readonly indent?: number | string | undefined;
+	readonly version?: number | undefined;
+	readonly children?: ReadonlyArray<PayloadContentNodeType> | undefined;
+	readonly direction?: string | null | undefined;
+	readonly textStyle?: string | undefined;
+	readonly textFormat?: number | undefined;
+	readonly fields?: PayloadBlockFieldsType | undefined;
+	readonly tag?: string | undefined;
+	readonly mode?: string | undefined;
+	readonly text?: string | undefined;
+	readonly style?: string | undefined;
+	readonly detail?: number | undefined;
+	readonly id?: string | undefined;
+}
 
-type PayloadMediaType = {
-  readonly id: number;
-  readonly alt: string | null;
-  readonly caption: PayloadRichContentType | null;
-  readonly updatedAt: string;
-  readonly createdAt: string;
-  readonly url: string;
-  readonly thumbnailURL: string;
-  readonly filename: string;
-  readonly mimeType: string;
-  readonly filesize: number;
-  readonly width: number;
-  readonly height: number;
-  readonly focalX: number;
-  readonly focalY: number;
-  readonly sizes: Schema.Schema.Type<typeof PayloadMediaSizesSchema>;
-};
+interface PayloadBlockFieldsType {
+	readonly id?: string | undefined;
+	readonly media?: PayloadMediaType | undefined;
+	readonly blockName?: string | undefined;
+	readonly blockType?: string | undefined;
+	readonly content?: PayloadRichContentType | undefined;
+	readonly style?: string | undefined;
+	readonly url?: string | undefined;
+	readonly newTab?: boolean | undefined;
+	readonly arenaSlug?: string | undefined;
+	readonly arenaTitle?: string | undefined;
+}
+
+interface PayloadMediaType {
+	readonly id: PayloadMediaId;
+	readonly alt: string | null;
+	readonly caption: PayloadRichContentType | null;
+	readonly updatedAt: string;
+	readonly createdAt: string;
+	readonly url: string;
+	readonly thumbnailURL: string;
+	readonly filename: string;
+	readonly mimeType: string;
+	readonly filesize: number;
+	readonly width: number;
+	readonly height: number;
+	readonly focalX: number;
+	readonly focalY: number;
+	readonly sizes: Schema.Schema.Type<typeof PayloadMediaSizesSchema>;
+}
+
+// =============================================================================
+// Media Schema
+// =============================================================================
 
 export const PayloadMediaSchema: Schema.Schema<PayloadMediaType> = Schema.Struct({
-  id: Schema.Number,
-  alt: Schema.NullOr(Schema.String),
-  caption: Schema.suspend(
-    (): Schema.Schema<PayloadRichContentType | null> => Schema.NullOr(PayloadRichContentSchema),
-  ),
-  updatedAt: Schema.String,
-  createdAt: Schema.String,
-  url: Schema.String,
-  thumbnailURL: Schema.String,
-  filename: Schema.String,
-  mimeType: Schema.String,
-  filesize: Schema.Number,
-  width: Schema.Number,
-  height: Schema.Number,
-  focalX: Schema.Number,
-  focalY: Schema.Number,
-  sizes: PayloadMediaSizesSchema,
-});
+	id: PayloadMediaId,
+	alt: Schema.NullOr(Schema.String),
+	caption: Schema.suspend((): Schema.Schema<PayloadRichContentType | null> =>
+		Schema.NullOr(PayloadRichContentSchema),
+	),
+	updatedAt: Schema.String,
+	createdAt: Schema.String,
+	url: Schema.String,
+	thumbnailURL: Schema.String,
+	filename: Schema.String,
+	mimeType: Schema.String,
+	filesize: Schema.Number,
+	width: Schema.Number,
+	height: Schema.Number,
+	focalX: Schema.Number,
+	focalY: Schema.Number,
+	sizes: PayloadMediaSizesSchema,
+}) as unknown as Schema.Schema<PayloadMediaType>;
 
 export const PayloadBlockFieldsSchema: Schema.Schema<PayloadBlockFieldsType> = Schema.Struct({
-  id: Schema.optional(Schema.String),
-  media: Schema.optional(PayloadMediaSchema),
-  blockName: Schema.optional(Schema.String),
-  blockType: Schema.optional(Schema.String),
-  content: Schema.optional(
-    Schema.suspend((): Schema.Schema<PayloadRichContentType> => PayloadRichContentSchema),
-  ),
-  style: Schema.optional(Schema.String),
-  url: Schema.optional(Schema.String),
-  newTab: Schema.optional(Schema.Boolean),
-  arenaSlug: Schema.optional(Schema.String),
-  arenaTitle: Schema.optional(Schema.String),
-});
+	id: Schema.optional(Schema.String),
+	media: Schema.optional(PayloadMediaSchema),
+	blockName: Schema.optional(Schema.String),
+	blockType: Schema.optional(Schema.String),
+	content: Schema.optional(
+		Schema.suspend((): Schema.Schema<PayloadRichContentType> => PayloadRichContentSchema),
+	),
+	style: Schema.optional(Schema.String),
+	url: Schema.optional(Schema.String),
+	newTab: Schema.optional(Schema.Boolean),
+	arenaSlug: Schema.optional(Schema.String),
+	arenaTitle: Schema.optional(Schema.String),
+}) as Schema.Schema<PayloadBlockFieldsType>;
 
-export const PayloadContentNodeSchema: Schema.Schema<PayloadContentNodeType> = Schema.suspend(() =>
-  Schema.Struct({
-    type: Schema.String,
-    format: Schema.optional(Schema.Union(Schema.Number, Schema.String)),
-    indent: Schema.optional(Schema.Union(Schema.Number, Schema.String)),
-    version: Schema.optional(Schema.Number),
-    children: Schema.optional(Schema.Array(PayloadContentNodeSchema)),
-    direction: Schema.optional(Schema.NullOr(Schema.String)),
-    textStyle: Schema.optional(Schema.String),
-    textFormat: Schema.optional(Schema.Number),
-    fields: Schema.optional(PayloadBlockFieldsSchema),
-    tag: Schema.optional(Schema.String),
-    mode: Schema.optional(Schema.String),
-    text: Schema.optional(Schema.String),
-    style: Schema.optional(Schema.String),
-    detail: Schema.optional(Schema.Number),
-    id: Schema.optional(Schema.String),
-  }),
+export const PayloadContentNodeSchema: Schema.Schema<PayloadContentNodeType> = Schema.suspend(
+	() =>
+		Schema.Struct({
+			type: Schema.String,
+			format: Schema.optional(Schema.Union(Schema.Number, Schema.String)),
+			indent: Schema.optional(Schema.Union(Schema.Number, Schema.String)),
+			version: Schema.optional(Schema.Number),
+			children: Schema.optional(Schema.Array(PayloadContentNodeSchema)),
+			direction: Schema.optional(Schema.NullOr(Schema.String)),
+			textStyle: Schema.optional(Schema.String),
+			textFormat: Schema.optional(Schema.Number),
+			fields: Schema.optional(PayloadBlockFieldsSchema),
+			tag: Schema.optional(Schema.String),
+			mode: Schema.optional(Schema.String),
+			text: Schema.optional(Schema.String),
+			style: Schema.optional(Schema.String),
+			detail: Schema.optional(Schema.Number),
+			id: Schema.optional(Schema.String),
+		}) as Schema.Schema<PayloadContentNodeType>,
 );
 
 export const PayloadRichContentSchema: Schema.Schema<PayloadRichContentType> = Schema.Struct({
-  root: PayloadContentNodeSchema,
-});
+	root: PayloadContentNodeSchema,
+}) as Schema.Schema<PayloadRichContentType>;
 
 // =============================================================================
 // Post Schema
 // =============================================================================
 
 export const PayloadHeroImageSchema = Schema.Struct({
-  url: Schema.String,
-  alt: Schema.optional(Schema.String),
+	url: Schema.String,
+	alt: Schema.optional(Schema.String),
 });
 
 export const PayloadMetaSchema = Schema.Struct({
-  title: Schema.optional(Schema.NullOr(Schema.String)),
-  description: Schema.optional(Schema.NullOr(Schema.String)),
-  image: Schema.optional(Schema.NullOr(Schema.String)),
+	title: Schema.optional(Schema.NullOr(Schema.String)),
+	description: Schema.optional(Schema.NullOr(Schema.String)),
+	image: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 export const PayloadPostSchema = Schema.Struct({
-  id: Schema.Union(Schema.Number, Schema.String),
-  title: Schema.String,
-  summary: Schema.optional(Schema.NullOr(Schema.String)),
-  publishedAt: Schema.String,
-  slug: Schema.String,
-  content: Schema.optional(Schema.Union(Schema.String, PayloadRichContentSchema)),
-  heroImage: Schema.optional(Schema.NullOr(PayloadHeroImageSchema)),
-  arenaSlug: Schema.optional(Schema.NullOr(Schema.String)),
-  arenaTitle: Schema.optional(Schema.NullOr(Schema.String)),
-  createdAt: Schema.String,
-  updatedAt: Schema.String,
-  meta: Schema.optional(PayloadMetaSchema),
+	id: PayloadPostId,
+	title: Schema.String,
+	summary: Schema.optional(Schema.NullOr(Schema.String)),
+	publishedAt: Schema.String,
+	slug: Schema.String,
+	content: Schema.optional(Schema.Union(Schema.String, PayloadRichContentSchema)),
+	heroImage: Schema.optional(Schema.NullOr(PayloadHeroImageSchema)),
+	arenaSlug: Schema.optional(Schema.NullOr(Schema.String)),
+	arenaTitle: Schema.optional(Schema.NullOr(Schema.String)),
+	createdAt: Schema.String,
+	updatedAt: Schema.String,
+	meta: Schema.optional(PayloadMetaSchema),
 });
 
 // =============================================================================
@@ -171,18 +180,18 @@ export const PayloadPostSchema = Schema.Struct({
 // =============================================================================
 
 export const PayloadWorkSchema = Schema.Struct({
-  id: Schema.Union(Schema.Number, Schema.String),
-  title: Schema.String,
-  summary: Schema.optional(Schema.NullOr(Schema.String)),
-  publishedAt: Schema.String,
-  slug: Schema.String,
-  content: Schema.optional(Schema.Union(Schema.String, PayloadRichContentSchema)),
-  heroImage: Schema.optional(Schema.NullOr(PayloadHeroImageSchema)),
-  arenaSlug: Schema.optional(Schema.NullOr(Schema.String)),
-  arenaTitle: Schema.optional(Schema.NullOr(Schema.String)),
-  createdAt: Schema.String,
-  updatedAt: Schema.String,
-  meta: Schema.optional(PayloadMetaSchema),
+	id: PayloadWorkId,
+	title: Schema.String,
+	summary: Schema.optional(Schema.NullOr(Schema.String)),
+	publishedAt: Schema.String,
+	slug: Schema.String,
+	content: Schema.optional(Schema.Union(Schema.String, PayloadRichContentSchema)),
+	heroImage: Schema.optional(Schema.NullOr(PayloadHeroImageSchema)),
+	arenaSlug: Schema.optional(Schema.NullOr(Schema.String)),
+	arenaTitle: Schema.optional(Schema.NullOr(Schema.String)),
+	createdAt: Schema.String,
+	updatedAt: Schema.String,
+	meta: Schema.optional(PayloadMetaSchema),
 });
 
 // =============================================================================
@@ -190,15 +199,15 @@ export const PayloadWorkSchema = Schema.Struct({
 // =============================================================================
 
 export const PayloadResponseSchema = <A, I, R>(itemSchema: Schema.Schema<A, I, R>) =>
-  Schema.Struct({
-    docs: Schema.Array(itemSchema),
-    totalDocs: Schema.Number,
-    limit: Schema.Number,
-    page: Schema.Number,
-    totalPages: Schema.Number,
-    hasNextPage: Schema.Boolean,
-    hasPrevPage: Schema.Boolean,
-  });
+	Schema.Struct({
+		docs: Schema.Array(itemSchema),
+		totalDocs: Schema.Number,
+		limit: Schema.Number,
+		page: Schema.Number,
+		totalPages: Schema.Number,
+		hasNextPage: Schema.Boolean,
+		hasPrevPage: Schema.Boolean,
+	});
 
 // =============================================================================
 // Derived Types (from schemas)
@@ -215,11 +224,11 @@ export type PayloadMeta = Schema.Schema.Type<typeof PayloadMetaSchema>;
 export type PayloadPost = Schema.Schema.Type<typeof PayloadPostSchema>;
 export type PayloadWork = Schema.Schema.Type<typeof PayloadWorkSchema>;
 export type PayloadResponse<T> = {
-  readonly docs: ReadonlyArray<T>;
-  readonly totalDocs: number;
-  readonly limit: number;
-  readonly page: number;
-  readonly totalPages: number;
-  readonly hasNextPage: boolean;
-  readonly hasPrevPage: boolean;
+	readonly docs: ReadonlyArray<T>;
+	readonly totalDocs: number;
+	readonly limit: number;
+	readonly page: number;
+	readonly totalPages: number;
+	readonly hasNextPage: boolean;
+	readonly hasPrevPage: boolean;
 };

--- a/packages/@tom/types/src/errors.ts
+++ b/packages/@tom/types/src/errors.ts
@@ -1,82 +1,103 @@
-import { Data } from "effect";
+import { Schema } from "effect";
 
-export class ImageError extends Data.TaggedError("ImageError")<{
-  readonly response: Response;
-  readonly cause?: unknown;
-}> {}
+export class ImageError extends Schema.TaggedError<ImageError>()("ImageError", {
+  response: Schema.Unknown,
+  cause: Schema.optional(Schema.Unknown),
+}) {}
 
-export class PolarApiError extends Data.TaggedError("PolarApiError")<{
-  readonly message: string;
-  readonly status: number;
-  readonly operation: string;
-}> {}
+export class PolarApiError extends Schema.TaggedError<PolarApiError>()("PolarApiError", {
+  message: Schema.String,
+  status: Schema.Number,
+  operation: Schema.String,
+}) {}
 
-export class ArenaConfigError extends Data.TaggedError("ArenaConfigError")<{
-  readonly message: string;
-}> {}
+export class ArenaConfigError extends Schema.TaggedError<ArenaConfigError>()("ArenaConfigError", {
+  message: Schema.String,
+}) {}
 
-export class SearchError extends Data.TaggedError("SearchError")<{
-  message: string;
-}> {}
+export class SearchError extends Schema.TaggedError<SearchError>()("SearchError", {
+  message: Schema.String,
+}) {}
 
-export class HttpError extends Data.TaggedError("HttpError")<{
-  readonly message: string;
-  readonly status: number;
-}> {}
+export class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
+  message: Schema.String,
+  status: Schema.Number,
+}) {}
 
-export class DatabaseConnectionError extends Data.TaggedError("DatabaseConnectionError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class DatabaseConnectionError extends Schema.TaggedError<DatabaseConnectionError>()(
+  "DatabaseConnectionError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+) {}
 
-export class StoredProcedureError extends Data.TaggedError("StoredProcedureError")<{
-  readonly procedure: string;
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class StoredProcedureError extends Schema.TaggedError<StoredProcedureError>()(
+  "StoredProcedureError",
+  {
+    procedure: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+) {}
 
-export class GuestbookValidationError extends Data.TaggedError("GuestbookValidationError")<{
-  readonly message: string;
-  readonly field?: string;
-}> {}
+export class GuestbookValidationError extends Schema.TaggedError<GuestbookValidationError>()(
+  "GuestbookValidationError",
+  {
+    message: Schema.String,
+    field: Schema.optional(Schema.String),
+  },
+) {}
 
-export class OAuthSessionError extends Data.TaggedError("OAuthSessionError")<{
-  readonly message: string;
-  readonly sessionToken?: string;
-}> {}
+export class OAuthSessionError extends Schema.TaggedError<OAuthSessionError>()(
+  "OAuthSessionError",
+  {
+    message: Schema.String,
+    sessionToken: Schema.optional(Schema.String),
+  },
+) {}
 
-export class MissingFieldError extends Data.TaggedError("MissingFieldError")<{
-  readonly field: string;
-}> {}
+export class MissingFieldError extends Schema.TaggedError<MissingFieldError>()(
+  "MissingFieldError",
+  {
+    field: Schema.String,
+  },
+) {}
 
-export class ProfanityError extends Data.TaggedError("ProfanityError")<{
-  readonly message: string;
-}> {}
+export class ProfanityError extends Schema.TaggedError<ProfanityError>()("ProfanityError", {
+  message: Schema.String,
+}) {}
 
-export class AuthenticationError extends Data.TaggedError("AuthenticationError")<{
-  readonly message: string;
-}> {}
+export class AuthenticationError extends Schema.TaggedError<AuthenticationError>()(
+  "AuthenticationError",
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class NodeinfoError extends Data.TaggedError("NodeinfoError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class NodeinfoError extends Schema.TaggedError<NodeinfoError>()("NodeinfoError", {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Unknown),
+}) {}
 
-export class FontFetchError extends Data.TaggedError("FontFetchError")<{
-  readonly message: string;
-  readonly cause: string;
-}> {}
+export class FontFetchError extends Schema.TaggedError<FontFetchError>()("FontFetchError", {
+  message: Schema.String,
+  cause: Schema.String,
+}) {}
 
-export class ValidationError extends Data.TaggedError("ValidationError")<{
-  readonly field: string;
-  readonly issue: string;
-}> {}
+export class ValidationError extends Schema.TaggedError<ValidationError>()("ValidationError", {
+  field: Schema.String,
+  issue: Schema.String,
+}) {}
 
-export class ImageGenerationError extends Data.TaggedError("ImageGenerationError")<{
-  readonly message: string;
-}> {}
+export class ImageGenerationError extends Schema.TaggedError<ImageGenerationError>()(
+  "ImageGenerationError",
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class TelegramError extends Data.TaggedError("TelegramError")<{
-  readonly message: string;
-  readonly status?: number;
-}> {}
+export class TelegramError extends Schema.TaggedError<TelegramError>()("TelegramError", {
+  message: Schema.String,
+  status: Schema.optional(Schema.Number),
+}) {}

--- a/packages/@tom/utils/__tests__/telegram.integration.spec.ts
+++ b/packages/@tom/utils/__tests__/telegram.integration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Effect, Layer, Redacted } from "effect";
-import { TelegramService, TelegramServiceLive } from "../src/telegram";
+import { TelegramService } from "../src/telegram";
 import { AppConfig } from "../src/services/config";
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
@@ -8,6 +8,7 @@ const chatId = process.env.TELEGRAM_CHAT_ID;
 
 const createConfigLayer = (botToken: string, chat: string) =>
   Layer.succeed(AppConfig, {
+    _tag: "AppConfig",
     arenaToken: Redacted.make(""),
     payloadUrl: Redacted.make(""),
     databaseUrl: Redacted.make(""),
@@ -17,7 +18,7 @@ const createConfigLayer = (botToken: string, chat: string) =>
   });
 
 const createLayer = (botToken: string, chat: string) =>
-  Layer.provideMerge(TelegramServiceLive, createConfigLayer(botToken, chat));
+  Layer.provideMerge(TelegramService.Default, createConfigLayer(botToken, chat));
 
 const runTestResult = <A, E>(
   effect: Effect.Effect<A, E, TelegramService>,

--- a/packages/@tom/utils/__tests__/telegram.test.ts
+++ b/packages/@tom/utils/__tests__/telegram.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Effect, Layer, Redacted } from "effect";
-import { TelegramService, TelegramServiceLive } from "../src/telegram";
+import { TelegramService } from "../src/telegram";
 import { AppConfig } from "../src/services/config";
 
 type TestConfig = {
@@ -12,6 +12,7 @@ const createConfigLayer = (config: TestConfig) => {
   const token = config.telegramBotToken;
   const chatId = config.telegramChatId;
   return Layer.succeed(AppConfig, {
+    _tag: "AppConfig",
     arenaToken: Redacted.make(""),
     payloadUrl: Redacted.make(""),
     databaseUrl: Redacted.make(""),
@@ -22,7 +23,7 @@ const createConfigLayer = (config: TestConfig) => {
 };
 
 const createLayer = (config: TestConfig) =>
-  Layer.provideMerge(TelegramServiceLive, createConfigLayer(config));
+  Layer.provideMerge(TelegramService.Default, createConfigLayer(config));
 
 const runTestEffect = <A, E>(
   effect: Effect.Effect<A, E, TelegramService>,

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -1,4 +1,4 @@
-import { Context, Layer, Redacted } from "effect";
+import { Effect, Layer, Redacted } from "effect";
 
 export interface AppConfigShape {
   readonly arenaToken: Redacted.Redacted<string> | undefined;
@@ -17,8 +17,6 @@ const parseOptionalSecret = (value?: string): string | undefined => {
   return v;
 };
 
-export class AppConfig extends Context.Tag("AppConfig")<AppConfig, AppConfigShape>() {}
-
 export type CloudflareEnv = {
   ARENA_TOKEN?: string;
   PAYLOAD_URL?: string;
@@ -31,20 +29,54 @@ export type CloudflareEnv = {
   NODE_ENV?: string;
 };
 
-export const makeAppConfigLayer = (env: CloudflareEnv): Layer.Layer<AppConfig> =>
-  Layer.succeed(
-    AppConfig,
-    (() => {
-      const arenaToken = parseOptionalSecret(env.ARENA_TOKEN);
-      return {
-        arenaToken: arenaToken ? Redacted.make(arenaToken) : undefined,
-        payloadUrl: Redacted.make(env.PAYLOAD_URL ?? ""),
-        databaseUrl: Redacted.make(env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL ?? ""),
-        telegramBotToken: env.TELEGRAM_BOT_TOKEN
-          ? Redacted.make(env.TELEGRAM_BOT_TOKEN)
-          : undefined,
-        telegramChatId: env.TELEGRAM_CHAT_ID,
-        isDev: env.NODE_ENV !== "production",
-      };
-    })(),
-  );
+export class AppConfig extends Effect.Service<AppConfig>()("AppConfig", {
+  accessors: true,
+  succeed: {
+    arenaToken: undefined as Redacted.Redacted<string> | undefined,
+    payloadUrl: Redacted.make(""),
+    databaseUrl: Redacted.make(""),
+    telegramBotToken: undefined as Redacted.Redacted<string> | undefined,
+    telegramChatId: undefined as string | undefined,
+    isDev: true as boolean,
+  },
+}) {
+  static fromEnv(env: CloudflareEnv): Layer.Layer<AppConfig> {
+    const arenaToken = parseOptionalSecret(env.ARENA_TOKEN);
+    return Layer.succeed(AppConfig, {
+      _tag: "AppConfig",
+      arenaToken: arenaToken ? Redacted.make(arenaToken) : undefined,
+      payloadUrl: Redacted.make(env.PAYLOAD_URL ?? ""),
+      databaseUrl: Redacted.make(env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL ?? ""),
+      telegramBotToken: env.TELEGRAM_BOT_TOKEN ? Redacted.make(env.TELEGRAM_BOT_TOKEN) : undefined,
+      telegramChatId: env.TELEGRAM_CHAT_ID,
+      isDev: env.NODE_ENV !== "production",
+    });
+  }
+}
+
+/**
+ * Create a config layer from a partial config object.
+ * Useful for testing and API routes that only need subset of config.
+ */
+export const makeAppConfigLayer = (
+  config: Partial<{
+    ARENA_TOKEN: string;
+    PAYLOAD_URL: string;
+    DATABASE_URL: string;
+    TELEGRAM_BOT_TOKEN: string;
+    TELEGRAM_CHAT_ID: string;
+    NODE_ENV: string;
+  }>,
+): Layer.Layer<AppConfig> => {
+  return Layer.succeed(AppConfig, {
+    _tag: "AppConfig",
+    arenaToken: config.ARENA_TOKEN ? Redacted.make(config.ARENA_TOKEN) : undefined,
+    payloadUrl: Redacted.make(config.PAYLOAD_URL ?? ""),
+    databaseUrl: Redacted.make(config.DATABASE_URL ?? ""),
+    telegramBotToken: config.TELEGRAM_BOT_TOKEN
+      ? Redacted.make(config.TELEGRAM_BOT_TOKEN)
+      : undefined,
+    telegramChatId: config.TELEGRAM_CHAT_ID,
+    isDev: config.NODE_ENV !== "production",
+  });
+};

--- a/packages/@tom/utils/src/services/index.ts
+++ b/packages/@tom/utils/src/services/index.ts
@@ -1,3 +1,3 @@
 export * from "./config";
-export { TelegramService, TelegramServiceLive } from "../telegram";
+export { TelegramService } from "../telegram";
 export type { TelegramServiceShape } from "../telegram";

--- a/packages/@tom/utils/src/telegram.ts
+++ b/packages/@tom/utils/src/telegram.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Effect, Redacted } from "effect";
 import { TelegramError } from "@tom/types";
 import { AppConfig } from "./services/config";
 
@@ -7,84 +7,83 @@ export interface TelegramServiceShape {
   readonly sendError: (message: string, error?: unknown) => Effect.Effect<void, TelegramError>;
 }
 
-export class TelegramService extends Context.Tag("TelegramService")<
-  TelegramService,
-  TelegramServiceShape
->() {}
-
-const formatErrorMessage = (level: string, message: string, error?: unknown): string => {
-  const timestamp = new Date().toISOString();
-  let text = `*${level}*\n\n`;
-  text += `*Time:* ${timestamp}\n`;
-  text += `*Message:* ${message}`;
-
-  if (error) {
-    const errorStr = error instanceof Error ? error.message : String(error);
-    const stack = error instanceof Error ? error.stack : undefined;
-    text += `\n\n*Error:* \`${errorStr}\``;
-    if (stack) {
-      text += `\n\n*Stack:* \n\`\`\`\n${stack}\n\`\`\``;
-    }
-  }
-
-  return text;
-};
-
-const doSendTelegramAlert = (
-  token: string,
-  chatId: string,
-  text: string,
-): Effect.Effect<void, TelegramError> =>
-  Effect.gen(function* () {
-    const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
-
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(telegramUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            chat_id: chatId,
-            text,
-            parse_mode: "Markdown",
-          }),
-        }),
-      catch: (error) =>
-        new TelegramError({
-          message: error instanceof Error ? error.message : "Unknown error",
-        }),
-    });
-
-    if (!response.ok) {
-      return yield* Effect.fail(
-        new TelegramError({
-          message: `Telegram API error: ${response.status} ${response.statusText}`,
-          status: response.status,
-        }),
-      );
-    }
-  });
-
-export const TelegramServiceLive = Layer.effect(
-  TelegramService,
-  Effect.gen(function* () {
+export class TelegramService extends Effect.Service<TelegramService>()("TelegramService", {
+  accessors: true,
+  dependencies: [AppConfig.Default],
+  effect: Effect.gen(function* () {
     const config = yield* AppConfig;
 
     // Return no-op service if not configured
     if (!config.telegramBotToken || !config.telegramChatId) {
       return {
-        sendAlert: () => Effect.void,
-        sendError: () => Effect.void,
+        sendAlert: Effect.fn("TelegramService.sendAlert")(function* () {
+          // no-op
+        }),
+        sendError: Effect.fn("TelegramService.sendError")(function* () {
+          // no-op
+        }),
       };
     }
 
     const token = Redacted.value(config.telegramBotToken);
     const chatId = config.telegramChatId;
 
+    const formatErrorMessage = (level: string, message: string, error?: unknown): string => {
+      const timestamp = new Date().toISOString();
+      let text = `*${level}*\n\n`;
+      text += `*Time:* ${timestamp}\n`;
+      text += `*Message:* ${message}`;
+
+      if (error) {
+        const errorStr = error instanceof Error ? error.message : String(error);
+        const stack = error instanceof Error ? error.stack : undefined;
+        text += `\n\n*Error:* \`${errorStr}\``;
+        if (stack) {
+          text += `\n\n*Stack:* \n\`\`\`\n${stack}\n\`\`\``;
+        }
+      }
+
+      return text;
+    };
+
+    const doSendTelegramAlert = (text: string): Effect.Effect<void, TelegramError> =>
+      Effect.gen(function* () {
+        const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
+
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            fetch(telegramUrl, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                chat_id: chatId,
+                text,
+                parse_mode: "Markdown",
+              }),
+            }),
+          catch: (error) =>
+            new TelegramError({
+              message: error instanceof Error ? error.message : "Unknown error",
+            }),
+        });
+
+        if (!response.ok) {
+          return yield* Effect.fail(
+            new TelegramError({
+              message: `Telegram API error: ${response.status} ${response.statusText}`,
+              status: response.status,
+            }),
+          );
+        }
+      });
+
     return {
-      sendAlert: (message) => doSendTelegramAlert(token, chatId, message),
-      sendError: (message, error) =>
-        doSendTelegramAlert(token, chatId, formatErrorMessage("ERROR", message, error)),
+      sendAlert: Effect.fn("TelegramService.sendAlert")((message: string) =>
+        doSendTelegramAlert(message),
+      ),
+      sendError: Effect.fn("TelegramService.sendError")((message: string, error?: unknown) =>
+        doSendTelegramAlert(formatErrorMessage("ERROR", message, error)),
+      ),
     };
   }),
-);
+}) {}


### PR DESCRIPTION
## Summary

This PR modernizes the codebase with Effect best practices and patterns:

### Services Migrated to Effect.Service
- AppConfig - static `fromEnv()` factory pattern
- DatabaseService - with `accessors: true` and `Effect.fn` naming
- ArenaService - with explicit `dependencies: [AppConfig.Default]`
- PayloadService - with `Effect.fn` naming for tracing
- TelegramService - with `Effect.fn` naming

### Error Types Migrated
- 17 error classes migrated from `Data.TaggedError` to `Schema.TaggedError`
- Enables better serialization and RPC compatibility

### Branded ID Types
- Added 9 branded ID types (ArenaUserId, ArenaChannelId, ArenaBlockId, etc.)
- Updated arena.ts and payload.ts schemas to use branded types
- Added parsing utilities for boundary validation

### Effect.fn Naming
- Added tracing names to PayloadService methods
- Added tracing names to checkout functions

### Files Changed
- 22 files changed (969 insertions, 706 deletions)

## Test Plan
- [ ] Run `bun typecheck` - all affected packages pass
- [ ] Run `bun test` - existing tests pass
- [ ] Verify service composition works in runtime