### PR TITLE
fix(effect): resolve yieldable error and Effect.fn lint issues

### DIFF
--- a/apps/web/src/libs/actions/arena/client.ts
+++ b/apps/web/src/libs/actions/arena/client.ts
@@ -18,10 +18,10 @@ export function fetchArena<T>(
 
     return yield* operation(client).pipe(Effect.retry(retryPolicy));
   }).pipe(
-    Effect.catchAll((error) =>
-      Effect.gen(function* () {
+    Effect.catchAll(
+      Effect.fn("fetchArenaErrorHandler")(function* (error: HttpError) {
         yield* Effect.logError(`Arena operation failed after retries: ${name}`, error);
-        return yield* Effect.fail(error);
+        return yield* error;
       }),
     ),
   );

--- a/apps/web/src/libs/actions/guestbook/auth.ts
+++ b/apps/web/src/libs/actions/guestbook/auth.ts
@@ -37,202 +37,205 @@ const generateState = () => {
   return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
 };
 
-export const initiateAuth = (fediverseHandle: string) =>
-  Effect.gen(function* () {
-    const db = yield* DatabaseService;
+const initiateAuth_ = Effect.fn("initiateAuth")(function* (fediverseHandle: string) {
+  const db = yield* DatabaseService;
 
-    const parts = fediverseHandle.split("@").filter(Boolean);
-    if (parts.length !== 2) {
-      return yield* Effect.fail(
-        new GuestbookValidationError({
-          message:
-            "Invalid fediverse handle format. Use: user@instance.social (without the leading @)",
-          field: "fediverseHandle",
-        }),
-      );
-    }
+  const parts = fediverseHandle.split("@").filter(Boolean);
+  if (parts.length !== 2) {
+    return yield* new GuestbookValidationError({
+      message: "Invalid fediverse handle format. Use: user@instance.social (without the leading @)",
+      field: "fediverseHandle",
+    });
+  }
 
-    const [_username, instance] = parts;
-    const instanceUrl = `https://${instance}`;
+  const [_username, instance] = parts;
+  const instanceUrl = `https://${instance}`;
 
-    const snsType = yield* detector(instanceUrl).pipe(
-      Effect.catchAll(() => Effect.succeed("mastodon" as const)),
-    );
+  const snsType = yield* detector(instanceUrl).pipe(
+    Effect.catchAll(() => Effect.succeed("mastodon" as const)),
+  );
 
-    const client = generator(snsType, instanceUrl);
-    const state = generateState();
+  const client = generator(snsType, instanceUrl);
+  const state = generateState();
 
-    const appData = yield* Effect.tryPromise({
-      try: async () => {
-        return await client.registerApp("Guestbook", {
-          scopes: ["read:accounts"],
-          redirect_uris: Redacted.value(REDIRECT_URI),
-        });
-      },
-      catch: (error) => {
-        void Effect.runFork(Effect.logError("Megalodon registerApp error:", error));
+  const appData = yield* Effect.tryPromise({
+    try: async () => {
+      return await client.registerApp("Guestbook", {
+        scopes: ["read:accounts"],
+        redirect_uris: Redacted.value(REDIRECT_URI),
+      });
+    },
+    catch: (error) => {
+      void Effect.runFork(Effect.logError("Megalodon registerApp error:", error));
 
-        if (error && typeof error === "object" && "code" in error) {
-          const code = (error as { code: string }).code;
+      if (error && typeof error === "object" && "code" in error) {
+        const code = (error as { code: string }).code;
 
-          if (code === "ETIMEDOUT" || code === "ECONNABORTED") {
+        if (code === "ETIMEDOUT" || code === "ECONNABORTED") {
+          return new HttpError({
+            message: `Connection timeout trying to reach ${instance}. This might be a network/firewall issue on the server, or the instance may be down. Try a different instance like mastodon.social`,
+            status: HttpStatus.GatewayTimeout,
+          });
+        }
+
+        if (code === "ENOTFOUND") {
+          return new HttpError({
+            message: `Could not find ${instance}. Please check the instance name is correct.`,
+            status: HttpStatus.NotFound,
+          });
+        }
+
+        if (code === "ECONNREFUSED") {
+          return new HttpError({
+            message: `Connection refused by ${instance}. The instance may be down.`,
+            status: HttpStatus.ServiceUnavailable,
+          });
+        }
+
+        if (code === "ENETUNREACH") {
+          return new HttpError({
+            message: `Network unreachable for ${instance}. This is likely a server network configuration issue.`,
+            status: HttpStatus.ServiceUnavailable,
+          });
+        }
+      }
+
+      if (error instanceof AggregateError) {
+        const firstError = error.errors[0];
+        if (firstError && "code" in firstError) {
+          const code = (firstError as { code: string }).code;
+          if (code === "ETIMEDOUT") {
             return new HttpError({
-              message: `Connection timeout trying to reach ${instance}. This might be a network/firewall issue on the server, or the instance may be down. Try a different instance like mastodon.social`,
+              message: `Connection timeout trying to reach ${instance}. The server cannot reach this instance. Try a different instance like mastodon.social or fosstodon.org`,
               status: HttpStatus.GatewayTimeout,
             });
           }
-
-          if (code === "ENOTFOUND") {
-            return new HttpError({
-              message: `Could not find ${instance}. Please check the instance name is correct.`,
-              status: HttpStatus.NotFound,
-            });
-          }
-
-          if (code === "ECONNREFUSED") {
-            return new HttpError({
-              message: `Connection refused by ${instance}. The instance may be down.`,
-              status: HttpStatus.ServiceUnavailable,
-            });
-          }
-
-          if (code === "ENETUNREACH") {
-            return new HttpError({
-              message: `Network unreachable for ${instance}. This is likely a server network configuration issue.`,
-              status: HttpStatus.ServiceUnavailable,
-            });
-          }
         }
+      }
 
-        if (error instanceof AggregateError) {
-          const firstError = error.errors[0];
-          if (firstError && "code" in firstError) {
-            const code = (firstError as { code: string }).code;
-            if (code === "ETIMEDOUT") {
-              return new HttpError({
-                message: `Connection timeout trying to reach ${instance}. The server cannot reach this instance. Try a different instance like mastodon.social or fosstodon.org`,
-                status: HttpStatus.GatewayTimeout,
-              });
-            }
-          }
-        }
+      return new HttpError({
+        message: `Failed to connect to ${instance}. Please verify it's a valid Mastodon/Fediverse instance and try a well-known instance like mastodon.social`,
+        status: HttpStatus.BadGateway,
+      });
+    },
+  });
 
-        return new HttpError({
-          message: `Failed to connect to ${instance}. Please verify it's a valid Mastodon/Fediverse instance and try a well-known instance like mastodon.social`,
-          status: HttpStatus.BadGateway,
-        });
-      },
-    });
+  const sessionToken = generateSessionToken();
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
 
-    const sessionToken = generateSessionToken();
-    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+  yield* db.createOAuthSession({
+    session_token: sessionToken,
+    fediverse_instance: instance ?? "",
+    client_id: appData.client_id ?? "",
+    client_secret: appData.client_secret ?? "",
+    state: state,
+    code_verifier: null,
+    expires_at: expiresAt,
+  });
 
-    yield* db.createOAuthSession({
-      session_token: sessionToken,
-      fediverse_instance: instance ?? "",
-      client_id: appData.client_id ?? "",
-      client_secret: appData.client_secret ?? "",
-      state: state,
-      code_verifier: null,
-      expires_at: expiresAt,
-    });
-
-    const authUrl = appData.url ?? "";
-    if (!authUrl) {
-      return yield* Effect.fail(
-        new OAuthSessionError({
-          message: `Failed to generate authorization URL for ${instance}. The instance may not support OAuth.`,
-          sessionToken,
-        }),
-      );
-    }
-
-    return {
-      authUrl,
+  const authUrl = appData.url ?? "";
+  if (!authUrl) {
+    return yield* new OAuthSessionError({
+      message: `Failed to generate authorization URL for ${instance}. The instance may not support OAuth.`,
       sessionToken,
-      instance,
-    };
-  }).pipe(Effect.retry(retryPolicy));
+    });
+  }
+
+  return {
+    authUrl,
+    sessionToken,
+    instance,
+  };
+});
+
+export const initiateAuth = (fediverseHandle: string) =>
+  initiateAuth_(fediverseHandle).pipe(Effect.retry(retryPolicy));
+
+const handleCallback_ = Effect.fn("handleCallback")(function* (params: {
+  code: string;
+  session_token: string;
+}) {
+  const db = yield* DatabaseService;
+  const session = yield* db.getOAuthSession(params.session_token);
+
+  if (!session) {
+    return yield* new OAuthSessionError({
+      message: "Invalid or expired session",
+      sessionToken: params.session_token,
+    });
+  }
+
+  const instanceUrl = `https://${session.fediverse_instance}`;
+
+  const snsType = yield* detector(instanceUrl).pipe(
+    Effect.catchAll(() => Effect.succeed("mastodon" as const)),
+  );
+
+  const client = generator(snsType, instanceUrl);
+
+  const tokenData = yield* Effect.tryPromise({
+    try: async () =>
+      client.fetchAccessToken(
+        session.client_id,
+        session.client_secret,
+        params.code,
+        Redacted.value(REDIRECT_URI),
+      ),
+    catch: (error) =>
+      new AuthenticationError({
+        message: `Failed to fetch access token: ${error}`,
+      }),
+  });
+
+  const authedClient = generator(snsType, instanceUrl, tokenData.access_token);
+
+  const account = yield* Effect.tryPromise({
+    try: async () => authedClient.verifyAccountCredentials(),
+    catch: (error) =>
+      new AuthenticationError({
+        message: `Failed to verify credentials: ${error}`,
+      }),
+  });
+
+  yield* db.deleteOAuthSession(params.session_token);
+
+  const user: FediverseUser = {
+    username: account.data.acct,
+    instance: session.fediverse_instance,
+    display_name: account.data.display_name,
+    avatar_url: account.data.avatar,
+    access_token: tokenData.access_token,
+  };
+
+  return user;
+});
 
 export const handleCallback = (params: { code: string; session_token: string }) =>
-  Effect.gen(function* () {
-    const db = yield* DatabaseService;
-    const session = yield* db.getOAuthSession(params.session_token);
+  handleCallback_(params).pipe(Effect.retry(retryPolicy));
 
-    if (!session) {
-      return yield* Effect.fail(
-        new OAuthSessionError({
-          message: "Invalid or expired session",
-          sessionToken: params.session_token,
-        }),
-      );
-    }
+const signGuestbook_ = Effect.fn("signGuestbook")(function* (params: {
+  user: FediverseUser;
+  message: string;
+}) {
+  const db = yield* DatabaseService;
+  const hasSigned = yield* db.hasUserSigned(`${params.user.username}@${params.user.instance}`);
 
-    const instanceUrl = `https://${session.fediverse_instance}`;
-
-    const snsType = yield* detector(instanceUrl).pipe(
-      Effect.catchAll(() => Effect.succeed("mastodon" as const)),
-    );
-
-    const client = generator(snsType, instanceUrl);
-
-    const tokenData = yield* Effect.tryPromise({
-      try: async () =>
-        client.fetchAccessToken(
-          session.client_id,
-          session.client_secret,
-          params.code,
-          Redacted.value(REDIRECT_URI),
-        ),
-      catch: (error) =>
-        new AuthenticationError({
-          message: `Failed to fetch access token: ${error}`,
-        }),
+  if (hasSigned) {
+    return yield* new GuestbookValidationError({
+      message: "You have already signed the guestbook",
     });
+  }
 
-    const authedClient = generator(snsType, instanceUrl, tokenData.access_token);
+  const entry = yield* db.createGuestbookEntry({
+    fediverse_username: `${params.user.username}@${params.user.instance}`,
+    fediverse_instance: params.user.instance,
+    display_name: params.user.display_name,
+    avatar_url: params.user.avatar_url,
+    message: params.message,
+  });
 
-    const account = yield* Effect.tryPromise({
-      try: async () => authedClient.verifyAccountCredentials(),
-      catch: (error) =>
-        new AuthenticationError({
-          message: `Failed to verify credentials: ${error}`,
-        }),
-    });
-
-    yield* db.deleteOAuthSession(params.session_token);
-
-    const user: FediverseUser = {
-      username: account.data.acct,
-      instance: session.fediverse_instance,
-      display_name: account.data.display_name,
-      avatar_url: account.data.avatar,
-      access_token: tokenData.access_token,
-    };
-
-    return user;
-  }).pipe(Effect.retry(retryPolicy));
+  return entry;
+});
 
 export const signGuestbook = (params: { user: FediverseUser; message: string }) =>
-  Effect.gen(function* () {
-    const db = yield* DatabaseService;
-    const hasSigned = yield* db.hasUserSigned(`${params.user.username}@${params.user.instance}`);
-
-    if (hasSigned) {
-      return yield* Effect.fail(
-        new GuestbookValidationError({
-          message: "You have already signed the guestbook",
-        }),
-      );
-    }
-
-    const entry = yield* db.createGuestbookEntry({
-      fediverse_username: `${params.user.username}@${params.user.instance}`,
-      fediverse_instance: params.user.instance,
-      display_name: params.user.display_name,
-      avatar_url: params.user.avatar_url,
-      message: params.message,
-    });
-
-    return entry;
-  }).pipe(Effect.retry(retryPolicy));
+  signGuestbook_(params).pipe(Effect.retry(retryPolicy));

--- a/apps/web/src/libs/actions/guestbook/detector.ts
+++ b/apps/web/src/libs/actions/guestbook/detector.ts
@@ -42,86 +42,80 @@ const detectFromNodeinfo = (
     return Effect.succeed("mastodon");
   }
 
-  return Effect.fail(new NodeinfoError({ message: "Unknown SNS" }));
+  return new NodeinfoError({ message: "Unknown SNS" });
 };
 
-const fetchNodeinfoVersion = (
+const fetchNodeinfoVersion = Effect.fn("fetchNodeinfoVersion")(function* (
   href: string,
   version: string,
-): Effect.Effect<NodeinfoData, NodeinfoError> =>
-  Effect.gen(function* () {
-    const res = yield* Effect.tryPromise({
-      try: () =>
-        fetch(href, {
-          signal: AbortSignal.timeout(20000),
-        }),
-      catch: (error) =>
-        new NodeinfoError({
-          message: `Failed to fetch nodeinfo ${version} data`,
-          cause: error,
-        }),
-    });
-
-    if (!res.ok) {
-      return yield* Effect.fail(
-        new NodeinfoError({
-          message: `Failed to fetch nodeinfo data: ${res.status} ${res.statusText}`,
-        }),
-      );
-    }
-
-    const data = yield* Effect.tryPromise({
-      try: () => res.json() as Promise<NodeinfoData>,
-      catch: (error) =>
-        new NodeinfoError({
-          message: `Failed to parse nodeinfo ${version} data`,
-          cause: error,
-        }),
-    });
-
-    return data;
+) {
+  const res = yield* Effect.tryPromise({
+    try: () =>
+      fetch(href, {
+        signal: AbortSignal.timeout(20000),
+      }),
+    catch: (error) =>
+      new NodeinfoError({
+        message: `Failed to fetch nodeinfo ${version} data`,
+        cause: error,
+      }),
   });
 
-export const detector = (url: string): Effect.Effect<SNSType, NodeinfoError> =>
-  Effect.gen(function* () {
-    const res = yield* Effect.tryPromise({
-      try: () =>
-        fetch(`${url}/.well-known/nodeinfo`, {
-          signal: AbortSignal.timeout(20000),
-        }),
-      catch: (error) =>
-        new NodeinfoError({
-          message: "Failed to fetch nodeinfo endpoint",
-          cause: error,
-        }),
+  if (!res.ok) {
+    return yield* new NodeinfoError({
+      message: `Failed to fetch nodeinfo data: ${res.status} ${res.statusText}`,
     });
+  }
 
-    if (!res.ok) {
-      return yield* Effect.fail(
-        new NodeinfoError({
-          message: `Failed to fetch nodeinfo: ${res.status} ${res.statusText}`,
-        }),
-      );
-    }
-
-    const data = yield* Effect.tryPromise({
-      try: () => res.json() as Promise<Links>,
-      catch: (error) =>
-        new NodeinfoError({
-          message: "Failed to parse nodeinfo response",
-          cause: error,
-        }),
-    });
-
-    const link = data.links.find(
-      (l) => l.rel === NODEINFO_VERSIONS["2.0"] || l.rel === NODEINFO_VERSIONS["2.1"],
-    );
-
-    if (!link) {
-      return yield* Effect.fail(new NodeinfoError({ message: "Could not find nodeinfo" }));
-    }
-
-    const version = link.rel === NODEINFO_VERSIONS["2.1"] ? "2.1" : "2.0";
-    const nodeinfo = yield* fetchNodeinfoVersion(link.href, version);
-    return yield* detectFromNodeinfo(nodeinfo.software, nodeinfo.metadata);
+  const data = yield* Effect.tryPromise({
+    try: () => res.json() as Promise<NodeinfoData>,
+    catch: (error) =>
+      new NodeinfoError({
+        message: `Failed to parse nodeinfo ${version} data`,
+        cause: error,
+      }),
   });
+
+  return data;
+});
+
+export const detector = Effect.fn("detector")(function* (url: string) {
+  const res = yield* Effect.tryPromise({
+    try: () =>
+      fetch(`${url}/.well-known/nodeinfo`, {
+        signal: AbortSignal.timeout(20000),
+      }),
+    catch: (error) =>
+      new NodeinfoError({
+        message: "Failed to fetch nodeinfo endpoint",
+        cause: error,
+      }),
+  });
+
+  if (!res.ok) {
+    return yield* new NodeinfoError({
+      message: `Failed to fetch nodeinfo: ${res.status} ${res.statusText}`,
+    });
+  }
+
+  const data = yield* Effect.tryPromise({
+    try: () => res.json() as Promise<Links>,
+    catch: (error) =>
+      new NodeinfoError({
+        message: "Failed to parse nodeinfo response",
+        cause: error,
+      }),
+  });
+
+  const link = data.links.find(
+    (l) => l.rel === NODEINFO_VERSIONS["2.0"] || l.rel === NODEINFO_VERSIONS["2.1"],
+  );
+
+  if (!link) {
+    return yield* new NodeinfoError({ message: "Could not find nodeinfo" });
+  }
+
+  const version = link.rel === NODEINFO_VERSIONS["2.1"] ? "2.1" : "2.0";
+  const nodeinfo = yield* fetchNodeinfoVersion(link.href, version);
+  return yield* detectFromNodeinfo(nodeinfo.software, nodeinfo.metadata);
+});

--- a/apps/web/src/libs/actions/guestbook/index.ts
+++ b/apps/web/src/libs/actions/guestbook/index.ts
@@ -70,7 +70,7 @@ export const initiateAuthAction = action(async (formData: FormData) => {
       yield* Effect.logInfo("guestbook:initiateAuth:start");
       const handle = formData.get("handle")?.toString();
       if (!handle) {
-        return yield* Effect.fail(new MissingFieldError({ field: "handle" }));
+        return yield* new MissingFieldError({ field: "handle" });
       }
 
       const result = yield* auth.initiateAuth(handle);
@@ -94,22 +94,20 @@ export const signGuestbookAction = action(async (formData: FormData) => {
       yield* Effect.logInfo("guestbook:sign:start");
       const message = formData.get("message")?.toString();
       if (!message) {
-        return yield* Effect.fail(new MissingFieldError({ field: "message" }));
+        return yield* new MissingFieldError({ field: "message" });
       }
 
       const profanityCheck = checkProfanity(message);
       if (profanityCheck.hasProfanity) {
-        return yield* Effect.fail(
-          new ProfanityError({
-            message:
-              profanityCheck.message ?? "Your message contains profanity. Please keep it clean!",
-          }),
-        );
+        return yield* new ProfanityError({
+          message:
+            profanityCheck.message ?? "Your message contains profanity. Please keep it clean!",
+        });
       }
 
       const userCookie = yield* getCookieValue(USER_COOKIE);
       if (!userCookie) {
-        return yield* Effect.fail(new AuthenticationError({ message: "Not authenticated" }));
+        return yield* new AuthenticationError({ message: "Not authenticated" });
       }
 
       const user = JSON.parse(userCookie) as auth.FediverseUser;

--- a/packages/@tom/checkout/src/index.ts
+++ b/packages/@tom/checkout/src/index.ts
@@ -11,105 +11,96 @@ export const formatPrice = (product: Product): string => {
   return amt !== undefined && amt !== null ? `$${amt / 100}` : "Free";
 };
 
-export const fetchProducts = Effect.fn("fetchProducts")(
-  (isDev: boolean): Effect.Effect<Product[], HttpError> =>
-    Effect.gen(function* () {
-      const base = getCheckoutApiBase(isDev);
-      const response = yield* Effect.tryPromise({
-        try: () => fetch(`${base}/products`),
-        catch: () => new HttpError({ message: "Network error", status: 0 }),
-      });
+export const fetchProducts = Effect.fn("fetchProducts")(function* (isDev: boolean) {
+  const base = getCheckoutApiBase(isDev);
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(`${base}/products`),
+    catch: () => new HttpError({ message: "Network error", status: 0 }),
+  });
 
-      if (!response.ok) {
-        return yield* Effect.fail(
-          new HttpError({
-            message: "Failed to load products",
-            status: response.status,
-          }),
-        );
-      }
+  if (!response.ok) {
+    return yield* new HttpError({
+      message: "Failed to load products",
+      status: response.status,
+    });
+  }
 
-      return yield* Effect.tryPromise({
-        try: () => response.json() as Promise<Product[]>,
-        catch: () =>
-          new HttpError({
-            message: "Failed to parse response",
-            status: HttpStatus.InternalServerError,
-          }),
-      });
-    }),
-);
+  return yield* Effect.tryPromise({
+    try: () => response.json() as Promise<Product[]>,
+    catch: () =>
+      new HttpError({
+        message: "Failed to parse response",
+        status: HttpStatus.InternalServerError,
+      }),
+  });
+});
 
-export const fetchProduct = Effect.fn("fetchProduct")(
-  (productId: string, isDev: boolean): Effect.Effect<Product, HttpError> =>
-    Effect.gen(function* () {
-      const base = getCheckoutApiBase(isDev);
-      const response = yield* Effect.tryPromise({
-        try: () => fetch(`${base}/products/${productId}`),
-        catch: () => new HttpError({ message: "Network error", status: 0 }),
-      });
+export const fetchProduct = Effect.fn("fetchProduct")(function* (
+  productId: string,
+  isDev: boolean,
+) {
+  const base = getCheckoutApiBase(isDev);
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(`${base}/products/${productId}`),
+    catch: () => new HttpError({ message: "Network error", status: 0 }),
+  });
 
-      if (!response.ok) {
-        return yield* Effect.fail(
-          new HttpError({
-            message: "Failed to load product",
-            status: response.status,
-          }),
-        );
-      }
+  if (!response.ok) {
+    return yield* new HttpError({
+      message: "Failed to load product",
+      status: response.status,
+    });
+  }
 
-      return yield* Effect.tryPromise({
-        try: () => response.json() as Promise<Product>,
-        catch: () =>
-          new HttpError({
-            message: "Failed to parse response",
-            status: HttpStatus.InternalServerError,
-          }),
-      });
-    }),
-);
+  return yield* Effect.tryPromise({
+    try: () => response.json() as Promise<Product>,
+    catch: () =>
+      new HttpError({
+        message: "Failed to parse response",
+        status: HttpStatus.InternalServerError,
+      }),
+  });
+});
 
-export const createCustomer = Effect.fn("createCustomer")(
-  (input: CustomerInput, isDev: boolean): Effect.Effect<Customer, HttpError> =>
-    Effect.gen(function* () {
-      const base = getCheckoutApiBase(isDev);
-      const response = yield* Effect.tryPromise({
-        try: () =>
-          fetch(`${base}/customers`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(input),
-          }),
-        catch: () => new HttpError({ message: "Network error", status: 0 }),
-      });
+export const createCustomer = Effect.fn("createCustomer")(function* (
+  input: CustomerInput,
+  isDev: boolean,
+) {
+  const base = getCheckoutApiBase(isDev);
+  const response = yield* Effect.tryPromise({
+    try: () =>
+      fetch(`${base}/customers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      }),
+    catch: () => new HttpError({ message: "Network error", status: 0 }),
+  });
 
-      if (!response.ok) {
-        const errorData = yield* Effect.tryPromise({
-          try: () => response.json() as Promise<{ error?: string }>,
-          catch: () =>
-            new HttpError({
-              message: "Failed to create customer",
-              status: response.status,
-            }),
-        });
-        return yield* Effect.fail(
-          new HttpError({
-            message: errorData.error ?? "Failed to create customer",
-            status: response.status,
-          }),
-        );
-      }
+  if (!response.ok) {
+    const errorData = yield* Effect.tryPromise({
+      try: () => response.json() as Promise<{ error?: string }>,
+      catch: () =>
+        new HttpError({
+          message: "Failed to create customer",
+          status: response.status,
+        }),
+    });
+    return yield* new HttpError({
+      message: errorData.error ?? "Failed to create customer",
+      status: response.status,
+    });
+  }
 
-      return yield* Effect.tryPromise({
-        try: () => response.json() as Promise<Customer>,
-        catch: () =>
-          new HttpError({
-            message: "Failed to parse response",
-            status: HttpStatus.InternalServerError,
-          }),
-      });
-    }),
-);
+  return yield* Effect.tryPromise({
+    try: () => response.json() as Promise<Customer>,
+    catch: () =>
+      new HttpError({
+        message: "Failed to parse response",
+        status: HttpStatus.InternalServerError,
+      }),
+  });
+});
 
 export const getCheckoutUrl = (productId: string, customerId: string, isDev: boolean): string => {
   const base = getCheckoutApiBase(isDev);

--- a/packages/@tom/payload/src/service.ts
+++ b/packages/@tom/payload/src/service.ts
@@ -183,21 +183,18 @@ export class PayloadService extends Effect.Service<PayloadService>()("PayloadSer
         });
       },
 
-      getPostBySlug: Effect.fn("PayloadService.getPostBySlug")(
-        (slug: string): Effect.Effect<PayloadPost | null, PayloadError> =>
-          Effect.gen(function* () {
-            const endpoint = `/posts?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
-            const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
-              useCache: true,
-            });
+      getPostBySlug: Effect.fn("PayloadService.getPostBySlug")(function* (slug: string) {
+        const endpoint = `/posts?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
+        const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
+          useCache: true,
+        });
 
-            if (!data.docs || data.docs.length === 0) {
-              return null;
-            }
+        if (!data.docs || data.docs.length === 0) {
+          return null;
+        }
 
-            return data.docs[0] ?? null;
-          }),
-      ),
+        return data.docs[0] ?? null;
+      }),
 
       getWorks: (params) => {
         const endpoint = `/works${buildQuery(params)}`;
@@ -206,21 +203,18 @@ export class PayloadService extends Effect.Service<PayloadService>()("PayloadSer
         });
       },
 
-      getWorkBySlug: Effect.fn("PayloadService.getWorkBySlug")(
-        (slug: string): Effect.Effect<PayloadPost | null, PayloadError> =>
-          Effect.gen(function* () {
-            const endpoint = `/works?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
-            const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
-              useCache: true,
-            });
+      getWorkBySlug: Effect.fn("PayloadService.getWorkBySlug")(function* (slug: string) {
+        const endpoint = `/works?where[slug][equals]=${encodeURIComponent(slug)}&limit=1`;
+        const data = yield* doFetch<PayloadResponse<PayloadPost>>(endpoint, {
+          useCache: true,
+        });
 
-            if (!data.docs || data.docs.length === 0) {
-              return null;
-            }
+        if (!data.docs || data.docs.length === 0) {
+          return null;
+        }
 
-            return data.docs[0] ?? null;
-          }),
-      ),
+        return data.docs[0] ?? null;
+      }),
     };
 
     return service;

--- a/packages/@tom/utils/src/telegram.ts
+++ b/packages/@tom/utils/src/telegram.ts
@@ -45,36 +45,33 @@ export class TelegramService extends Effect.Service<TelegramService>()("Telegram
       return text;
     };
 
-    const doSendTelegramAlert = (text: string): Effect.Effect<void, TelegramError> =>
-      Effect.gen(function* () {
-        const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
+    const doSendTelegramAlert = Effect.fn("doSendTelegramAlert")(function* (text: string) {
+      const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
 
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(telegramUrl, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                chat_id: chatId,
-                text,
-                parse_mode: "Markdown",
-              }),
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          fetch(telegramUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              chat_id: chatId,
+              text,
+              parse_mode: "Markdown",
             }),
-          catch: (error) =>
-            new TelegramError({
-              message: error instanceof Error ? error.message : "Unknown error",
-            }),
-        });
-
-        if (!response.ok) {
-          return yield* Effect.fail(
-            new TelegramError({
-              message: `Telegram API error: ${response.status} ${response.statusText}`,
-              status: response.status,
-            }),
-          );
-        }
+          }),
+        catch: (error) =>
+          new TelegramError({
+            message: error instanceof Error ? error.message : "Unknown error",
+          }),
       });
+
+      if (!response.ok) {
+        return yield* new TelegramError({
+          message: `Telegram API error: ${response.status} ${response.statusText}`,
+          status: response.status,
+        });
+      }
+    });
 
     return {
       sendAlert: Effect.fn("TelegramService.sendAlert")((message: string) =>


### PR DESCRIPTION
## Summary
- Fixed TS29 `unnecessaryFailYieldableError` - 14 instances across 6 files
- Fixed TS41 `effectFnOpportunity` - converted functions to `Effect.fn` pattern for better tracing

## Changes

### TS29 Fixes (Yieldable Errors)
Converted `Effect.fail(Error.make(...))` to `yield* Error.make(...)`:
- `apps/web/src/libs/actions/arena/client.ts`
- `apps/web/src/libs/actions/guestbook/auth.ts`
- `apps/web/src/libs/actions/guestbook/detector.ts`
- `apps/web/src/libs/actions/guestbook/index.ts`
- `packages/@tom/checkout/src/index.ts`
- `packages/@tom/utils/src/telegram.ts`

### TS41 Fixes (Effect.fn Pattern)
Converted functions to use `Effect.fn("name")` for better tracing:
- Guestbook auth actions (`initiateAuth`, `handleCallback`, `signGuestbook`)
- Guestbook detector functions
- Payload service functions
- Checkout functions
- Telegram alert function
- Various error handlers

## Test Plan
- [ ] `bun run typecheck` passes in apps/web
- [ ] `bun run lint` passes
- [ ] `bun test` passes (noting one pre-existing external API test failure)
