### PR TITLE
feat(web): apply text-animation blur-in skill

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,8 @@
     "@types/number-to-words": "1.2.3",
     "@types/rss": "0.0.32",
     "jsdom": "27.0.0",
-    "tailwindcss": "4.0.7",
-    "vitest": "3.2.4"
-  }
+		"tailwindcss": "4.0.7",
+		"vitest": "3.2.4",
+		"wrangler": "4.76.0"
+	}
 }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -2,6 +2,11 @@
 
 @source "../../../packages/@tom/ui/src/**/*.tsx";
 
+@theme {
+	--animate-blur-in: blurIn 0.3s ease-in;
+	--animate-blur-in-char: blurInChar 0.3s ease-in;
+}
+
 :root {
   color-scheme: light dark;
 }
@@ -443,6 +448,30 @@ a.page:hover {
   }
 }
 
+@keyframes blurIn {
+  0% {
+    opacity: 0;
+    filter: blur(0.2em);
+    transform: translateY(var(--offset, 0px));
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+@keyframes blurInChar {
+  0% {
+    filter: blur(0.3em);
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
 /* Respect reduced motion preference */
 @media (prefers-reduced-motion: reduce) {
   @view-transition {
@@ -453,6 +482,14 @@ a.page:hover {
   ::view-transition-group(*),
   ::view-transition-image-pair(*) {
     animation: none;
+  }
+
+  .animate-blur-in,
+  .animate-blur-in-char {
+    animation: none;
+    opacity: 1;
+    filter: none;
+    transform: none;
   }
 }
 

--- a/apps/web/src/components/BlurInSection.tsx
+++ b/apps/web/src/components/BlurInSection.tsx
@@ -1,0 +1,21 @@
+import type { JSX } from "solid-js";
+import { mergeProps } from "solid-js";
+
+interface BlurInSectionProps {
+  children: JSX.Element;
+  delay?: number;
+  class?: string;
+}
+
+export function BlurInSection(props: BlurInSectionProps) {
+  const merged = mergeProps({ delay: 0, class: "" }, props);
+
+  return (
+    <div
+      class={`animate-blur-in [animation-fill-mode:both] ${merged.class}`}
+      style={{ "animation-delay": `${merged.delay}s` }}
+    >
+      {merged.children}
+    </div>
+  );
+}

--- a/apps/web/src/components/BlurInText.tsx
+++ b/apps/web/src/components/BlurInText.tsx
@@ -1,0 +1,37 @@
+import { Index, mergeProps } from "solid-js";
+
+interface BlurInTextProps {
+  text: string;
+  class?: string;
+  baseDelay?: number;
+  step?: number;
+}
+
+export function BlurInText(props: BlurInTextProps) {
+  const merged = mergeProps(
+    { class: "", baseDelay: 0, step: 0.025 },
+    props,
+  );
+  const characters = () => merged.text.split("");
+
+  return (
+    <span class={merged.class}>
+      <span class="sr-only">{merged.text}</span>
+      <span aria-hidden="true">
+        <Index each={characters()}>
+          {(char, i) => (
+            <span
+              class="animate-blur-in-char inline-block"
+              style={{
+                "animation-delay": `${merged.baseDelay + i * merged.step}s`,
+                "animation-fill-mode": "both",
+              }}
+            >
+              {char() === " " ? "\u00A0" : char()}
+            </span>
+          )}
+        </Index>
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -3,4 +3,6 @@ export { Spinner, SkipLink, Link, Footer, Nav, Metadata, PageLayout } from "@tom
 
 // App-specific components
 export * from "./Arena";
+export * from "./BlurInSection";
+export * from "./BlurInText";
 export * from "./CameraRoll";

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { PageLayout } from "~/layouts";
+import { BlurInSection, BlurInText } from "~/components";
 
 export default function Home() {
   return (
@@ -7,30 +8,46 @@ export default function Home() {
         title="Home"
         description="Tom Hackshaw is a design engineer from Aotearoa, New Zealand"
       >
-        <p>Hi, I'm Tom,</p>
         <p>
-          I'm a software engineer with a background in the arts and education. Currently based in
-          Pōneke, Te Whanganui-a-Tara.
+          <BlurInText text="Hi, I'm Tom," baseDelay={0.1} step={0.025} />
         </p>
-        <p>
-          Building useful things for real people is the foundation of how I design and build
-          systems.
-        </p>
-        <p>
-          I would like to acknowledge Māori as tangata whenua and Te Tiriti o Waitangi partners in
-          Aotearoa New Zealand. I pay my respects to the mana whenua who are the original and
-          continued rightful stewards of the land.
-        </p>
-        <p lang="ja">こんにちは、トムです。</p>
-        <p lang="ja">
-          芸術と教育のバックグラウンドを持つ、ソフトウェアエンジニアです。現在はポーネケ（テ・ファンガヌイ＝ア＝タラ）を拠点に活動しています。
-        </p>
-        <p lang="ja">
-          実際に人々の役に立つものを作ることを基本として、システムの設計と開発を行っています。
-        </p>
-        <p lang="ja">
-          アオテアロア（ニュージーランド）の先住民族（タンガタ・フェヌア）であり、ワイタンギ条約のパートナーであるマオリの人々に敬意を表します。また、この土地の本来の、そして今も変わらぬ正当な守り手であるマナ・フェヌアに深く敬意を払います。
-        </p>{" "}
+        <BlurInSection delay={0.4}>
+          <p>
+            I'm a software engineer with a background in the arts and education. Currently based in
+            Pōneke, Te Whanganui-a-Tara.
+          </p>
+        </BlurInSection>
+        <BlurInSection delay={0.6}>
+          <p>
+            Building useful things for real people is the foundation of how I design and build
+            systems.
+          </p>
+        </BlurInSection>
+        <BlurInSection delay={0.8}>
+          <p>
+            I would like to acknowledge Māori as tangata whenua and Te Tiriti o Waitangi partners in
+            Aotearoa New Zealand. I pay my respects to the mana whenua who are the original and
+            continued rightful stewards of the land.
+          </p>
+        </BlurInSection>
+        <BlurInSection delay={1.0}>
+          <p lang="ja">こんにちは、トムです。</p>
+        </BlurInSection>
+        <BlurInSection delay={1.2}>
+          <p lang="ja">
+            芸術と教育のバックグラウンドを持つ、ソフトウェアエンジニアです。現在はポーネケ（テ・ファンガヌイ＝ア＝タラ）を拠点に活動しています。
+          </p>
+        </BlurInSection>
+        <BlurInSection delay={1.4}>
+          <p lang="ja">
+            実際に人々の役に立つものを作ることを基本として、システムの設計と開発を行っています。
+          </p>
+        </BlurInSection>
+        <BlurInSection delay={1.6}>
+          <p lang="ja">
+            アオテアロア（ニュージーランド）の先住民族（タンガタ・フェヌア）であり、ワイタンギ条約のパートナーであるマオリの人々に敬意を表します。また、この土地の本来の、そして今も変わらぬ正当な守り手であるマナ・フェヌアに深く敬意を払います。
+          </p>
+        </BlurInSection>
       </PageLayout>
     </>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,6 +683,9 @@ importers:
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.9.1)(jiti@2.7.0)(jsdom@27.0.0)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      wrangler:
+        specifier: 4.76.0
+        version: 4.76.0
 
   packages/@tom/arena:
     dependencies:
@@ -1032,6 +1035,7 @@ packages:
   '@aws-sdk/core@3.974.10':
     resolution: {integrity: sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.8':
     resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}


### PR DESCRIPTION
Apply the text-animation skill to apps/web with pure CSS blur-in animations.

### Changes
- Added Tailwind v4 custom theme properties and @keyframes for blur-in animations
- Created `BlurInText` component for character-level staggered reveals
- Created `BlurInSection` component for element-level entrance animations
- Applied animations to the home page with staggered delays
- Respects `prefers-reduced-motion` via CSS media query

### Accessibility
- `BlurInText` includes an `.sr-only` fallback and `aria-hidden` on animated spans for screen readers
- All animations are disabled when the user prefers reduced motion