### PR TITLE
feat(guestbook): add Turnstile bot protection to sign-ups

### DIFF
--- a/apps/adapter/src/__tests__/guestbook-sign.test.ts
+++ b/apps/adapter/src/__tests__/guestbook-sign.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import type { CloudflareEnv } from "@tom/utils/services/config";
+import { app } from "../index";
+import { requestWithEnv, testEnv } from "../test/helpers";
+
+const signGuestbookMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../integrations/guestbook/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../integrations/guestbook/auth")>();
+  return {
+    ...actual,
+    signGuestbook: signGuestbookMock,
+  };
+});
+
+const fetchMock = vi.fn();
+
+const userCookie = encodeURIComponent(
+  JSON.stringify({
+    username: "tom",
+    instance: "mastodon.social",
+    display_name: "Tom",
+    avatar_url: "https://mastodon.social/avatar.png",
+    access_token: "token",
+  }),
+);
+
+type SignBody = { message: string; token?: string | undefined };
+
+type SiteverifyResult = { success: boolean; action?: string; hostname?: string };
+
+const signRequest = (env: CloudflareEnv, body: SignBody) =>
+  app.fetch(
+    requestWithEnv("http://localhost/guestbook/sign", env, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: `guestbook_user=${userCookie}` },
+      body: JSON.stringify(body),
+    }),
+  );
+
+const signEnv = () => testEnv({ TURNSTILE_SECRET: "test-secret" });
+
+const mockSiteverify = (result: SiteverifyResult) =>
+  fetchMock.mockResolvedValue(new Response(JSON.stringify(result), { status: 200 }));
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  signGuestbookMock.mockReset();
+  signGuestbookMock.mockImplementation(() => Effect.succeed({ id: 1 }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /guestbook/sign with Turnstile", () => {
+  it("signs without verification when no secret is configured", async () => {
+    const response = await signRequest(testEnv(), { message: "Hello" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(signGuestbookMock).toHaveBeenCalledWith(expect.objectContaining({ message: "Hello" }));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing token when a secret is configured", async () => {
+    const response = await signRequest(signEnv(), { message: "Hello" });
+
+    expect(response.status).toBe(400);
+    expect(signGuestbookMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid token", async () => {
+    mockSiteverify({ success: false });
+    const response = await signRequest(signEnv(), { message: "Hello", token: "token-123" });
+
+    expect(response.status).toBe(400);
+    expect(signGuestbookMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token for the wrong action", async () => {
+    mockSiteverify({ success: true, action: "other-action", hostname: "tom.so" });
+    const response = await signRequest(signEnv(), { message: "Hello", token: "token-123" });
+
+    expect(response.status).toBe(400);
+    expect(signGuestbookMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token from an unexpected hostname", async () => {
+    mockSiteverify({ success: true, action: "guestbook-sign", hostname: "evil.example.com" });
+    const response = await signRequest(signEnv(), { message: "Hello", token: "token-123" });
+
+    expect(response.status).toBe(400);
+    expect(signGuestbookMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when siteverify is unreachable", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const response = await signRequest(signEnv(), { message: "Hello", token: "token-123" });
+
+    expect(response.status).toBe(400);
+    expect(signGuestbookMock).not.toHaveBeenCalled();
+  });
+
+  it("signs when the token verifies", async () => {
+    mockSiteverify({ success: true, action: "guestbook-sign", hostname: "tom.so" });
+    const response = await signRequest(signEnv(), { message: "Hello", token: "token-123" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(signGuestbookMock).toHaveBeenCalledWith(expect.objectContaining({ message: "Hello" }));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+    expect(init.method).toBe("POST");
+    const body = new URLSearchParams(init.body as URLSearchParams);
+    expect(body.get("response")).toBe("token-123");
+    expect(body.get("secret")).toBe("test-secret");
+  });
+});

--- a/apps/adapter/src/integrations/guestbook/index.ts
+++ b/apps/adapter/src/integrations/guestbook/index.ts
@@ -35,6 +35,75 @@ type GuestbookError =
   | OAuthSessionError
   | HttpError;
 
+const TURNSTILE_SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const TURNSTILE_ACTION = "guestbook-sign";
+
+const TurnstileVerifySchema = Schema.Struct({
+  success: Schema.Boolean,
+  action: Schema.optional(Schema.String),
+  hostname: Schema.optional(Schema.String),
+});
+
+/**
+ * Hostnames that may legitimately embed the guestbook widget. Subdomains of
+ * `tom.so` are covered by the widget's domain registration, so the check is
+ * apex + subdomains + the local-dev hostnames.
+ */
+const isExpectedTurnstileHostname = (hostname: string): boolean =>
+  hostname === "tom.so" ||
+  hostname.endsWith(".tom.so") ||
+  hostname === "localhost" ||
+  hostname === "127.0.0.1";
+
+/**
+ * Verify a Turnstile token against the canonical siteverify endpoint. Fails
+ * closed: a missing token, transport error, non-2xx response, malformed
+ * body, or action/hostname mismatch all reject the sign. Tokens are
+ * single-use — the widget must render fresh before the next attempt.
+ */
+const verifyTurnstileToken = (
+  token: string | undefined,
+  secret: string,
+): Effect.Effect<boolean, never> =>
+  Effect.gen(function* () {
+    if (!token) return false;
+
+    const response = yield* Effect.tryPromise(() =>
+      fetch(TURNSTILE_SITEVERIFY_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ secret, response: token }),
+        signal: AbortSignal.timeout(10_000),
+      }),
+    ).pipe(
+      Effect.catch(
+        Effect.fn("turnstileSiteverifyErrorHandler")(function* (cause: unknown) {
+          yield* Effect.logWarning("guestbook:sign:turnstile-siteverify-error", cause);
+          return undefined;
+        }),
+      ),
+    );
+    if (!response || !response.ok) return false;
+
+    const body = yield* Effect.tryPromise(() => response.json()).pipe(
+      Effect.catch(
+        Effect.fn("turnstileJsonErrorHandler")(function* () {
+          yield* Effect.logWarning("guestbook:sign:turnstile-body-error");
+          return undefined as unknown;
+        }),
+      ),
+    );
+    const result = Option.getOrNull(Schema.decodeUnknownOption(TurnstileVerifySchema)(body));
+    if (!result) return false;
+
+    return (
+      result.success === true &&
+      result.action === TURNSTILE_ACTION &&
+      result.hostname !== undefined &&
+      isExpectedTurnstileHostname(result.hostname)
+    );
+  });
+
 const guestbookStatus = (error: GuestbookError): number => {
   if (error instanceof HttpError) return error.status;
   if (error instanceof AuthenticationError) return 401;
@@ -229,6 +298,23 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
               message:
                 profanityCheck.message ?? "Your message contains profanity. Please keep it clean!",
             });
+          }
+
+          // Turnstile gates the sign: the web client embeds the widget and
+          // sends the token with the request. The secret binding is absent
+          // only in local dev / tests — deployed stacks always enforce.
+          const turnstileSecret = env.TURNSTILE_SECRET;
+          if (turnstileSecret) {
+            const verified = yield* verifyTurnstileToken(body.token, turnstileSecret);
+            if (!verified) {
+              yield* Effect.logWarning("guestbook:sign:turnstile-rejected");
+              return yield* new HttpError({
+                message: "Verification failed. Please try again.",
+                status: 400,
+              });
+            }
+          } else {
+            yield* Effect.logWarning("guestbook:sign:turnstile-disabled");
           }
 
           yield* auth.signGuestbook({ user, message: body.message });

--- a/apps/adapter/src/schemas.ts
+++ b/apps/adapter/src/schemas.ts
@@ -58,7 +58,12 @@ export const guestbookUserCookieSchema = Schema.toStandardSchemaV1(
 export const handleBodySchema = Schema.toStandardSchemaV1(Schema.Struct({ handle: Schema.String }));
 
 export const messageBodySchema = Schema.toStandardSchemaV1(
-  Schema.Struct({ message: Schema.String }),
+  Schema.Struct({
+    message: Schema.String,
+    // Turnstile widget token; absent in local dev, where the adapter skips
+    // verification because TURNSTILE_SECRET is not bound.
+    token: Schema.optional(Schema.String),
+  }),
 );
 
 export const callbackQuerySchema = Schema.toStandardSchemaV1(

--- a/apps/web/src/components/Turnstile.tsx
+++ b/apps/web/src/components/Turnstile.tsx
@@ -1,0 +1,104 @@
+import { createEffect, onCleanup } from "solid-js";
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (element: HTMLElement, options: TurnstileRenderOptions) => string;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+export type TurnstileRenderOptions = {
+  sitekey: string;
+  action?: string;
+  callback?: (token: string) => void;
+  "expired-callback"?: () => void;
+};
+
+const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+/**
+ * Read at call time (not module scope) so tests can stub the env before
+ * mounting. Inlined by Vite from the Alchemy VITE_ prefix at build time;
+ * absent in local dev, where the widget renders nothing.
+ */
+export const getTurnstileSitekey = (): string | undefined =>
+  import.meta.env.VITE_TURNSTILE_SITEKEY as string | undefined;
+
+let scriptLoadPromise: Promise<boolean> | undefined;
+
+const loadTurnstileScript = (): Promise<boolean> => {
+  // Already loaded (or stubbed in tests) — nothing to inject.
+  if (window.turnstile) return Promise.resolve(true);
+  if (!scriptLoadPromise) {
+    scriptLoadPromise = new Promise((resolve) => {
+      const script = document.createElement("script");
+      script.src = TURNSTILE_SCRIPT_SRC;
+      script.async = true;
+      script.onload = () => resolve(true);
+      script.onerror = () => resolve(false);
+      document.head.appendChild(script);
+    });
+  }
+  return scriptLoadPromise;
+};
+
+type TurnstileProps = {
+  /** Siteverify action — must match the backend's expected action. */
+  action: string;
+  /** Bump to re-render a fresh widget (tokens are single-use). */
+  attempt?: number;
+  /** Called with a fresh token once the challenge is solved. */
+  onToken: (token: string) => void;
+  /** Called when a previously issued token expires. */
+  onExpire?: () => void;
+};
+
+/**
+ * Reusable Cloudflare Turnstile widget. Renders nothing when the sitekey is
+ * not configured (local dev without the Alchemy binding), loads the widget
+ * script once, and re-renders a fresh widget whenever `attempt` changes so
+ * callers can enforce token single-use.
+ */
+export function Turnstile(props: TurnstileProps) {
+  let containerRef: HTMLDivElement | undefined;
+  let currentWidgetId: string | undefined;
+  let renderGeneration = 0;
+
+  createEffect(() => {
+    // Track `attempt` so bumping it re-runs this effect.
+    void props.attempt;
+    const container = containerRef;
+    const sitekey = getTurnstileSitekey();
+    if (!container || !sitekey) return;
+
+    if (currentWidgetId) window.turnstile?.remove(currentWidgetId);
+    currentWidgetId = undefined;
+
+    // Stale-render guard: an `attempt` bump while the script is still
+    // loading must not render the previous attempt's widget.
+    const generation = ++renderGeneration;
+    loadTurnstileScript().then((loaded) => {
+      if (!loaded || generation !== renderGeneration || !window.turnstile) return;
+      currentWidgetId = window.turnstile.render(container, {
+        sitekey,
+        action: props.action,
+        callback: (token) => props.onToken(token),
+        "expired-callback": () => props.onExpire?.(),
+      });
+    });
+  });
+
+  onCleanup(() => {
+    if (currentWidgetId) window.turnstile?.remove(currentWidgetId);
+  });
+
+  return (
+    <div
+      ref={(element) => {
+        containerRef = element;
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/__tests__/Turnstile.test.tsx
+++ b/apps/web/src/components/__tests__/Turnstile.test.tsx
@@ -1,0 +1,71 @@
+import { render, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Turnstile, type TurnstileRenderOptions } from "../Turnstile";
+
+const renderWidget = vi.fn<(element: HTMLElement, options: TurnstileRenderOptions) => string>(
+  () => "widget-1",
+);
+const removeWidget = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("VITE_TURNSTILE_SITEKEY", "test-sitekey");
+  Object.defineProperty(window, "turnstile", {
+    configurable: true,
+    value: { render: renderWidget, remove: removeWidget },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  delete window.turnstile;
+});
+
+describe("Turnstile", () => {
+  it("renders a widget with the sitekey and action", async () => {
+    const onToken = vi.fn();
+    render(() => <Turnstile action="guestbook-sign" onToken={onToken} />);
+
+    await waitFor(() => expect(renderWidget).toHaveBeenCalled());
+    expect(renderWidget).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        sitekey: "test-sitekey",
+        action: "guestbook-sign",
+      }),
+    );
+    // The script is already loaded (stubbed) — nothing injected.
+    expect(document.querySelector('script[src*="turnstile"]')).toBeNull();
+  });
+
+  it("reports the token through onToken", async () => {
+    const onToken = vi.fn();
+    render(() => <Turnstile action="guestbook-sign" onToken={onToken} />);
+    await waitFor(() => expect(renderWidget).toHaveBeenCalled());
+
+    const options = renderWidget.mock.calls[0]?.[1];
+    options?.callback?.("token-123");
+    expect(onToken).toHaveBeenCalledWith("token-123");
+  });
+
+  it("renders a fresh widget when attempt changes", async () => {
+    const onToken = vi.fn();
+    const [attempt, setAttempt] = createSignal(0);
+    render(() => <Turnstile action="guestbook-sign" attempt={attempt()} onToken={onToken} />);
+    await waitFor(() => expect(renderWidget).toHaveBeenCalledTimes(1));
+
+    setAttempt(1);
+    await waitFor(() => expect(renderWidget).toHaveBeenCalledTimes(2));
+    expect(removeWidget).toHaveBeenCalledWith("widget-1");
+  });
+
+  it("renders nothing when the sitekey is unset", async () => {
+    vi.stubEnv("VITE_TURNSTILE_SITEKEY", undefined);
+    render(() => <Turnstile action="guestbook-sign" onToken={vi.fn()} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(renderWidget).not.toHaveBeenCalled();
+    expect(document.querySelector('script[src*="turnstile"]')).toBeNull();
+  });
+});

--- a/apps/web/src/routes/guestbook.tsx
+++ b/apps/web/src/routes/guestbook.tsx
@@ -5,6 +5,7 @@ import { PageLayout } from "@tom/ui/PageLayout";
 import { Spinner } from "@tom/ui/Spinner";
 import { BlurInSection } from "~/components/BlurInSection";
 import { BlurInText } from "~/components/BlurInText";
+import { Turnstile, getTurnstileSitekey } from "~/components/Turnstile";
 import { callAdapter, unwrapAdapter } from "~/libs/adapter";
 import { queryClient } from "~/libs/query-client";
 
@@ -25,8 +26,8 @@ const initiateAuth = async (handle: string) => {
   return unwrapAdapter(result);
 };
 
-const signGuestbook = async (message: string) => {
-  const result = await callAdapter().guestbook.sign.post({ message });
+const signGuestbook = async (message: string, token?: string) => {
+  const result = await callAdapter().guestbook.sign.post({ message, token });
   return unwrapAdapter(result);
 };
 
@@ -62,6 +63,10 @@ export default function Guestbook() {
 
   const [message, setMessage] = createSignal("");
   const [handle, setHandle] = createSignal("");
+  const [turnstileToken, setTurnstileToken] = createSignal<string>();
+  const [turnstileAttempt, setTurnstileAttempt] = createSignal(0);
+  const [verificationError, setVerificationError] = createSignal("");
+  const turnstileSitekey = getTurnstileSitekey();
 
   const authMutation = useMutation(() => ({
     mutationFn: (inputHandle: string) => initiateAuth(inputHandle),
@@ -71,10 +76,17 @@ export default function Guestbook() {
   }));
 
   const signMutation = useMutation(() => ({
-    mutationFn: (inputMessage: string) => signGuestbook(inputMessage),
+    mutationFn: (input: { message: string; token?: string | undefined }) =>
+      signGuestbook(input.message, input.token),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["guestbook-entries"] });
       setMessage("");
+    },
+    onSettled: () => {
+      // Tokens are single-use (redeemed at siteverify) — render a fresh
+      // widget after every attempt.
+      setTurnstileAttempt((attempt) => attempt + 1);
+      setTurnstileToken(undefined);
     },
   }));
 
@@ -184,7 +196,14 @@ export default function Guestbook() {
                         e.preventDefault();
                         const formData = new FormData(e.currentTarget);
                         const inputMessage = formData.get("message")?.toString();
-                        if (inputMessage) signMutation.mutate(inputMessage);
+                        if (!inputMessage) return;
+                        const token = turnstileToken();
+                        if (turnstileSitekey && !token) {
+                          setVerificationError("Complete the verification to sign the guestbook.");
+                          return;
+                        }
+                        setVerificationError("");
+                        signMutation.mutate({ message: inputMessage, token });
                       }}
                     >
                       <textarea
@@ -197,6 +216,19 @@ export default function Guestbook() {
                         disabled={signMutation.isPending}
                         class="input w-full min-h-32 mb-2"
                       />
+                      <Show when={turnstileSitekey}>
+                        <div class="mb-2">
+                          <Turnstile
+                            action="guestbook-sign"
+                            attempt={turnstileAttempt()}
+                            onToken={setTurnstileToken}
+                            onExpire={() => setTurnstileToken(undefined)}
+                          />
+                        </div>
+                      </Show>
+                      <Show when={verificationError()}>
+                        <div class="mb-2 text-sm alert-error">{verificationError()}</div>
+                      </Show>
                       <div class="flex justify-between items-center">
                         <span class="text-sm text-muted">{message().length}/500</span>
                         <button

--- a/infra/apps/adapter.run.ts
+++ b/infra/apps/adapter.run.ts
@@ -6,6 +6,7 @@ import { Stage } from "alchemy/Stage";
 import { devSecretVars, stageHost, stageWebHost, tomSecrets } from "../shared.run.ts";
 import { webHyperdrive } from "../hyperdrive/web.hyperdrive.ts";
 import { tomQueue } from "../queues/tom.queue.ts";
+import { turnstileWidget } from "../turnstile/widget.ts";
 
 const rootDir = `${import.meta.dirname}/../..`;
 
@@ -19,6 +20,15 @@ export const adapter = Effect.gen(function* () {
   const secretEnv = isAlchemyDev
     ? devSecrets
     : { TOM_SECRETS: tomSecrets, HYPERDRIVE: webHyperdrive };
+
+  // Turnstile resolves only on deploys — local dev runs without it. The
+  // widget secret backs the server-side siteverify in the guestbook sign
+  // handler (deployed as a secret binding, never plain text).
+  const turnstileEnv = isAlchemyDev
+    ? {}
+    : yield* Effect.map(turnstileWidget, (turnstile) => ({
+        TURNSTILE_SECRET: turnstile.secret,
+      }));
 
   return yield* Cloudflare.Worker("wwwtom-adapter", {
     main: `${rootDir}/apps/adapter/src/index.ts`,
@@ -40,6 +50,7 @@ export const adapter = Effect.gen(function* () {
     env: {
       NODE_ENV: "production",
       ...secretEnv,
+      ...turnstileEnv,
       WORK_QUEUE: tomQueue,
       ...(isAlchemyDev
         ? {

--- a/infra/apps/web.run.ts
+++ b/infra/apps/web.run.ts
@@ -8,6 +8,7 @@ import { webHyperdrive } from "../hyperdrive/web.hyperdrive.ts";
 import { webKv } from "../kv/web.kv.ts";
 import { tomQueue } from "../queues/tom.queue.ts";
 import { stageHost, stageWebHost, tomSecrets } from "../shared.run.ts";
+import { turnstileWidget } from "../turnstile/widget.ts";
 import { previewComment } from "../utils/github/preview-comment.ts";
 
 const rootDir = `${import.meta.dirname}/../../apps/web`;
@@ -16,8 +17,16 @@ export const web = Effect.gen(function* () {
   const stage = yield* Stage;
   const isAlchemyDev = yield* ALCHEMY_DEV;
   const adapterHost = stageHost(stage, "adapter");
-  // Inlined into the client bundle at build time (Alchemy VITE_ prefix).
-  const viteEnv = isAlchemyDev ? {} : { VITE_ADAPTER_URL: `https://${adapterHost}` };
+
+  // Turnstile resolves only on deploys — local dev runs without it. The
+  // sitekey is inlined into the client bundle at build time (Alchemy VITE_
+  // prefix).
+  const viteEnv = isAlchemyDev
+    ? {}
+    : yield* Effect.map(turnstileWidget, (turnstile) => ({
+        VITE_ADAPTER_URL: `https://${adapterHost}`,
+        VITE_TURNSTILE_SITEKEY: turnstile.sitekey,
+      }));
 
   return yield* Cloudflare.Website.Vite("wwwtom-web", {
     rootDir,

--- a/infra/turnstile/widget.ts
+++ b/infra/turnstile/widget.ts
@@ -1,0 +1,27 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import { Effect } from "effect";
+import { Stage } from "alchemy/Stage";
+
+/**
+ * The single Turnstile widget guarding user-generated content flows (the
+ * guestbook sign form for now). Referenced from both the adapter stack
+ * (server-side siteverify secret) and the web stack (client-side sitekey).
+ *
+ * Production adopts the plain `wwwtom` widget; other stages get a
+ * per-stage widget (`wwwtom-${stage}`) so a per-stage `alchemy destroy`
+ * (e.g. the PR-preview cleanup) never deletes the production widget.
+ *
+ * Domains cover the web apex `tom.so` — subdomains are covered
+ * automatically — plus `localhost`/`127.0.0.1` so the widget can render
+ * during local development. Which hostnames a deployment actually accepts
+ * is decided server-side by the adapter's siteverify hostname check.
+ */
+export const turnstileWidget = Effect.gen(function* () {
+  const stage = yield* Stage;
+
+  return yield* Cloudflare.Turnstile.Widget("wwwtom", {
+    name: stage === "production" ? "wwwtom" : `wwwtom-${stage}`,
+    domains: ["tom.so", "localhost", "127.0.0.1"],
+    mode: "managed",
+  });
+});

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -47,6 +47,10 @@ export type CloudflareEnv = {
   ADAPTER_URL?: string;
   API_URL?: string;
   GUESTBOOK_RETURN_URL?: string;
+  // Server-side Turnstile siteverify secret (guestbook sign flow). Set by
+  // Alchemy from the shared widget; absent in local dev, where the adapter
+  // skips verification.
+  TURNSTILE_SECRET?: string;
   NODE_ENV?: string;
   LOG_LEVEL?: string;
   OTEL_ENDPOINT?: string;


### PR DESCRIPTION
Protect guestbook sign-ups with Cloudflare Turnstile end to end: an Alchemy-managed widget, a reusable Solid component, and canonical server-side siteverify in the adapter.

### Changes

- **Infra (`infra/turnstile/widget.ts`)** — one shared `Cloudflare.Turnstile.Widget` resource referenced by both the web and adapter stacks. Production adopts the plain `wwwtom` widget; other stages get `wwwtom-<stage>` so a per-stage `alchemy destroy` never deletes the production widget. Domains: `tom.so` (subdomains covered automatically) + `localhost`/`127.0.0.1` for local dev.
  - `infra/apps/web.run.ts` — resolves the widget on deploys only and inlines `VITE_TURNSTILE_SITEKEY` into the client bundle.
  - `infra/apps/adapter.run.ts` — binds `TURNSTILE_SECRET` from the widget's `Redacted` secret (deployed as a secret binding, never plain text).
- **Adapter** — `verifyTurnstileToken` in the guestbook integration: canonical siteverify POST with a 10s timeout, **fails closed** on missing token / transport error / non-2xx / malformed body / `success:false` / wrong `action` (`guestbook-sign`) / unexpected `hostname` (`tom.so` + subdomains + localhost). Sign handler requires a verified token before writing; skips (with a `turnstile-disabled` warning log) only when the secret is unbound — local dev/tests.
- **Web** — reusable `apps/web/src/components/Turnstile.tsx`: loads the widget script once, renders nothing without a sitekey (dev/SSR-safe), exposes `onToken`/`onExpire`, and re-renders a fresh widget when `attempt` changes (tokens are single-use). Wired into the guestbook sign form: token sent with the request, submit gated client-side when enabled, fresh widget after every attempt.
- **Shared** — `TURNSTILE_SECRET` added to `CloudflareEnv` in `@tom/utils/services/config`.

### Tests

- `apps/adapter/src/__tests__/guestbook-sign.test.ts` (7): skip-when-unconfigured, missing/invalid/wrong-action/wrong-hostname/unreachable-siteverify rejection, and the happy path with siteverify request-body assertions.
- `apps/web/src/components/__tests__/Turnstile.test.tsx` (4): renders with sitekey/action, token callback, fresh widget on attempt change, renders nothing without a sitekey.
- Full adapter suite 45/45 passing; web suite passing; infra + adapter typecheck clean; `oxfmt --check` clean across the repo.

### Deploy note

First deploy requires `Account.Turnstile:Edit` on the deploy token — the adapter deploy (which runs before web) creates the widget on first run. Widget domains are mutable in place; adding another site later is just a domain + hostname-allowlist change.

### Checklist

- [x] I've left instructions in this PR for reviewers (where necessary).
- [x] I've created appropriate, meaningful tests if necessary.
- [x] I've added documentation and/or comments where we are introducing new patterns that aren't already established.
- [x] My changes have (passing) tests.
- [x] I'm confident this PR resolves the issue it is linked to in GitHub.
