### PR TITLE
fix(utils): correct OTEL endpoint parsing; salvage tests from #110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 playwright-report/
 test-results/
 blob-report/
+
+# Vitest coverage artifacts
+coverage/

--- a/apps/api/src/__tests__/polar.test.ts
+++ b/apps/api/src/__tests__/polar.test.ts
@@ -132,6 +132,24 @@ describe("polar routes", () => {
       });
     });
 
+    it("returns 500 JSON when Polar returns an invalid checkout URL", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ url: "not a url" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const response = await app.fetch(
+        internalRequest("http://localhost/checkout?products=prod_1", env),
+      );
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        type: "about:blank",
+        status: 500,
+        title: "Polar returned an invalid checkout URL",
+      });
+    });
+
     it("returns 500 JSON when Polar is unreachable", async () => {
       fetchMock.mockRejectedValue(new TypeError("fetch failed"));
       const response = await app.fetch(

--- a/packages/utils/__tests__/config.test.ts
+++ b/packages/utils/__tests__/config.test.ts
@@ -6,23 +6,8 @@ import {
   makeAppConfigLayer,
   parseAdminEmails,
   readCloudflareEnv,
-  resolveSecretValue,
 } from "../src/services/config";
 import { SecretsError } from "@tom/types/errors";
-
-describe("resolveSecretValue", () => {
-  it("resolves undefined to undefined", async () => {
-    expect(await resolveSecretValue(undefined)).toBeUndefined();
-  });
-
-  it("resolves a plain string to itself", async () => {
-    expect(await resolveSecretValue("plain-token")).toBe("plain-token");
-  });
-
-  it("resolves a Secrets Store binding via get()", async () => {
-    expect(await resolveSecretValue({ get: async () => "minted-token" })).toBe("minted-token");
-  });
-});
 
 describe("parseAdminEmails", () => {
   it("splits comma-separated emails into a string[]", () => {
@@ -169,10 +154,5 @@ describe("makeAppConfigLayer", () => {
       HYPERDRIVE: { connectionString: "postgres://pooled" },
     });
     expect(Redacted.value(resolved.databaseUrl)).toBe("postgres://pooled");
-  });
-
-  it("treats only production as non-dev", async () => {
-    expect((await readConfig({ NODE_ENV: "development" })).isDev).toBe(true);
-    expect((await readConfig({ NODE_ENV: "production" })).isDev).toBe(false);
   });
 });

--- a/packages/utils/__tests__/config.test.ts
+++ b/packages/utils/__tests__/config.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
-import type { CloudflareEnv } from "../src/services/config";
-import { parseAdminEmails, readCloudflareEnv } from "../src/services/config";
+import { Effect, Redacted } from "effect";
+import type { CloudflareEnv, PartialCloudflareEnv } from "../src/services/config";
+import {
+  AppConfig,
+  makeAppConfigLayer,
+  parseAdminEmails,
+  readCloudflareEnv,
+  resolveSecretValue,
+} from "../src/services/config";
+import { SecretsError } from "@tom/types/errors";
+
+describe("resolveSecretValue", () => {
+  it("resolves undefined to undefined", async () => {
+    expect(await resolveSecretValue(undefined)).toBeUndefined();
+  });
+
+  it("resolves a plain string to itself", async () => {
+    expect(await resolveSecretValue("plain-token")).toBe("plain-token");
+  });
+
+  it("resolves a Secrets Store binding via get()", async () => {
+    expect(await resolveSecretValue({ get: async () => "minted-token" })).toBe("minted-token");
+  });
+});
 
 describe("parseAdminEmails", () => {
   it("splits comma-separated emails into a string[]", () => {
@@ -105,5 +127,52 @@ describe("readCloudflareEnv tenant secrets", () => {
     );
     expect(resolved.GOOGLE_CLIENT_ID).toBe("bundle-id");
     expect(resolved.GOOGLE_CLIENT_SECRET).toBe("bundle-secret");
+  });
+
+  it("throws SecretsError when TOM_SECRETS is not valid JSON", async () => {
+    await expect(
+      readCloudflareEnv({ TOM_SECRETS: { get: async () => "not-json" } }),
+    ).rejects.toThrow(SecretsError);
+  });
+
+  it("drops unknown keys from the TOM_SECRETS bundle", async () => {
+    const resolved = await readCloudflareEnv(
+      bundleEnv({ INTERNAL_API_TOKEN: "token", UNKNOWN_KEY: "nope" }),
+    );
+    expect(resolved.INTERNAL_API_TOKEN).toBe("token");
+    expect(Object.hasOwn(resolved, "UNKNOWN_KEY")).toBe(false);
+  });
+});
+
+describe("makeAppConfigLayer", () => {
+  const readConfig = (env: PartialCloudflareEnv) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* AppConfig;
+      }).pipe(Effect.provide(makeAppConfigLayer(env))),
+    );
+
+  it("trims optional secrets and drops undefined/null placeholders", async () => {
+    const trimmed = await readConfig({ ARENA_TOKEN: "  token  " });
+    expect(trimmed.arenaToken ? Redacted.value(trimmed.arenaToken) : undefined).toBe("token");
+
+    const placeholder = await readConfig({ ARENA_TOKEN: "undefined" });
+    expect(placeholder.arenaToken).toBeUndefined();
+
+    const nullPlaceholder = await readConfig({ ARENA_API_URL: "NULL" });
+    expect(nullPlaceholder.arenaBaseUrl).toBeUndefined();
+  });
+
+  it("prefers the Hyperdrive connection string over DATABASE_URL", async () => {
+    const resolved = await readConfig({
+      DATABASE_URL: "postgres://direct",
+      HYPERDRIVE: { connectionString: "postgres://pooled" },
+    });
+    expect(Redacted.value(resolved.databaseUrl)).toBe("postgres://pooled");
+  });
+
+  it("treats only production as non-dev", async () => {
+    expect((await readConfig({ NODE_ENV: "development" })).isDev).toBe(true);
+    expect((await readConfig({ NODE_ENV: "production" })).isDev).toBe(false);
   });
 });

--- a/packages/utils/__tests__/logging.test.ts
+++ b/packages/utils/__tests__/logging.test.ts
@@ -168,6 +168,36 @@ describe("otelConfigFromResolvedEnv", () => {
     });
   });
 
+  it("strips trailing slashes before the /collector/event suffix", () => {
+    const otel = otelConfigFromResolvedEnv({
+      OTEL_ENDPOINT: "https://example.com/collector/event///",
+      AXIOM_TOKEN: "secret",
+    });
+    expect(otel?.tracesUrl).toBe("https://example.com/v1/traces");
+    expect(otel?.logsUrl).toBe("https://example.com/v1/logs");
+  });
+
+  it("trims surrounding whitespace from the endpoint", () => {
+    const otel = otelConfigFromResolvedEnv({
+      OTEL_ENDPOINT: "  https://example.com/collector/event  ",
+      AXIOM_TOKEN: "secret",
+    });
+    expect(otel?.tracesUrl).toBe("https://example.com/v1/traces");
+  });
+
+  it("keeps a /collector/event segment that is not the suffix", () => {
+    const otel = otelConfigFromResolvedEnv({
+      OTEL_ENDPOINT: "https://example.com/a/collector/event/b",
+      AXIOM_TOKEN: "secret",
+    });
+    expect(otel?.tracesUrl).toBe("https://example.com/a/collector/event/b/v1/traces");
+  });
+
+  it("falls back to the Axiom endpoint when OTEL_ENDPOINT is blank", () => {
+    const otel = otelConfigFromResolvedEnv({ OTEL_ENDPOINT: "   ", AXIOM_TOKEN: "secret" });
+    expect(otel?.tracesUrl).toBe("https://api.axiom.co/v1/traces");
+  });
+
   it("returns undefined when the token is missing", () => {
     expect(otelConfigFromResolvedEnv({})).toBeUndefined();
     expect(otelConfigFromResolvedEnv({ OTEL_ENDPOINT: "https://example.com" })).toBeUndefined();

--- a/packages/utils/__tests__/logging.test.ts
+++ b/packages/utils/__tests__/logging.test.ts
@@ -168,29 +168,13 @@ describe("otelConfigFromResolvedEnv", () => {
     });
   });
 
-  it("strips trailing slashes before the /collector/event suffix", () => {
+  it("trims whitespace and strips trailing slashes before the /collector/event suffix", () => {
     const otel = otelConfigFromResolvedEnv({
-      OTEL_ENDPOINT: "https://example.com/collector/event///",
+      OTEL_ENDPOINT: "  https://example.com/collector/event///  ",
       AXIOM_TOKEN: "secret",
     });
     expect(otel?.tracesUrl).toBe("https://example.com/v1/traces");
     expect(otel?.logsUrl).toBe("https://example.com/v1/logs");
-  });
-
-  it("trims surrounding whitespace from the endpoint", () => {
-    const otel = otelConfigFromResolvedEnv({
-      OTEL_ENDPOINT: "  https://example.com/collector/event  ",
-      AXIOM_TOKEN: "secret",
-    });
-    expect(otel?.tracesUrl).toBe("https://example.com/v1/traces");
-  });
-
-  it("keeps a /collector/event segment that is not the suffix", () => {
-    const otel = otelConfigFromResolvedEnv({
-      OTEL_ENDPOINT: "https://example.com/a/collector/event/b",
-      AXIOM_TOKEN: "secret",
-    });
-    expect(otel?.tracesUrl).toBe("https://example.com/a/collector/event/b/v1/traces");
   });
 
   it("falls back to the Axiom endpoint when OTEL_ENDPOINT is blank", () => {

--- a/packages/utils/__tests__/telegram.integration.spec.ts
+++ b/packages/utils/__tests__/telegram.integration.spec.ts
@@ -13,7 +13,6 @@ const createConfigLayer = (botToken: string, chat: string) =>
     databaseUrl: Redacted.make(""),
     telegramBotToken: Redacted.make(botToken),
     telegramChatId: chat,
-    isDev: true,
   });
 
 const createLayer = (botToken: string, chat: string) =>

--- a/packages/utils/__tests__/telegram.test.ts
+++ b/packages/utils/__tests__/telegram.test.ts
@@ -18,7 +18,6 @@ const createConfigLayer = (config: TestConfig) => {
     databaseUrl: Redacted.make(""),
     telegramBotToken: token ? Redacted.make(token) : undefined,
     telegramChatId: chatId,
-    isDev: true,
   });
 };
 

--- a/packages/utils/src/services/config.ts
+++ b/packages/utils/src/services/config.ts
@@ -9,7 +9,6 @@ export interface AppConfigContract {
   readonly databaseUrl: Redacted.Redacted<string>;
   readonly telegramBotToken: Redacted.Redacted<string> | undefined;
   readonly telegramChatId: string | undefined;
-  readonly isDev: boolean;
 }
 
 const parseOptionalSecret = (value?: string): string | undefined => {
@@ -270,20 +269,7 @@ export const readCloudflareEnv = async (env: CloudflareEnv): Promise<ResolvedClo
   };
 };
 
-export class AppConfig extends Context.Service<AppConfig, AppConfigContract>()("AppConfig") {
-  static readonly Default = Layer.succeed(AppConfig, {
-    arenaToken: undefined as Redacted.Redacted<string> | undefined,
-    arenaBaseUrl: undefined as string | undefined,
-    databaseUrl: Redacted.make(""),
-    telegramBotToken: undefined as Redacted.Redacted<string> | undefined,
-    telegramChatId: undefined as string | undefined,
-    isDev: true as boolean,
-  });
-
-  static fromEnv(env: CloudflareEnv): Layer.Layer<AppConfig> {
-    return makeAppConfigLayer(env);
-  }
-}
+export class AppConfig extends Context.Service<AppConfig, AppConfigContract>()("AppConfig") {}
 
 export type PartialCloudflareEnv = {
   [K in keyof CloudflareEnv]?: CloudflareEnv[K] | undefined;
@@ -304,6 +290,5 @@ export const makeAppConfigLayer = (config: PartialCloudflareEnv): Layer.Layer<Ap
       ? Redacted.make(config.TELEGRAM_BOT_TOKEN)
       : undefined,
     telegramChatId: config.TELEGRAM_CHAT_ID,
-    isDev: config.NODE_ENV !== "production",
   });
 };

--- a/packages/utils/src/services/logging.ts
+++ b/packages/utils/src/services/logging.ts
@@ -40,12 +40,21 @@ export type LogContext = {
   readonly otel?: OtelConfig;
 };
 
+const stripTrailingSlashes = (value: string): string => {
+  let stripped = value;
+  while (stripped.endsWith("/")) stripped = stripped.slice(0, -1);
+  return stripped;
+};
+
 const parseOtelEndpoint = (raw: string | undefined): string | undefined => {
-  const endpoint = raw
-    ?.trim()
-    .replace(/\/collector\/event$/, "")
-    .replace(/\/+$/, "");
-  return endpoint ? endpoint : undefined;
+  if (raw === undefined) return undefined;
+  const trimmed = stripTrailingSlashes(raw.trim());
+  if (!trimmed) return undefined;
+  const suffix = "/collector/event";
+  const endpoint = trimmed.endsWith(suffix)
+    ? stripTrailingSlashes(trimmed.slice(0, -suffix.length))
+    : trimmed;
+  return endpoint || undefined;
 };
 
 // Axiom cloud OTLP base. The datasets are the runtime defaults

--- a/packages/utils/src/services/logging.ts
+++ b/packages/utils/src/services/logging.ts
@@ -40,11 +40,8 @@ export type LogContext = {
   readonly otel?: OtelConfig;
 };
 
-const stripTrailingSlashes = (value: string): string => {
-  let stripped = value;
-  while (stripped.endsWith("/")) stripped = stripped.slice(0, -1);
-  return stripped;
-};
+const stripTrailingSlashes = (value: string): string =>
+  value.endsWith("/") ? stripTrailingSlashes(value.slice(0, -1)) : value;
 
 const parseOtelEndpoint = (raw: string | undefined): string | undefined => {
   if (raw === undefined) return undefined;


### PR DESCRIPTION
Rebuilt on current `dev`. Salvages the real wins from the stale mutation-testing branch; the Stryker setup, source `// Stryker disable` comments and mutation-padding tests are dropped.

**Fix**

- `parseOtelEndpoint` now strips trailing slashes before the `/collector/event` suffix, so `OTEL_ENDPOINT=https://…/collector/event///` no longer yields `…/collector/event/v1/traces`. Regex-free (avoids the CodeQL polynomial-ReDoS alert) and covered for whitespace/blank values.

**Tests salvaged**

- `TOM_SECRETS` invalid-JSON and unknown-key handling; `makeAppConfigLayer` token trimming and Hyperdrive precedence.
- Polar `/checkout` returns 500 with the invalid-URL problem title when Polar returns an unusable `url`.

**Dropped as bloat**

- Stryker configs/scripts/deps for adapter/api/web/utils, ~150 source disable comments, `toBeDefined()` padding tests, and tests for APIs that no longer exist (`payloadUrl`, `toErrorResponse`, old `AppConfig` shape).
- Tests with no unique behavior: `resolveSecretValue` is covered through its callers, and the `isDev` flag has no production consumer.
- Unused `AppConfig.Default` / `AppConfig.fromEnv` statics and the `isDev` flag; `coverage/` is now gitignored so a coverage run no longer trips `pnpm format`.

Verified: `pnpm turbo run typecheck` (17/17), `pnpm test` (10/10), `oxfmt --check`, plus direct `tsc --noEmit` for `@tom/ui` and `@tom/editor`.
