### PR TITLE
feat(api,web,infra): Neon Postgres tsvector search with read replica and 3-char debounce

### DIFF
--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -45,6 +45,7 @@ export const app = new Elysia({
       credentials: true,
       methods: ["GET", "POST", "OPTIONS"],
       allowedHeaders: ["Content-Type", "x-use-simulator", "x-api-key"],
+      exposeHeaders: ["x-auth-cookie-token", "x-request-id"],
     }),
   )
   .derive(async ({ set, request, cookie }) => {

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -13,6 +13,7 @@ import {
 import type { CloudflareEnv } from "@tom/utils/services/config";
 import { AdapterError } from "./config/effect";
 import { addressIntegration } from "./integrations/address";
+import { authIntegration } from "./integrations/auth";
 import { arenaIntegration } from "./integrations/arena";
 import { payloadIntegration } from "./integrations/payload";
 import { polarIntegration } from "./integrations/polar";
@@ -105,6 +106,7 @@ export const app = new Elysia({
     return toErrorResponse(500, "Internal server error");
   })
   .use(addressIntegration)
+  .use(authIntegration)
   .use(arenaIntegration)
   .use(payloadIntegration)
   .use(polarIntegration)

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@tom/utils/services/worker";
 import type { CloudflareEnv } from "@tom/utils/services/config";
 import { AdapterError } from "./config/effect";
+import { addressIntegration } from "./integrations/address";
 import { arenaIntegration } from "./integrations/arena";
 import { payloadIntegration } from "./integrations/payload";
 import { polarIntegration } from "./integrations/polar";
@@ -103,6 +104,7 @@ export const app = new Elysia({
     sendErrorAlert(getRequestEnv(request), "Unhandled adapter error", error);
     return toErrorResponse(500, "Internal server error");
   })
+  .use(addressIntegration)
   .use(arenaIntegration)
   .use(payloadIntegration)
   .use(polarIntegration)

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -44,7 +44,7 @@ export const app = new Elysia({
       },
       credentials: true,
       methods: ["GET", "POST", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "x-use-simulator"],
+      allowedHeaders: ["Content-Type", "x-use-simulator", "x-api-key"],
     }),
   )
   .derive(async ({ set, request, cookie }) => {

--- a/apps/adapter/src/integrations/address/index.ts
+++ b/apps/adapter/src/integrations/address/index.ts
@@ -54,8 +54,15 @@ export const addressIntegration = new Elysia({ name: "address" })
           limitValue !== undefined ? { ...baseQuery, limit: limitValue } : baseQuery;
         const apiQuery = bboxValue !== undefined ? { ...withLimit, bbox: bboxValue } : withLimit;
 
+        const apiKeyHeader = request.headers.get("x-api-key");
         const result = yield* Effect.tryPromise({
-          try: () => api.v1.search.get({ query: apiQuery }),
+          try: () =>
+            api.v1.search.get(
+              Object.assign(
+                { query: apiQuery },
+                apiKeyHeader ? { headers: { "x-api-key": apiKeyHeader } } : {},
+              ),
+            ),
           catch: (cause) =>
             new HttpError({ message: "Failed to proxy address search", status: 502, cause }),
         });

--- a/apps/adapter/src/integrations/address/index.ts
+++ b/apps/adapter/src/integrations/address/index.ts
@@ -9,9 +9,9 @@ import { AdapterError, runAdapter } from "../../config/effect";
 import { simulatorEnv } from "../../simulator";
 
 const SearchQuerySchema = Schema.Struct({
-  q: Schema.String,
+  q: Schema.Union([Schema.String, Schema.Array(Schema.String)]),
   limit: Schema.optional(Schema.String),
-  bbox: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.Union([Schema.String, Schema.Array(Schema.String)])),
 });
 
 const RawMetaSchema = Schema.Struct({
@@ -38,16 +38,21 @@ export const addressIntegration = new Elysia({ name: "address" })
       const api = callApi(apiUrl, env.INTERNAL_API_TOKEN);
 
       const program = Effect.gen(function* () {
+        const qValue = Array.isArray(query.q) ? query.q.join(",") : query.q;
+        const limitValue =
+          query.limit && Array.isArray(query.limit) ? query.limit.join(",") : query.limit;
+        const bboxValue =
+          query.bbox && Array.isArray(query.bbox) ? query.bbox.join(",") : query.bbox;
         yield* Effect.logInfo("address:search:proxy", {
-          q: query.q,
-          limit: query.limit,
-          bbox: query.bbox,
+          q: qValue,
+          limit: limitValue,
+          bbox: bboxValue,
         });
 
-        const baseQuery = { q: query.q };
+        const baseQuery = { q: qValue };
         const withLimit =
-          query.limit !== undefined ? { ...baseQuery, limit: query.limit } : baseQuery;
-        const apiQuery = query.bbox !== undefined ? { ...withLimit, bbox: query.bbox } : withLimit;
+          limitValue !== undefined ? { ...baseQuery, limit: limitValue } : baseQuery;
+        const apiQuery = bboxValue !== undefined ? { ...withLimit, bbox: bboxValue } : withLimit;
 
         const result = yield* Effect.tryPromise({
           try: () => api.v1.search.get({ query: apiQuery }),

--- a/apps/adapter/src/integrations/address/index.ts
+++ b/apps/adapter/src/integrations/address/index.ts
@@ -14,6 +14,12 @@ const SearchQuerySchema = Schema.Struct({
   bbox: Schema.optional(Schema.String),
 });
 
+const RawMetaSchema = Schema.Struct({
+  version: Schema.String,
+  totalAddresses: Schema.Number,
+  lastUpdated: Schema.Union([Schema.String, Schema.Date]),
+});
+
 const searchQuerySchema = Schema.toStandardSchemaV1(SearchQuerySchema);
 const addressSearchResponseSchema = Schema.toStandardSchemaV1(Schema.Array(AddressSchema));
 const metaResponseSchema = Schema.toStandardSchemaV1(MetaSchema);
@@ -38,10 +44,10 @@ export const addressIntegration = new Elysia({ name: "address" })
           bbox: query.bbox,
         });
 
-        // oxlint-disable-next-line anti-slop/no-known-value-widening -- Eden treaty query contract requires optional limit/bbox
-        const apiQuery: { q: string; limit?: string; bbox?: string } = { q: query.q };
-        if (query.limit !== undefined) apiQuery.limit = query.limit;
-        if (query.bbox !== undefined) apiQuery.bbox = query.bbox;
+        const baseQuery = { q: query.q };
+        const withLimit =
+          query.limit !== undefined ? { ...baseQuery, limit: query.limit } : baseQuery;
+        const apiQuery = query.bbox !== undefined ? { ...withLimit, bbox: query.bbox } : withLimit;
 
         const result = yield* Effect.tryPromise({
           try: () => api.v1.search.get({ query: apiQuery }),
@@ -107,15 +113,37 @@ export const addressIntegration = new Elysia({ name: "address" })
       const api = callApi(apiUrl, env.INTERNAL_API_TOKEN);
 
       const program = Effect.gen(function* () {
+        yield* Effect.logInfo("address:meta:proxy", { apiUrl });
         const result = yield* Effect.tryPromise({
           try: () => api.v1.meta.get(),
           catch: (cause) =>
             new HttpError({ message: "Failed to proxy address meta", status: 502, cause }),
         });
         if (result.error) {
-          return yield* new HttpError({ message: "Address meta failed", status: 502 });
+          yield* Effect.logError("address:meta:proxy:error", {
+            status: result.status,
+            error: result.error,
+          });
+          return yield* new HttpError({
+            message: "Address meta failed",
+            status: 502,
+            cause: result.error,
+          });
         }
-        return Schema.decodeUnknownSync(MetaSchema)(result.data);
+        const raw = yield* Effect.try({
+          try: () => Schema.decodeUnknownSync(RawMetaSchema)(result.data),
+          catch: (cause) =>
+            new HttpError({
+              message: "Meta decode failed",
+              status: 502,
+              cause,
+            }),
+        });
+        const normalized =
+          raw.lastUpdated instanceof Date
+            ? { ...raw, lastUpdated: raw.lastUpdated.toISOString() }
+            : raw;
+        return Schema.decodeUnknownSync(MetaSchema)(normalized);
       });
 
       return runAdapter(

--- a/apps/adapter/src/integrations/address/index.ts
+++ b/apps/adapter/src/integrations/address/index.ts
@@ -1,0 +1,131 @@
+import { Elysia } from "elysia";
+import { Effect, Option, Schema } from "effect";
+import { HttpError } from "@tom/types/errors";
+import { AddressSchema, MetaSchema } from "@tom/schemas/address";
+import { callApi } from "../../callApi";
+import { readCloudflareEnv } from "@tom/utils/services/config";
+import { getRequestEnv, logContextFromRequest } from "@tom/utils/services/worker";
+import { AdapterError, runAdapter } from "../../config/effect";
+import { simulatorEnv } from "../../simulator";
+
+const SearchQuerySchema = Schema.Struct({
+  q: Schema.String,
+  limit: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.String),
+});
+
+const searchQuerySchema = Schema.toStandardSchemaV1(SearchQuerySchema);
+const addressSearchResponseSchema = Schema.toStandardSchemaV1(Schema.Array(AddressSchema));
+const metaResponseSchema = Schema.toStandardSchemaV1(MetaSchema);
+const ErrorBodySchema = Schema.Struct({ error: Schema.String });
+const EdenErrorSchema = Schema.Struct({
+  status: Schema.Unknown,
+  value: Schema.Unknown,
+});
+
+export const addressIntegration = new Elysia({ name: "address" })
+  .get(
+    "/address/search",
+    async ({ query, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      const api = callApi(apiUrl, env.INTERNAL_API_TOKEN);
+
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo("address:search:proxy", {
+          q: query.q,
+          limit: query.limit,
+          bbox: query.bbox,
+        });
+
+        // oxlint-disable-next-line anti-slop/no-known-value-widening -- Eden treaty query contract requires optional limit/bbox
+        const apiQuery: { q: string; limit?: string; bbox?: string } = { q: query.q };
+        if (query.limit !== undefined) apiQuery.limit = query.limit;
+        if (query.bbox !== undefined) apiQuery.bbox = query.bbox;
+
+        const result = yield* Effect.tryPromise({
+          try: () => api.v1.search.get({ query: apiQuery }),
+          catch: (cause) =>
+            new HttpError({ message: "Failed to proxy address search", status: 502, cause }),
+        });
+
+        if (result.error) {
+          const errorOption = Schema.decodeUnknownOption(EdenErrorSchema)(result.error);
+          const status = Option.match(errorOption, {
+            onNone: () => 502,
+            onSome: (err) => {
+              const maybeNumber = Schema.decodeUnknownOption(Schema.NumberFromString)(
+                String(err.status),
+              );
+              if (Option.isSome(maybeNumber)) return maybeNumber.value;
+              const asNumber = Schema.decodeUnknownOption(Schema.Number)(err.status);
+              return Option.isSome(asNumber) ? asNumber.value : 502;
+            },
+          });
+
+          const valueOption = Schema.decodeUnknownOption(Schema.Struct({ value: Schema.Unknown }))(
+            result.error,
+          );
+          let message = "Address search failed";
+          if (Option.isSome(valueOption)) {
+            const maybeBody = Schema.decodeUnknownOption(ErrorBodySchema)(valueOption.value.value);
+            if (Option.isSome(maybeBody)) message = maybeBody.value.error;
+          }
+
+          return yield* new HttpError({ message, status });
+        }
+
+        const data = result.data ?? [];
+        return Schema.decodeUnknownSync(Schema.Array(AddressSchema))(data);
+      });
+
+      return runAdapter(
+        program,
+        (error) => new AdapterError(error.status || 500, error.message),
+        logContextFromRequest(request, "tom-adapter"),
+      );
+    },
+    {
+      query: searchQuerySchema,
+      response: {
+        200: addressSearchResponseSchema,
+        400: Schema.toStandardSchemaV1(Schema.Struct({ error: Schema.String })),
+        500: Schema.toStandardSchemaV1(Schema.Struct({ error: Schema.String })),
+      },
+      detail: {
+        description:
+          "Proxy NZ address search to Tom API (tsvector) — typed Eden treaty via adapter",
+        tags: ["address"],
+      },
+    },
+  )
+  .get(
+    "/address/meta",
+    async ({ request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      const api = callApi(apiUrl, env.INTERNAL_API_TOKEN);
+
+      const program = Effect.gen(function* () {
+        const result = yield* Effect.tryPromise({
+          try: () => api.v1.meta.get(),
+          catch: (cause) =>
+            new HttpError({ message: "Failed to proxy address meta", status: 502, cause }),
+        });
+        if (result.error) {
+          return yield* new HttpError({ message: "Address meta failed", status: 502 });
+        }
+        return Schema.decodeUnknownSync(MetaSchema)(result.data);
+      });
+
+      return runAdapter(
+        program,
+        (error) => new AdapterError(error.status || 500, error.message),
+        logContextFromRequest(request, "tom-adapter"),
+      );
+    },
+    {
+      response: { 200: metaResponseSchema },
+      detail: { description: "Proxy address dataset meta", tags: ["address"] },
+    },
+  );

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -89,9 +89,16 @@ const proxyToApi = async (
   const init: RequestInit = { method, headers, redirect: "manual" };
   if (body !== undefined) init.body = body;
   const response = await fetch(target.toString(), init);
+  const outHeaders = new Headers();
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() !== "set-cookie") outHeaders.set(key, value);
+  });
+  for (const cookieValue of response.headers.getSetCookie()) {
+    outHeaders.append("set-cookie", cookieValue);
+  }
   return new Response(response.body, {
     status: response.status,
-    headers: response.headers,
+    headers: outHeaders,
   });
 };
 

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -109,7 +109,13 @@ export const authIntegration = new Elysia({ name: "auth" })
     async ({ request }) => {
       const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
       const apiUrl = env.API_URL ?? "http://localhost:8787";
-      return proxyToApi(request, apiUrl, "GET", "/api/auth/get-session");
+      const response = await proxyToApi(request, apiUrl, "GET", "/api/auth/get-session");
+      const cookie = request.headers.get("cookie") ?? "";
+      response.headers.set(
+        "x-auth-cookie-token",
+        cookie.includes("better-auth.session_token") ? "present" : "absent",
+      );
+      return response;
     },
     {
       response: {

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -117,6 +117,11 @@ export const authIntegration = new Elysia({ name: "auth" })
       },
     },
   )
+  .get("/auth/accounts", async ({ request }) => {
+    const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+    const apiUrl = env.API_URL ?? "http://localhost:8787";
+    return proxyToApi(request, apiUrl, "GET", "/api/auth/list-accounts");
+  })
   .post(
     "/auth/sign-in/email",
     async ({ body, request }) => {

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -117,11 +117,21 @@ export const authIntegration = new Elysia({ name: "auth" })
       },
     },
   )
-  .get("/auth/accounts", async ({ request }) => {
-    const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
-    const apiUrl = env.API_URL ?? "http://localhost:8787";
-    return proxyToApi(request, apiUrl, "GET", "/api/auth/list-accounts");
-  })
+  .get(
+    "/auth/accounts",
+    async ({ request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "GET", "/api/auth/list-accounts");
+    },
+    {
+      response: {
+        200: Schema.toStandardSchemaV1(
+          Schema.Array(Schema.Struct({ providerId: Schema.optional(Schema.String) })),
+        ),
+      },
+    },
+  )
   .post(
     "/auth/sign-in/email",
     async ({ body, request }) => {

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -141,6 +141,36 @@ export const authIntegration = new Elysia({ name: "auth" })
     return proxyToApi(request, apiUrl, "POST", "/api/auth/sign-out");
   })
   .post(
+    "/auth/sign-in/social",
+    async ({ body, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "POST", "/api/auth/sign-in/social", JSON.stringify(body));
+    },
+    {
+      body: Schema.toStandardSchemaV1(
+        Schema.Struct({
+          provider: Schema.String,
+          callbackURL: Schema.optional(Schema.String),
+        }),
+      ),
+      response: {
+        200: Schema.toStandardSchemaV1(
+          Schema.Struct({
+            redirect: Schema.Boolean,
+            url: Schema.optional(Schema.String),
+          }),
+        ),
+      },
+    },
+  )
+  .get("/auth/callback/github", async ({ request }) => {
+    const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+    const apiUrl = env.API_URL ?? "http://localhost:8787";
+    const search = new URL(request.url).search;
+    return proxyToApi(request, apiUrl, "GET", `/api/auth/callback/github${search}`);
+  })
+  .post(
     "/auth/sso/register",
     async ({ body, request }) => {
       const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -164,6 +164,12 @@ export const authIntegration = new Elysia({ name: "auth" })
       },
     },
   )
+  .get("/api/auth/callback/github", async ({ request }) => {
+    const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+    const apiUrl = env.API_URL ?? "http://localhost:8787";
+    const search = new URL(request.url).search;
+    return proxyToApi(request, apiUrl, "GET", `/api/auth/callback/github${search}`);
+  })
   .get("/auth/callback/github", async ({ request }) => {
     const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
     const apiUrl = env.API_URL ?? "http://localhost:8787";

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -1,0 +1,191 @@
+import { Elysia } from "elysia";
+import { Schema } from "effect";
+import { readCloudflareEnv } from "@tom/utils/services/config";
+import { getRequestEnv } from "@tom/utils/services/worker";
+import { simulatorEnv } from "../../simulator";
+
+const SignInEmailSchema = Schema.Struct({
+  email: Schema.String,
+  password: Schema.String,
+});
+
+const SignUpEmailSchema = Schema.Struct({
+  name: Schema.String,
+  email: Schema.String,
+  password: Schema.String,
+});
+
+const SsoRegisterSchema = Schema.Struct({
+  idpMetadata: Schema.Unknown,
+  organizationId: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+});
+
+const ScopeSchema = Schema.Union([
+  Schema.Literal("all"),
+  Schema.Literal("one"),
+  Schema.Literal("multiple"),
+]);
+
+const CreateKeySchema = Schema.Struct({
+  name: Schema.String,
+  scope: ScopeSchema,
+  regions: Schema.Array(Schema.String),
+  postcodes: Schema.Boolean,
+});
+
+const UserSchema = Schema.Struct({
+  id: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  email: Schema.optional(Schema.String),
+});
+
+const SessionSchema = Schema.Struct({
+  session: Schema.optional(
+    Schema.Struct({
+      user: Schema.optional(UserSchema),
+    }),
+  ),
+});
+
+const KeySchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.optional(Schema.String),
+  start: Schema.optional(Schema.String),
+  createdAt: Schema.optional(Schema.Number),
+  metadata: Schema.optional(Schema.String),
+});
+
+const KeyListSchema = Schema.Array(KeySchema);
+
+const CreatedKeySchema = Schema.Struct({
+  id: Schema.String,
+  key: Schema.String,
+});
+
+const UsageSchema = Schema.Struct({
+  hour: Schema.Number,
+  day: Schema.Number,
+  week: Schema.Number,
+  month: Schema.Number,
+  year: Schema.Number,
+});
+
+const ErrorSchema = Schema.Struct({ error: Schema.String });
+
+const proxyToApi = async (
+  request: Request,
+  apiUrl: string,
+  method: string,
+  path: string,
+  body?: string,
+): Promise<Response> => {
+  const target = new URL(path, apiUrl);
+  const headers = new Headers({ "content-type": "application/json" });
+  const cookie = request.headers.get("cookie");
+  if (cookie) headers.set("cookie", cookie);
+  const init: RequestInit = { method, headers, redirect: "manual" };
+  if (body !== undefined) init.body = body;
+  const response = await fetch(target.toString(), init);
+  return new Response(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+};
+
+export const authIntegration = new Elysia({ name: "auth" })
+  .get(
+    "/auth/session",
+    async ({ request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "GET", "/api/auth/get-session");
+    },
+    {
+      response: {
+        200: Schema.toStandardSchemaV1(Schema.NullOr(SessionSchema)),
+      },
+    },
+  )
+  .post(
+    "/auth/sign-in/email",
+    async ({ body, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "POST", "/api/auth/sign-in/email", JSON.stringify(body));
+    },
+    { body: Schema.toStandardSchemaV1(SignInEmailSchema) },
+  )
+  .post(
+    "/auth/sign-up/email",
+    async ({ body, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "POST", "/api/auth/sign-up/email", JSON.stringify(body));
+    },
+    { body: Schema.toStandardSchemaV1(SignUpEmailSchema) },
+  )
+  .post("/auth/sign-out", async ({ request }) => {
+    const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+    const apiUrl = env.API_URL ?? "http://localhost:8787";
+    return proxyToApi(request, apiUrl, "POST", "/api/auth/sign-out");
+  })
+  .post(
+    "/auth/sso/register",
+    async ({ body, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "POST", "/api/auth/sso/register", JSON.stringify(body));
+    },
+    { body: Schema.toStandardSchemaV1(SsoRegisterSchema) },
+  )
+  .get(
+    "/auth/keys",
+    async ({ request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "GET", "/v1/keys");
+    },
+    {
+      response: {
+        200: Schema.toStandardSchemaV1(KeyListSchema),
+        401: Schema.toStandardSchemaV1(ErrorSchema),
+      },
+    },
+  )
+  .post(
+    "/auth/keys",
+    async ({ body, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      return proxyToApi(request, apiUrl, "POST", "/v1/keys", JSON.stringify(body));
+    },
+    {
+      body: Schema.toStandardSchemaV1(CreateKeySchema),
+      response: {
+        200: Schema.toStandardSchemaV1(CreatedKeySchema),
+        401: Schema.toStandardSchemaV1(ErrorSchema),
+        500: Schema.toStandardSchemaV1(ErrorSchema),
+      },
+    },
+  )
+  .get(
+    "/auth/usage",
+    async ({ query, request }) => {
+      const env = simulatorEnv(await readCloudflareEnv(getRequestEnv(request)), request);
+      const apiUrl = env.API_URL ?? "http://localhost:8787";
+      const keyId = query.keyId ?? "all";
+      const separator = apiUrl.includes("?") ? "&" : "?";
+      return proxyToApi(
+        request,
+        apiUrl,
+        "GET",
+        `/v1/usage${separator}keyId=${encodeURIComponent(keyId)}`,
+      );
+    },
+    {
+      response: {
+        200: Schema.toStandardSchemaV1(UsageSchema),
+      },
+    },
+  );

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -90,11 +90,12 @@ const proxyToApi = async (
   if (body !== undefined) init.body = body;
   const response = await fetch(target.toString(), init);
   const outHeaders = new Headers();
-  response.headers.forEach((value, key) => {
-    if (key.toLowerCase() !== "set-cookie") outHeaders.set(key, value);
-  });
-  for (const cookieValue of response.headers.getSetCookie()) {
-    outHeaders.append("set-cookie", cookieValue);
+  for (const [key, value] of response.headers) {
+    if (key.toLowerCase() === "set-cookie") {
+      outHeaders.append("set-cookie", value);
+    } else {
+      outHeaders.set(key, value);
+    }
   }
   return new Response(response.body, {
     status: response.status,

--- a/apps/adapter/src/integrations/auth/index.ts
+++ b/apps/adapter/src/integrations/auth/index.ts
@@ -84,6 +84,8 @@ const proxyToApi = async (
   const headers = new Headers({ "content-type": "application/json" });
   const cookie = request.headers.get("cookie");
   if (cookie) headers.set("cookie", cookie);
+  const origin = request.headers.get("origin");
+  if (origin) headers.set("origin", origin);
   const init: RequestInit = { method, headers, redirect: "manual" };
   if (body !== undefined) init.body = body;
   const response = await fetch(target.toString(), init);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,9 @@
     "@tom/utils": "workspace:*",
     "effect": "catalog:",
     "elysia": "catalog:",
+    "kysely": "catalog:",
+    "kysely-postgres-js": "3.0.0",
+    "postgres": "catalog:",
     "workers-og": "0.0.27"
   },
   "devDependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,11 @@
     "lint": "oxlint"
   },
   "dependencies": {
+    "@better-auth/api-key": "1.7.2",
+    "@better-auth/core": "1.7.2",
+    "@better-auth/sso": "1.7.2",
+    "@better-auth/utils": "0.4.2",
+    "@cloudflare/workers-types": "5.20260811.1",
     "@elysiajs/openapi": "catalog:",
     "@standard-schema/spec": "catalog:",
     "@tom/constants": "workspace:*",
@@ -18,6 +23,8 @@
     "@tom/types": "workspace:*",
     "@tom/ui": "workspace:*",
     "@tom/utils": "workspace:*",
+    "better-auth": "1.7.2",
+    "drizzle-orm": "0.45.2",
     "effect": "catalog:",
     "elysia": "catalog:",
     "kysely": "catalog:",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,6 @@
     "lint": "oxlint"
   },
   "dependencies": {
-    "@elysiajs/cors": "catalog:",
     "@elysiajs/openapi": "catalog:",
     "@standard-schema/spec": "catalog:",
     "@tom/constants": "workspace:*",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "lint": "oxlint"
   },
   "dependencies": {
+    "@elysiajs/cors": "catalog:",
     "@elysiajs/openapi": "catalog:",
     "@standard-schema/spec": "catalog:",
     "@tom/constants": "workspace:*",

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -1,0 +1,152 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+// Better Auth core tables for sqlite (better-auth 1.7.2, drizzle adapter).
+// Table/model names match Better Auth plugin expectations.
+
+export const user = sqliteTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: integer("emailVerified", { mode: "boolean" }).notNull(),
+  image: text("image"),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+  role: text("role"),
+  banned: integer("banned", { mode: "boolean" }),
+  banReason: text("banReason"),
+  banExpires: integer("banExpires", { mode: "timestamp" }),
+});
+
+export const session = sqliteTable("session", {
+  id: text("id").primaryKey(),
+  expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+  ipAddress: text("ipAddress"),
+  userAgent: text("userAgent"),
+  userId: text("userId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  impersonatedBy: text("impersonatedBy"),
+  activeOrganizationId: text("activeOrganizationId"),
+});
+
+export const account = sqliteTable("account", {
+  id: text("id").primaryKey(),
+  accountId: text("accountId").notNull(),
+  providerId: text("providerId").notNull(),
+  userId: text("userId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  accessToken: text("accessToken"),
+  refreshToken: text("refreshToken"),
+  idToken: text("idToken"),
+  accessTokenExpiresAt: integer("accessTokenExpiresAt", { mode: "timestamp" }),
+  refreshTokenExpiresAt: integer("refreshTokenExpiresAt", { mode: "timestamp" }),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+export const verification = sqliteTable("verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+  createdAt: integer("createdAt", { mode: "timestamp" }),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }),
+});
+
+// Organization plugin (also used by admin).
+
+export const organization = sqliteTable("organization", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  slug: text("slug").unique(),
+  logo: text("logo"),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  metadata: text("metadata"),
+});
+
+export const member = sqliteTable("member", {
+  id: text("id").primaryKey(),
+  organizationId: text("organizationId")
+    .notNull()
+    .references(() => organization.id, { onDelete: "cascade" }),
+  userId: text("userId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  role: text("role").notNull(),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+});
+
+export const invitation = sqliteTable("invitation", {
+  id: text("id").primaryKey(),
+  organizationId: text("organizationId")
+    .notNull()
+    .references(() => organization.id, { onDelete: "cascade" }),
+  email: text("email").notNull(),
+  role: text("role"),
+  status: text("status").notNull(),
+  expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+  inviterId: text("inviterId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+});
+
+// API key plugin (@better-auth/api-key) table.
+
+export const apikey = sqliteTable("apikey", {
+  configId: text("configId").notNull(),
+  name: text("name"),
+  start: text("start"),
+  referenceId: text("referenceId").notNull(),
+  prefix: text("prefix"),
+  key: text("key").notNull(),
+  refillInterval: integer("refillInterval"),
+  refillAmount: integer("refillAmount"),
+  lastRefillAt: integer("lastRefillAt", { mode: "timestamp" }),
+  enabled: integer("enabled", { mode: "boolean" }),
+  rateLimitEnabled: integer("rateLimitEnabled", { mode: "boolean" }),
+  rateLimitTimeWindow: integer("rateLimitTimeWindow"),
+  rateLimitMax: integer("rateLimitMax"),
+  requestCount: integer("requestCount"),
+  remaining: integer("remaining"),
+  lastRequest: integer("lastRequest", { mode: "timestamp" }),
+  expiresAt: integer("expiresAt", { mode: "timestamp" }),
+  id: text("id").primaryKey(),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+  permissions: text("permissions"),
+  metadata: text("metadata"),
+});
+
+// SSO plugin (@better-auth/sso) table. SAML IdP config is stored in
+// samlConfig (JSON); OIDC config in oidcConfig.
+
+export const ssoProvider = sqliteTable("ssoProvider", {
+  id: text("id").primaryKey(),
+  providerId: text("providerId").notNull(),
+  organizationId: text("organizationId"),
+  domain: text("domain").notNull(),
+  userId: text("userId").notNull(),
+  issuer: text("issuer").notNull(),
+  oidcConfig: text("oidcConfig"),
+  samlConfig: text("samlConfig"),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+// Commercial usage bucket. One row per API-keyed request so the dashboard can
+// aggregate per hour, day, week, month, year and filter by key.
+
+export const authUsage = sqliteTable("auth_usage", {
+  id: text("id").primaryKey(),
+  apikeyId: text("apikeyId"),
+  userId: text("userId"),
+  organizationId: text("organizationId"),
+  createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+  path: text("path").notNull(),
+});

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -39,6 +39,7 @@ export const account = sqliteTable("account", {
   userId: text("userId")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
+  issuer: text("issuer"),
   accessToken: text("accessToken"),
   refreshToken: text("refreshToken"),
   idToken: text("idToken"),

--- a/apps/api/src/db/migrations/0001_auth.sql
+++ b/apps/api/src/db/migrations/0001_auth.sql
@@ -1,0 +1,132 @@
+-- Better Auth + plugins (organization, admin, apiKey, sso) + commercial
+-- usage table. camelCase columns are quoted so SQLite preserves case,
+-- matching the Drizzle schema exactly (drizzle uses quoted identifiers).
+
+CREATE TABLE IF NOT EXISTS "user" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "email" TEXT NOT NULL UNIQUE,
+  "emailVerified" INTEGER NOT NULL,
+  "image" TEXT,
+  "createdAt" INTEGER NOT NULL,
+  "updatedAt" INTEGER NOT NULL,
+  "role" TEXT,
+  "banned" INTEGER,
+  "banReason" TEXT,
+  "banExpires" INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS "session" (
+  "id" TEXT PRIMARY KEY,
+  "expiresAt" INTEGER NOT NULL,
+  "token" TEXT NOT NULL UNIQUE,
+  "createdAt" INTEGER NOT NULL,
+  "updatedAt" INTEGER NOT NULL,
+  "ipAddress" TEXT,
+  "userAgent" TEXT,
+  "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "impersonatedBy" TEXT,
+  "activeOrganizationId" TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "account" (
+  "id" TEXT PRIMARY KEY,
+  "accountId" TEXT NOT NULL,
+  "providerId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "accessToken" TEXT,
+  "refreshToken" TEXT,
+  "idToken" TEXT,
+  "accessTokenExpiresAt" INTEGER,
+  "refreshTokenExpiresAt" INTEGER,
+  "scope" TEXT,
+  "password" TEXT,
+  "createdAt" INTEGER NOT NULL,
+  "updatedAt" INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification" (
+  "id" TEXT PRIMARY KEY,
+  "identifier" TEXT NOT NULL,
+  "value" TEXT NOT NULL,
+  "expiresAt" INTEGER NOT NULL,
+  "createdAt" INTEGER,
+  "updatedAt" INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS "organization" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "slug" TEXT UNIQUE,
+  "logo" TEXT,
+  "createdAt" INTEGER NOT NULL,
+  "metadata" TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "member" (
+  "id" TEXT PRIMARY KEY,
+  "organizationId" TEXT NOT NULL REFERENCES "organization"("id") ON DELETE CASCADE,
+  "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "role" TEXT NOT NULL,
+  "createdAt" INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "invitation" (
+  "id" TEXT PRIMARY KEY,
+  "organizationId" TEXT NOT NULL REFERENCES "organization"("id") ON DELETE CASCADE,
+  "email" TEXT NOT NULL,
+  "role" TEXT,
+  "status" TEXT NOT NULL,
+  "expiresAt" INTEGER NOT NULL,
+  "inviterId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "apikey" (
+  "configId" TEXT NOT NULL,
+  "name" TEXT,
+  "start" TEXT,
+  "referenceId" TEXT NOT NULL,
+  "prefix" TEXT,
+  "key" TEXT NOT NULL,
+  "refillInterval" INTEGER,
+  "refillAmount" INTEGER,
+  "lastRefillAt" INTEGER,
+  "enabled" INTEGER,
+  "rateLimitEnabled" INTEGER,
+  "rateLimitTimeWindow" INTEGER,
+  "rateLimitMax" INTEGER,
+  "requestCount" INTEGER,
+  "remaining" INTEGER,
+  "lastRequest" INTEGER,
+  "expiresAt" INTEGER,
+  "id" TEXT PRIMARY KEY,
+  "createdAt" INTEGER NOT NULL,
+  "updatedAt" INTEGER NOT NULL,
+  "permissions" TEXT,
+  "metadata" TEXT
+);
+CREATE INDEX IF NOT EXISTS "apikey_referenceId_idx" ON "apikey" ("referenceId");
+CREATE INDEX IF NOT EXISTS "apikey_key_idx" ON "apikey" ("key");
+
+CREATE TABLE IF NOT EXISTS "ssoProvider" (
+  "id" TEXT PRIMARY KEY,
+  "providerId" TEXT NOT NULL,
+  "organizationId" TEXT,
+  "domain" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "issuer" TEXT NOT NULL,
+  "oidcConfig" TEXT,
+  "samlConfig" TEXT,
+  "createdAt" INTEGER NOT NULL,
+  "updatedAt" INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "auth_usage" (
+  "id" TEXT PRIMARY KEY,
+  "apikeyId" TEXT,
+  "userId" TEXT,
+  "organizationId" TEXT,
+  "createdAt" INTEGER NOT NULL,
+  "path" TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "auth_usage_apikey_created_idx" ON "auth_usage" ("apikeyId", "createdAt");

--- a/apps/api/src/db/migrations/0002_auth_account_issuer.sql
+++ b/apps/api/src/db/migrations/0002_auth_account_issuer.sql
@@ -1,0 +1,4 @@
+-- Better Auth 1.7 account model adds the issuer namespace for OAuth
+-- accounts (e.g. the IdP issuer). 0001 shipped without it; the live
+-- production D1 already recorded 0001, so ALTER here.
+ALTER TABLE "account" ADD COLUMN "issuer" TEXT;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import { requireInternalTokenBeforeHandle } from "./internal";
 import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { ogRoutes } from "./routes/og";
 import { polarRoutes } from "./routes/polar";
+import { addressRoutes } from "./routes/addresses";
 
 export const app = new Elysia({
   adapter: CloudflareAdapter,
@@ -79,6 +80,7 @@ export const app = new Elysia({
     return toErrorResponse(500, "Internal server error");
   })
   .use(healthRoutes)
+  .use(addressRoutes)
   // OG image generation is a public route: social crawlers (Twitter, Slack,
   // iMessage) fetch the image URL without any auth headers.
   .use(ogRoutes)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import { CloudflareAdapter } from "elysia/adapter/cloudflare-worker";
+import { cors } from "@elysiajs/cors";
 import { openapi } from "@elysiajs/openapi";
 import { Effect } from "effect";
 import { otelConfigFromEnv, logLevelFromEnv } from "@tom/utils/services/logging";
@@ -22,6 +23,23 @@ export const app = new Elysia({
   adapter: CloudflareAdapter,
   name: "tom-api",
 })
+  .use(
+    cors({
+      origin: (request) => {
+        const origin = request.headers.get("origin");
+        if (!origin) return false;
+        return (
+          origin === "http://localhost:5173" ||
+          origin === "http://localhost:3000" ||
+          origin === "http://127.0.0.1:3000" ||
+          origin === "https://tom.so" ||
+          origin.endsWith(".tom.so")
+        );
+      },
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["Content-Type"],
+    }),
+  )
   .use(
     openapi({
       path: "/",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,5 @@
 import { Elysia } from "elysia";
 import { CloudflareAdapter } from "elysia/adapter/cloudflare-worker";
-import { cors } from "@elysiajs/cors";
 import { openapi } from "@elysiajs/openapi";
 import { Effect } from "effect";
 import { otelConfigFromEnv, logLevelFromEnv } from "@tom/utils/services/logging";
@@ -23,23 +22,6 @@ export const app = new Elysia({
   adapter: CloudflareAdapter,
   name: "tom-api",
 })
-  .use(
-    cors({
-      origin: (request) => {
-        const origin = request.headers.get("origin");
-        if (!origin) return false;
-        return (
-          origin === "http://localhost:5173" ||
-          origin === "http://localhost:3000" ||
-          origin === "http://127.0.0.1:3000" ||
-          origin === "https://tom.so" ||
-          origin.endsWith(".tom.so")
-        );
-      },
-      methods: ["GET", "POST", "OPTIONS"],
-      allowedHeaders: ["Content-Type"],
-    }),
-  )
   .use(
     openapi({
       path: "/",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,7 @@ import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { ogRoutes } from "./routes/og";
 import { polarRoutes } from "./routes/polar";
 import { addressRoutes } from "./routes/addresses";
+import { authRoutes } from "./routes/auth";
 
 export const app = new Elysia({
   adapter: CloudflareAdapter,
@@ -80,6 +81,7 @@ export const app = new Elysia({
     return toErrorResponse(500, "Internal server error");
   })
   .use(healthRoutes)
+  .use(authRoutes)
   .use(addressRoutes)
   // OG image generation is a public route: social crawlers (Twitter, Slack,
   // iMessage) fetch the image URL without any auth headers.

--- a/apps/api/src/internal.ts
+++ b/apps/api/src/internal.ts
@@ -19,7 +19,11 @@ const timingSafeEqual = (a: string, b: string): boolean => {
  * {@link INTERNAL_TOKEN_HEADER} value against `INTERNAL_API_TOKEN` (from
  * TOM_SECRETS); fail-closed when the secret isn't configured.
  */
-export const requireInternalTokenBeforeHandle = async ({ request }: { request: Request }) => {
+export const requireInternalTokenBeforeHandle = async ({
+  request,
+}: {
+  request: Request;
+}): Promise<void | Response> => {
   const env = await readCloudflareEnv(getRequestEnv(request));
   const expected = env.INTERNAL_API_TOKEN;
   const provided = request.headers.get(INTERNAL_TOKEN_HEADER);
@@ -32,4 +36,5 @@ export const requireInternalTokenBeforeHandle = async ({ request }: { request: R
     );
     return toErrorResponse(HttpStatus.Unauthorized, "Unauthorized");
   }
+  return undefined;
 };

--- a/apps/api/src/lib/auth.todo.ts
+++ b/apps/api/src/lib/auth.todo.ts
@@ -1,0 +1,10 @@
+// TODO: Better Auth with D1 for commercialisation
+// This file is a stub. When commercialising, replace with real auth.ts.
+// Steps are in docs/auth-commercialisation-plan.md
+// - pnpm add better-auth drizzle-orm
+// - Alchemy D1 binding: Cloudflare.D1.Database("wwwtom-auth-d1")
+// - adapter: drizzleAdapter(db, { provider: "sqlite" })
+// - plugins: sso, organization, apiKey, admin
+// - routes at /api/auth/*
+// See Better Auth docs and installed skills via `npx skills add better-auth/skills`
+export const authStub = "parked - see docs/auth-commercialisation-plan.md";

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,0 +1,75 @@
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { drizzle } from "drizzle-orm/d1";
+import { admin, organization } from "better-auth/plugins";
+import { apiKey } from "@better-auth/api-key";
+import { sso } from "@better-auth/sso";
+import type { D1Database } from "@cloudflare/workers-types";
+import { getRequestEnv } from "@tom/utils/services/worker";
+import { readCloudflareEnv } from "@tom/utils/services/config";
+
+import * as schema from "../db/auth-schema";
+
+export type AuthEnv = {
+  BETTER_AUTH_SECRET?: string | undefined;
+  BETTER_AUTH_URL?: string | undefined;
+};
+
+export const createAuth = (db: D1Database, env: AuthEnv) => {
+  const drizzleDb = drizzle(db, { schema });
+
+  return betterAuth({
+    appName: "tom.so",
+    baseURL: env.BETTER_AUTH_URL ?? "http://localhost:8787",
+    secret: env.BETTER_AUTH_SECRET,
+    database: drizzleAdapter(drizzleDb, {
+      provider: "sqlite",
+    }),
+    emailAndPassword: {
+      enabled: true,
+    },
+    plugins: [
+      organization(),
+      admin(),
+      apiKey({
+        requireName: true,
+        enableMetadata: true,
+        defaultPrefix: "tms_",
+      }),
+      sso(),
+    ] as never[],
+    trustedOrigins: [
+      "http://localhost:5173",
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "https://tom.so",
+      "https://*.tom.so",
+    ],
+  });
+};
+
+export type Auth = ReturnType<typeof createAuth>;
+
+let authCache: Auth | null = null;
+
+/**
+ * Per-request auth instance bound to the request's D1 binding and resolved
+ * TOM_SECRETS bundle. Cached per worker; the binding is stable.
+ */
+export const authFromRequest = async (request: Request): Promise<Auth | null> => {
+  if (authCache) return authCache;
+  const env = await readCloudflareEnv(getRequestEnv(request));
+  const binding = env.AUTH_DB;
+  if (!binding) return null;
+  authCache = createAuth(binding, {
+    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
+    BETTER_AUTH_URL: env.BETTER_AUTH_URL,
+  });
+  return authCache;
+};
+
+export const auth = createAuth({} as D1Database, {
+  BETTER_AUTH_SECRET: "cli-generate-placeholder-32-chars-minimum",
+  BETTER_AUTH_URL: "http://localhost:8787",
+});
+export default auth;

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -55,6 +55,7 @@ export const createAuth = (db: D1Database, env: AuthEnv) => {
     trustedOrigins: [
       "http://localhost:5173",
       "http://localhost:3000",
+      "http://localhost:8788",
       "http://127.0.0.1:3000",
       "https://tom.so",
       "https://*.tom.so",

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -38,6 +38,7 @@ export const createAuth = (db: D1Database, env: AuthEnv) => {
       }),
       sso(),
     ] as never[],
+    onAPIError: { throw: true },
     trustedOrigins: [
       "http://localhost:5173",
       "http://localhost:3000",

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -13,10 +13,14 @@ import * as schema from "../db/auth-schema";
 export type AuthEnv = {
   BETTER_AUTH_SECRET?: string | undefined;
   BETTER_AUTH_URL?: string | undefined;
+  GITHUB_CLIENT_ID?: string | undefined;
+  GITHUB_CLIENT_SECRET?: string | undefined;
 };
 
 export const createAuth = (db: D1Database, env: AuthEnv) => {
   const drizzleDb = drizzle(db, { schema });
+  const githubClientId = env.GITHUB_CLIENT_ID;
+  const githubClientSecret = env.GITHUB_CLIENT_SECRET;
 
   return betterAuth({
     appName: "tom.so",
@@ -28,6 +32,15 @@ export const createAuth = (db: D1Database, env: AuthEnv) => {
     emailAndPassword: {
       enabled: true,
     },
+    socialProviders:
+      githubClientId && githubClientSecret
+        ? {
+            github: {
+              clientId: githubClientId,
+              clientSecret: githubClientSecret,
+            },
+          }
+        : undefined,
     plugins: [
       organization(),
       admin(),
@@ -65,6 +78,8 @@ export const authFromRequest = async (request: Request): Promise<Auth | null> =>
   authCache = createAuth(binding, {
     BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
+    GITHUB_CLIENT_ID: env.GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET: env.GITHUB_CLIENT_SECRET,
   });
   return authCache;
 };

--- a/apps/api/src/routes/addresses.comma.test.ts
+++ b/apps/api/src/routes/addresses.comma.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { Elysia } from "elysia";
+import { Schema } from "effect";
+import { AddressSearchQuerySchema } from "@tom/schemas/address";
+import { toOpenApiSchema } from "../openapi";
+
+const searchQuerySchema = toOpenApiSchema(AddressSearchQuerySchema);
+
+describe("Elysia query validation with comma", () => {
+  const app = new Elysia().get(
+    "/v1/search",
+    ({ query }) => {
+      const raw = Schema.decodeUnknownSync(AddressSearchQuerySchema)(query);
+      const qValue: string = Array.isArray(raw.q) ? raw.q.join(",") : (raw.q as string);
+      return { q: qValue, raw };
+    },
+    {
+      query: searchQuerySchema,
+    },
+  );
+
+  it("accepts q without comma", async () => {
+    const response = await app.handle(
+      new Request("http://localhost/v1/search?q=Dominion%20road&limit=20"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { q: string };
+    expect(body.q).toBe("Dominion road");
+  });
+
+  it("accepts q with comma encoded as %2C", async () => {
+    const response = await app.handle(
+      new Request("http://localhost/v1/search?q=Dominion%20road%2C%204&limit=20"),
+    );
+    expect(response.status).not.toBe(400);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { q: string };
+    expect(body.q).toBe("Dominion road, 4");
+  });
+
+  it("accepts q with comma and space via Elysia array split", async () => {
+    // Elysia splits q=Dominion road, 4 into q: ["Dominion road", " 4"]
+    const response = await app.handle(
+      new Request("http://localhost/v1/search?q=Dominion%20road,%204&limit=20"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { q: string };
+    expect(body.q).toBe("Dominion road, 4");
+  });
+
+  it("accepts bbox with commas", async () => {
+    const response = await app.handle(
+      new Request("http://localhost/v1/search?q=dominion&bbox=174.7,-41.2,174.8,-41.1&limit=5"),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("accepts bbox encoded as %2C", async () => {
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/search?q=dominion&bbox=174.7%2C-41.2%2C174.8%2C-41.1&limit=5",
+      ),
+    );
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -220,7 +220,7 @@ export const addressRoutes = new Elysia({ name: "address" })
   )
   .get(
     "/v1/meta",
-    async ({ request }) => {
+    async ({ request, set }) => {
       const services = await addressServicesFromRequest(request);
       const effect = services
         .getMeta()
@@ -231,6 +231,7 @@ export const addressRoutes = new Elysia({ name: "address" })
         );
       const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
       if (result instanceof Response) return result;
+      set.headers["Cache-Control"] = "public, max-age=60, stale-while-revalidate=30";
       return result;
     },
     {

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -43,7 +43,18 @@ export const addressRoutes = new Elysia({ name: "address" })
   .get(
     "/v1/search",
     async ({ query, request, set }) => {
-      const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)(query);
+      const raw = Schema.decodeUnknownSync(AddressSearchQuerySchema)(query);
+      const qValue: string = Array.isArray(raw.q) ? raw.q.join(",") : (raw.q as string);
+      const bboxRaw: string | undefined = raw.bbox
+        ? Array.isArray(raw.bbox)
+          ? (raw.bbox as readonly string[]).join(",")
+          : (raw.bbox as string)
+        : undefined;
+      const decoded = {
+        q: qValue,
+        limit: raw.limit as string | undefined,
+        bbox: bboxRaw,
+      } satisfies { q: string; limit?: string; bbox?: string };
       const trimmed = decoded.q.trim();
       if (trimmed.length < 3) {
         set.status = 400;
@@ -134,7 +145,27 @@ export const addressRoutes = new Elysia({ name: "address" })
   .get(
     "/v1/addresses",
     async ({ query, request }) => {
-      const decoded = Schema.decodeUnknownSync(AddressListQuerySchema)(query);
+      const raw = Schema.decodeUnknownSync(AddressListQuerySchema)(query);
+      const bboxRaw: string | undefined = raw.bbox
+        ? Array.isArray(raw.bbox)
+          ? (raw.bbox as readonly string[]).join(",")
+          : (raw.bbox as string)
+        : undefined;
+      const decoded = {
+        limit: raw.limit as string | undefined,
+        offset: raw.offset as string | undefined,
+        town_city: raw.town_city as string | undefined,
+        suburb_locality: raw.suburb_locality as string | undefined,
+        road_name: raw.road_name as string | undefined,
+        bbox: bboxRaw,
+      } satisfies {
+        limit?: string;
+        offset?: string;
+        town_city?: string;
+        suburb_locality?: string;
+        road_name?: string;
+        bbox?: string;
+      };
       const limit = parseLimit(decoded.limit, 100, 1000);
       const offset = parseLimit(decoded.offset, 0, 1_000_000);
       const bboxValue = decoded.bbox;

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -98,8 +98,8 @@ export const addressRoutes = new Elysia({ name: "address" })
               apikeyId: verified.id,
               userId: verified.referenceId,
             }),
-          catch: () => Promise.resolve(),
-        });
+          catch: (cause) => new Error(String(cause)),
+        }).pipe(Effect.ignore);
 
         const scoped =
           scopeMetadata && scopeMetadata.scope !== "all"

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -92,9 +92,13 @@ export const addressRoutes = new Elysia({ name: "address" })
         }
 
         const scopeMetadata = verified.metadata;
-        void recordUsage(request, {
-          apikeyId: verified.id,
-          userId: verified.referenceId,
+        yield* Effect.tryPromise({
+          try: () =>
+            recordUsage(request, {
+              apikeyId: verified.id,
+              userId: verified.referenceId,
+            }),
+          catch: () => Promise.resolve(),
         });
 
         const scoped =

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -54,7 +54,7 @@ export const addressRoutes = new Elysia({ name: "address" })
         q: qValue,
         limit: raw.limit as string | undefined,
         bbox: bboxRaw,
-      } satisfies { q: string; limit?: string; bbox?: string };
+      } satisfies { q: string; limit?: string | undefined; bbox?: string | undefined };
       const trimmed = decoded.q.trim();
       if (trimmed.length < 3) {
         set.status = 400;
@@ -159,12 +159,12 @@ export const addressRoutes = new Elysia({ name: "address" })
         road_name: raw.road_name as string | undefined,
         bbox: bboxRaw,
       } satisfies {
-        limit?: string;
-        offset?: string;
-        town_city?: string;
-        suburb_locality?: string;
-        road_name?: string;
-        bbox?: string;
+        limit?: string | undefined;
+        offset?: string | undefined;
+        town_city?: string | undefined;
+        suburb_locality?: string | undefined;
+        road_name?: string | undefined;
+        bbox?: string | undefined;
       };
       const limit = parseLimit(decoded.limit, 100, 1000);
       const offset = parseLimit(decoded.offset, 0, 1_000_000);

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -14,6 +14,8 @@ import {
 import { logContextFromRequest, runEffect, toErrorResponse } from "@tom/utils/services/worker";
 import { toOpenApiSchema } from "../openapi";
 import { addressServicesFromRequest } from "../services/address";
+import { recordUsage, verifyApiKeyRecord } from "../services/auth";
+import { isRegionAllowed } from "../services/address/regions";
 
 const addressSchema = AddressSchema;
 const addressListSchema = AddressListSchema;
@@ -75,13 +77,39 @@ export const addressRoutes = new Elysia({ name: "address" })
       }
 
       const services = await addressServicesFromRequest(request);
-      const effect = services
-        .searchAddresses(trimmed, limit, bbox)
-        .pipe(
-          Effect.catch((error: HttpError) =>
-            Effect.succeed(toErrorResponse(error.status, error.message)),
-          ),
-        );
+      const effect = Effect.gen(function* () {
+        const rows = yield* services.searchAddresses(trimmed, limit, bbox);
+        const apiKeyHeader = request.headers.get("x-api-key");
+        if (!apiKeyHeader) return rows;
+
+        const verified = yield* Effect.tryPromise({
+          try: () => verifyApiKeyRecord(request, apiKeyHeader),
+          catch: (cause) =>
+            new HttpError({ message: "Failed to verify API key", status: 500, cause }),
+        });
+        if (!verified) {
+          return yield* new HttpError({ message: "Invalid API key", status: 401 });
+        }
+
+        const scopeMetadata = verified.metadata;
+        void recordUsage(request, {
+          apikeyId: verified.id,
+          userId: verified.referenceId,
+        });
+
+        const scoped =
+          scopeMetadata && scopeMetadata.scope !== "all"
+            ? rows.filter((row) => isRegionAllowed(row.territorialAuthority, scopeMetadata.regions))
+            : rows;
+        if (scopeMetadata && scopeMetadata.postcodes === false) {
+          return scoped.map((row) => ({ ...row, postcode: null }));
+        }
+        return scoped;
+      }).pipe(
+        Effect.catch((error: HttpError) =>
+          Effect.succeed(toErrorResponse(error.status, error.message)),
+        ),
+      );
 
       const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
       if (result instanceof Response) return result;

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -2,32 +2,22 @@ import { Elysia } from "elysia";
 import { Effect, Schema } from "effect";
 import { HttpError } from "@tom/types/errors";
 import { errorResponseSchema } from "@tom/schemas/error";
+import {
+  AddressListSchema,
+  AddressSchema,
+  AddressSearchQuerySchema,
+  AddressListQuerySchema,
+  MetaSchema,
+  ParamsSchema,
+  ReverseQuerySchema,
+} from "@tom/schemas/address";
 import { logContextFromRequest, runEffect, toErrorResponse } from "@tom/utils/services/worker";
 import { toOpenApiSchema } from "../openapi";
 import { addressServicesFromRequest } from "../services/address";
 
-const addressSchema = Schema.Struct({
-  addressId: Schema.Number,
-  fullAddress: Schema.String,
-  fullAddressNumber: Schema.String,
-  fullAddressRoad: Schema.NullishOr(Schema.String),
-  suburb: Schema.String,
-  townCity: Schema.String,
-  territorialAuthority: Schema.String,
-  region: Schema.NullishOr(Schema.String),
-  postcode: Schema.NullishOr(Schema.String),
-  longitude: Schema.Number,
-  latitude: Schema.Number,
-});
-
-const addressListSchema = Schema.Array(addressSchema);
-
-const metaSchema = Schema.Struct({
-  version: Schema.String,
-  totalAddresses: Schema.Number,
-  lastUpdated: Schema.String,
-});
-
+const addressSchema = AddressSchema;
+const addressListSchema = AddressListSchema;
+const metaSchema = MetaSchema;
 const errorSchema = errorResponseSchema;
 
 const parseLimit = (raw: string | undefined, fallback: number, max: number): number => {
@@ -44,70 +34,16 @@ const parseBbox = (value: string): readonly [number, number, number, number] => 
   return [minLng, minLat, maxLng, maxLat];
 };
 
-const BboxParamSchema = Schema.String.pipe(
-  Schema.annotate({
-    description: "Bounding box filter as minLng,minLat,maxLng,maxLat",
-    examples: ["174.77,-41.29,174.79,-41.28"],
-  }),
-);
-
-const SearchQuerySchema = Schema.Struct({
-  q: Schema.String.pipe(
-    Schema.annotate({
-      description: "Search query string (min 3 chars)",
-      examples: ["lambton quay"],
-    }),
-  ),
-  bbox: Schema.optional(BboxParamSchema),
-  limit: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Maximum results (default: 100, max: 1000)" }),
-  ),
-});
-
-const searchQuerySchema = toOpenApiSchema(SearchQuerySchema);
-
-const ReverseQuerySchema = Schema.Struct({
-  lat: Schema.String.pipe(
-    Schema.annotate({ description: "Latitude in decimal degrees", examples: ["-41.2865"] }),
-  ),
-  lng: Schema.String.pipe(
-    Schema.annotate({ description: "Longitude in decimal degrees", examples: ["174.7762"] }),
-  ),
-  limit: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Maximum results (default: 10, max: 100)" }),
-  ),
-});
-
+const searchQuerySchema = toOpenApiSchema(AddressSearchQuerySchema);
 const reverseQuerySchema = toOpenApiSchema(ReverseQuerySchema);
-
-const ListQuerySchema = Schema.Struct({
-  limit: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Maximum results (default: 100, max: 1000)" }),
-  ),
-  offset: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Number of results to skip" }),
-  ),
-  town_city: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Filter by town/city name", examples: ["Wellington"] }),
-  ),
-  suburb_locality: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Filter by suburb/locality", examples: ["Te Aro"] }),
-  ),
-  road_name: Schema.optional(Schema.String).pipe(
-    Schema.annotate({ description: "Filter by road/street name", examples: ["Lambton Quay"] }),
-  ),
-  bbox: Schema.optional(BboxParamSchema),
-});
-
-const listQuerySchema = toOpenApiSchema(ListQuerySchema);
-
-const ParamsSchema = Schema.Struct({ id: Schema.String });
+const listQuerySchema = toOpenApiSchema(AddressListQuerySchema);
+const paramsSchema = toOpenApiSchema(ParamsSchema);
 
 export const addressRoutes = new Elysia({ name: "address" })
   .get(
     "/v1/search",
     async ({ query, request, set }) => {
-      const decoded = Schema.decodeUnknownSync(SearchQuerySchema)(query);
+      const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)(query);
       const trimmed = decoded.q.trim();
       if (trimmed.length < 3) {
         set.status = 400;
@@ -182,6 +118,7 @@ export const addressRoutes = new Elysia({ name: "address" })
       return result;
     },
     {
+      params: paramsSchema,
       response: {
         200: toOpenApiSchema(addressSchema),
         400: toOpenApiSchema(errorSchema),
@@ -198,7 +135,7 @@ export const addressRoutes = new Elysia({ name: "address" })
   .get(
     "/v1/addresses",
     async ({ query, request }) => {
-      const decoded = Schema.decodeUnknownSync(ListQuerySchema)(query);
+      const decoded = Schema.decodeUnknownSync(AddressListQuerySchema)(query);
       const limit = parseLimit(decoded.limit, 100, 1000);
       const offset = parseLimit(decoded.offset, 0, 1_000_000);
       const bboxValue = decoded.bbox;

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -63,8 +63,6 @@ export const addressRoutes = new Elysia({ name: "address" })
         }
       }
 
-      set.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60";
-
       const services = await addressServicesFromRequest(request);
       const effect = services
         .searchAddresses(trimmed, limit, bbox)
@@ -76,6 +74,7 @@ export const addressRoutes = new Elysia({ name: "address" })
 
       const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
       if (result instanceof Response) return result;
+      set.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60";
       return result;
     },
     {

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -1,0 +1,311 @@
+import { Elysia } from "elysia";
+import { Effect, Schema } from "effect";
+import { HttpError } from "@tom/types/errors";
+import { errorResponseSchema } from "@tom/schemas/error";
+import { logContextFromRequest, runEffect, toErrorResponse } from "@tom/utils/services/worker";
+import { toOpenApiSchema } from "../openapi";
+import { addressServicesFromRequest } from "../services/address";
+
+const addressSchema = Schema.Struct({
+  addressId: Schema.Number,
+  fullAddress: Schema.String,
+  fullAddressNumber: Schema.String,
+  fullAddressRoad: Schema.NullishOr(Schema.String),
+  suburb: Schema.String,
+  townCity: Schema.String,
+  territorialAuthority: Schema.String,
+  region: Schema.NullishOr(Schema.String),
+  postcode: Schema.NullishOr(Schema.String),
+  longitude: Schema.Number,
+  latitude: Schema.Number,
+});
+
+const addressListSchema = Schema.Array(addressSchema);
+
+const metaSchema = Schema.Struct({
+  version: Schema.String,
+  totalAddresses: Schema.Number,
+  lastUpdated: Schema.String,
+});
+
+const errorSchema = errorResponseSchema;
+
+const parseLimit = (raw: string | undefined, fallback: number, max: number): number => {
+  const value = parseInt(raw ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? Math.min(value, max) : fallback;
+};
+
+const parseBbox = (value: string): readonly [number, number, number, number] => {
+  const parts = value.split(",").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
+    throw new Error("bbox must have 4 comma-separated values");
+  }
+  const [minLng, minLat, maxLng, maxLat] = parts as [number, number, number, number];
+  return [minLng, minLat, maxLng, maxLat];
+};
+
+const BboxParamSchema = Schema.String.pipe(
+  Schema.annotate({
+    description: "Bounding box filter as minLng,minLat,maxLng,maxLat",
+    examples: ["174.77,-41.29,174.79,-41.28"],
+  }),
+);
+
+const SearchQuerySchema = Schema.Struct({
+  q: Schema.String.pipe(
+    Schema.annotate({
+      description: "Search query string (min 3 chars)",
+      examples: ["lambton quay"],
+    }),
+  ),
+  bbox: Schema.optional(BboxParamSchema),
+  limit: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Maximum results (default: 100, max: 1000)" }),
+  ),
+});
+
+const searchQuerySchema = toOpenApiSchema(SearchQuerySchema);
+
+const ReverseQuerySchema = Schema.Struct({
+  lat: Schema.String.pipe(
+    Schema.annotate({ description: "Latitude in decimal degrees", examples: ["-41.2865"] }),
+  ),
+  lng: Schema.String.pipe(
+    Schema.annotate({ description: "Longitude in decimal degrees", examples: ["174.7762"] }),
+  ),
+  limit: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Maximum results (default: 10, max: 100)" }),
+  ),
+});
+
+const reverseQuerySchema = toOpenApiSchema(ReverseQuerySchema);
+
+const ListQuerySchema = Schema.Struct({
+  limit: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Maximum results (default: 100, max: 1000)" }),
+  ),
+  offset: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Number of results to skip" }),
+  ),
+  town_city: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Filter by town/city name", examples: ["Wellington"] }),
+  ),
+  suburb_locality: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Filter by suburb/locality", examples: ["Te Aro"] }),
+  ),
+  road_name: Schema.optional(Schema.String).pipe(
+    Schema.annotate({ description: "Filter by road/street name", examples: ["Lambton Quay"] }),
+  ),
+  bbox: Schema.optional(BboxParamSchema),
+});
+
+const listQuerySchema = toOpenApiSchema(ListQuerySchema);
+
+const ParamsSchema = Schema.Struct({ id: Schema.String });
+
+export const addressRoutes = new Elysia({ name: "address" })
+  .get(
+    "/v1/search",
+    async ({ query, request, set }) => {
+      const decoded = Schema.decodeUnknownSync(SearchQuerySchema)(query);
+      const trimmed = decoded.q.trim();
+      if (trimmed.length < 3) {
+        set.status = 400;
+        return toErrorResponse(400, "Query must be at least 3 characters");
+      }
+
+      const limit = parseLimit(decoded.limit, 100, 1000);
+
+      let bbox: readonly [number, number, number, number] | undefined;
+      const bboxValue = decoded.bbox;
+      if (bboxValue) {
+        try {
+          bbox = parseBbox(bboxValue);
+        } catch {
+          set.status = 400;
+          return toErrorResponse(400, "Invalid bbox format. Expected: minLng,minLat,maxLng,maxLat");
+        }
+      }
+
+      set.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60";
+
+      const services = await addressServicesFromRequest(request);
+      const effect = services
+        .searchAddresses(trimmed, limit, bbox)
+        .pipe(
+          Effect.catch((error: HttpError) =>
+            Effect.succeed(toErrorResponse(error.status, error.message)),
+          ),
+        );
+
+      const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
+      if (result instanceof Response) return result;
+      return result;
+    },
+    {
+      query: searchQuerySchema,
+      response: {
+        200: toOpenApiSchema(addressListSchema),
+        400: toOpenApiSchema(errorSchema),
+        500: toOpenApiSchema(errorSchema),
+      },
+      detail: {
+        summary: "Full-text search addresses (tsvector)",
+        description:
+          "Search NZ addresses via Postgres tsvector/GIN with tsquery, alias expansion, and typo correction. Reads hit the Neon read replica. Query must be ≥3 chars; debounce 250ms on client.",
+        tags: ["address"],
+      },
+    },
+  )
+  .get(
+    "/v1/addresses/:id",
+    async ({ params, request, set }) => {
+      const decoded = Schema.decodeUnknownSync(ParamsSchema)(params);
+      const id = Number(decoded.id);
+      if (!Number.isFinite(id)) {
+        set.status = 400;
+        return toErrorResponse(400, "Invalid address id");
+      }
+      const services = await addressServicesFromRequest(request);
+      const effect = services.getAddressById(id).pipe(
+        Effect.flatMap((row) => {
+          if (!row)
+            return Effect.fail(new HttpError({ message: "Address not found", status: 404 }));
+          return Effect.succeed(row);
+        }),
+        Effect.catch((error: HttpError) =>
+          Effect.succeed(toErrorResponse(error.status, error.message)),
+        ),
+      );
+      const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
+      if (result instanceof Response) return result;
+      return result;
+    },
+    {
+      response: {
+        200: toOpenApiSchema(addressSchema),
+        400: toOpenApiSchema(errorSchema),
+        404: toOpenApiSchema(errorSchema),
+        500: toOpenApiSchema(errorSchema),
+      },
+      detail: {
+        summary: "Get address by ID",
+        description: "Retrieve a single NZ address by LINZ address_id. Reads hit the Neon replica.",
+        tags: ["address"],
+      },
+    },
+  )
+  .get(
+    "/v1/addresses",
+    async ({ query, request }) => {
+      const decoded = Schema.decodeUnknownSync(ListQuerySchema)(query);
+      const limit = parseLimit(decoded.limit, 100, 1000);
+      const offset = parseLimit(decoded.offset, 0, 1_000_000);
+      const bboxValue = decoded.bbox;
+      let bbox: readonly [number, number, number, number] | undefined;
+      if (bboxValue) {
+        try {
+          bbox = parseBbox(bboxValue);
+        } catch {
+          return toErrorResponse(400, "Invalid bbox format");
+        }
+      }
+
+      let filters: import("@tom/types/address").AddressFilters = { limit, offset };
+      if (decoded.town_city !== undefined) filters = { ...filters, townCity: decoded.town_city };
+      if (decoded.suburb_locality !== undefined)
+        filters = { ...filters, suburbLocality: decoded.suburb_locality };
+      if (decoded.road_name !== undefined) filters = { ...filters, roadName: decoded.road_name };
+      if (bbox !== undefined) filters = { ...filters, bbox };
+
+      const services = await addressServicesFromRequest(request);
+      const effect = services
+        .listAddresses(filters)
+        .pipe(
+          Effect.catch((error: HttpError) =>
+            Effect.succeed(toErrorResponse(error.status, error.message)),
+          ),
+        );
+      const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
+      if (result instanceof Response) return result;
+      return result;
+    },
+    {
+      query: listQuerySchema,
+      response: {
+        200: toOpenApiSchema(addressListSchema),
+        400: toOpenApiSchema(errorSchema),
+        500: toOpenApiSchema(errorSchema),
+      },
+      detail: {
+        summary: "List addresses with filters",
+        description:
+          "Paginated list with optional town/city, suburb, road, bbox filters. Reads hit replica.",
+        tags: ["address"],
+      },
+    },
+  )
+  .get(
+    "/v1/reverse",
+    async ({ query, request, set }) => {
+      const decoded = Schema.decodeUnknownSync(ReverseQuerySchema)(query);
+      const lat = Number(decoded.lat);
+      const lng = Number(decoded.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+        set.status = 400;
+        return toErrorResponse(400, "lat and lng are required numbers");
+      }
+      const limit = parseLimit(decoded.limit, 10, 100);
+      const services = await addressServicesFromRequest(request);
+      const effect = services
+        .reverseGeocode(lng, lat, limit)
+        .pipe(
+          Effect.catch((error: HttpError) =>
+            Effect.succeed(toErrorResponse(error.status, error.message)),
+          ),
+        );
+      const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
+      if (result instanceof Response) return result;
+      return result;
+    },
+    {
+      query: reverseQuerySchema,
+      response: {
+        200: toOpenApiSchema(addressListSchema),
+        400: toOpenApiSchema(errorSchema),
+        500: toOpenApiSchema(errorSchema),
+      },
+      detail: {
+        summary: "Reverse geocode",
+        description: "Nearest addresses by lng/lat distance. Reads hit replica.",
+        tags: ["address"],
+      },
+    },
+  )
+  .get(
+    "/v1/meta",
+    async ({ request }) => {
+      const services = await addressServicesFromRequest(request);
+      const effect = services
+        .getMeta()
+        .pipe(
+          Effect.catch((error: HttpError) =>
+            Effect.succeed(toErrorResponse(error.status, error.message)),
+          ),
+        );
+      const result = await runEffect(effect, logContextFromRequest(request, "tom-api"));
+      if (result instanceof Response) return result;
+      return result;
+    },
+    {
+      response: {
+        200: toOpenApiSchema(metaSchema),
+        500: toOpenApiSchema(errorSchema),
+      },
+      detail: {
+        summary: "Dataset metadata",
+        description: "Version, total count, last updated. Reads hit replica.",
+        tags: ["address"],
+      },
+    },
+  );

--- a/apps/api/src/routes/addresses.ts
+++ b/apps/api/src/routes/addresses.ts
@@ -98,7 +98,8 @@ export const addressRoutes = new Elysia({ name: "address" })
               apikeyId: verified.id,
               userId: verified.referenceId,
             }),
-          catch: (cause) => new Error(String(cause)),
+          catch: (cause) =>
+            new HttpError({ message: "Failed to record usage", status: 500, cause }),
         }).pipe(Effect.ignore);
 
         const scoped =

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,120 @@
+import { Elysia } from "elysia";
+import { Effect, Schema } from "effect";
+import { HttpError } from "@tom/types/errors";
+import { authFromRequest } from "../lib/auth";
+import { countUsageSince, createApiKeyRecord, listApiKeyRecords } from "../services/auth";
+import { logContextFromRequest, runEffect, toErrorResponse } from "@tom/utils/services/worker";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+const ScopeSchema = Schema.Union([
+  Schema.Literal("all"),
+  Schema.Literal("one"),
+  Schema.Literal("multiple"),
+]);
+
+const CreateKeyBodySchema = Schema.Struct({
+  name: Schema.String,
+  scope: ScopeSchema,
+  regions: Schema.Array(Schema.String),
+  postcodes: Schema.Boolean,
+});
+
+const UsageQuerySchema = Schema.Struct({
+  keyId: Schema.optional(Schema.String),
+});
+
+const getSessionUserId = async (request: Request): Promise<string | null> => {
+  const auth = await authFromRequest(request);
+  if (!auth) return null;
+  const session = await auth.api.getSession({ headers: request.headers });
+  return session?.user.id ?? null;
+};
+
+export const authRoutes = new Elysia({ name: "auth" })
+  .all("/api/auth/*", async ({ request }) => {
+    const auth = await authFromRequest(request);
+    if (!auth) {
+      return new Response(JSON.stringify({ error: "Auth DB not configured" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return auth.handler(request);
+  })
+  .post("/v1/keys", async ({ body, request, set }) => {
+    const decoded = Schema.decodeUnknownSync(CreateKeyBodySchema)(body ?? {});
+    const userId = await getSessionUserId(request);
+    if (!userId) {
+      set.status = 401;
+      return toErrorResponse(401, "Unauthorized");
+    }
+
+    const effect = Effect.tryPromise({
+      try: () => createApiKeyRecord(request, userId, decoded),
+      catch: (cause) =>
+        new HttpError({
+          message: `Failed to create API key: ${String(cause)}`,
+          status: 500,
+          cause,
+        }),
+    });
+
+    const result = await runEffect(
+      effect.pipe(Effect.catch((error) => Effect.succeed(toErrorResponse(500, error.message)))),
+      logContextFromRequest(request, "tom-api"),
+    );
+    if (result instanceof Response) return result;
+    return result;
+  })
+  .get("/v1/keys", async ({ request, set }) => {
+    const userId = await getSessionUserId(request);
+    if (!userId) {
+      set.status = 401;
+      return toErrorResponse(401, "Unauthorized");
+    }
+
+    const effect = Effect.tryPromise({
+      try: () => listApiKeyRecords(request, userId),
+      catch: (cause) =>
+        new HttpError({ message: `Failed to list API keys: ${String(cause)}`, status: 500, cause }),
+    });
+
+    const result = await runEffect(
+      effect.pipe(Effect.catch((error) => Effect.succeed(toErrorResponse(500, error.message)))),
+      logContextFromRequest(request, "tom-api"),
+    );
+    if (result instanceof Response) return result;
+    return result;
+  })
+  .get("/v1/usage", async ({ query, request }) => {
+    const decoded = Schema.decodeUnknownSync(UsageQuerySchema)(query);
+    const apikeyId = decoded.keyId && decoded.keyId !== "all" ? decoded.keyId : null;
+    const now = Date.now();
+
+    const effect = Effect.tryPromise({
+      try: async () => {
+        const [hour, day, week, month, year] = await Promise.all([
+          countUsageSince(request, now - HOUR_MS, apikeyId),
+          countUsageSince(request, now - DAY_MS, apikeyId),
+          countUsageSince(request, now - WEEK_MS, apikeyId),
+          countUsageSince(request, now - MONTH_MS, apikeyId),
+          countUsageSince(request, now - YEAR_MS, apikeyId),
+        ]);
+        return { hour, day, week, month, year };
+      },
+      catch: (cause) =>
+        new HttpError({ message: `Failed to load usage: ${String(cause)}`, status: 500, cause }),
+    });
+
+    const result = await runEffect(
+      effect.pipe(Effect.catch((error) => Effect.succeed(toErrorResponse(500, error.message)))),
+      logContextFromRequest(request, "tom-api"),
+    );
+    if (result instanceof Response) return result;
+    return result;
+  });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -4,6 +4,8 @@ import { HttpError } from "@tom/types/errors";
 import { authFromRequest } from "../lib/auth";
 import { countUsageSince, createApiKeyRecord, listApiKeyRecords } from "../services/auth";
 import { logContextFromRequest, runEffect, toErrorResponse } from "@tom/utils/services/worker";
+import { getRequestEnv } from "@tom/utils/services/worker";
+import { readCloudflareEnv } from "@tom/utils/services/config";
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -51,6 +53,35 @@ export const authRoutes = new Elysia({ name: "auth" })
         headers: { "content-type": "application/json" },
       });
     });
+  })
+  .get("/v1/debug/sessions", async ({ request, set }) => {
+    const env = await readCloudflareEnv(getRequestEnv(request));
+    if (!(env.BETTER_AUTH_URL ?? "").includes("dev")) {
+      set.status = 404;
+      return toErrorResponse(404, "Not found");
+    }
+    const db = env.AUTH_DB;
+    if (!db) {
+      set.status = 500;
+      return toErrorResponse(500, "Auth DB not configured");
+    }
+    const effect = Effect.tryPromise({
+      try: async () => {
+        const count = await db.prepare("SELECT count(*) AS n FROM session").all<{ n: number }>();
+        const recent = await db
+          .prepare("SELECT id, userId, expiresAt FROM session ORDER BY createdAt DESC LIMIT 5")
+          .all<{ id: string; userId: string; expiresAt: number }>();
+        return { count: count.results[0]?.n ?? 0, recent: recent.results };
+      },
+      catch: (cause) =>
+        new HttpError({ message: `Debug query failed: ${String(cause)}`, status: 500, cause }),
+    });
+    const result = await runEffect(
+      effect.pipe(Effect.catch((error) => Effect.succeed(toErrorResponse(500, error.message)))),
+      logContextFromRequest(request, "tom-api"),
+    );
+    if (result instanceof Response) return result;
+    return result;
   })
   .post("/v1/keys", async ({ body, request, set }) => {
     const decoded = Schema.decodeUnknownSync(CreateKeyBodySchema)(body ?? {});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -71,7 +71,20 @@ export const authRoutes = new Elysia({ name: "auth" })
         const recent = await db
           .prepare("SELECT id, userId, expiresAt FROM session ORDER BY createdAt DESC LIMIT 5")
           .all<{ id: string; userId: string; expiresAt: number }>();
-        return { count: count.results[0]?.n ?? 0, recent: recent.results };
+        const accounts = await db
+          .prepare(
+            "SELECT providerId, userId, createdAt FROM account ORDER BY createdAt DESC LIMIT 6",
+          )
+          .all<{ providerId: string; userId: string; createdAt: number }>();
+        const users = await db
+          .prepare("SELECT id, name, email, createdAt FROM user ORDER BY createdAt DESC LIMIT 6")
+          .all<{ id: string; name: string; email: string; createdAt: number }>();
+        return {
+          count: count.results[0]?.n ?? 0,
+          recent: recent.results,
+          accounts: accounts.results,
+          users: users.results,
+        };
       },
       catch: (cause) =>
         new HttpError({ message: `Debug query failed: ${String(cause)}`, status: 500, cause }),

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -44,7 +44,13 @@ export const authRoutes = new Elysia({ name: "auth" })
         headers: { "content-type": "application/json" },
       });
     }
-    return auth.handler(request);
+    return auth.handler(request).catch((error: Error) => {
+      const message = error.message;
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    });
   })
   .post("/v1/keys", async ({ body, request, set }) => {
     const decoded = Schema.decodeUnknownSync(CreateKeyBodySchema)(body ?? {});

--- a/apps/api/src/scripts/seed-addresses.ts
+++ b/apps/api/src/scripts/seed-addresses.ts
@@ -1,0 +1,68 @@
+import { Effect } from "effect";
+import { makeAddressDb } from "../services/address/db";
+import { ingestAll } from "../services/address/ingest";
+
+const getProcessEnv = (): Record<string, string | undefined> => {
+  const maybeProcess = (globalThis as { process?: { env: Record<string, string | undefined> } })
+    .process;
+  return maybeProcess?.env ?? {};
+};
+
+const getEnv = (key: string): string | undefined => {
+  const env = getProcessEnv();
+  const direct = env[key];
+  if (direct) return direct;
+
+  const bundle = env.TOM_SECRETS;
+  if (!bundle) return undefined;
+
+  try {
+    const parsed = JSON.parse(bundle) as Record<string, string>;
+    return parsed[key];
+  } catch {
+    return undefined;
+  }
+};
+
+const main = Effect.gen(function* () {
+  const addressDb = getEnv("ADDRESS_DB");
+  const linzApiKey = getEnv("LINZ_API_KEY");
+
+  if (!addressDb) {
+    return yield* Effect.fail(
+      new Error("ADDRESS_DB not configured. Set ADDRESS_DB or TOM_SECRETS with ADDRESS_DB"),
+    );
+  }
+  if (!linzApiKey) {
+    return yield* Effect.fail(
+      new Error("LINZ_API_KEY not configured. Set LINZ_API_KEY or TOM_SECRETS with LINZ_API_KEY"),
+    );
+  }
+
+  yield* Effect.logInfo("seed-addresses: starting", {
+    addressDb: `${addressDb.slice(0, 30)}...`,
+    linzKey: `${linzApiKey.slice(0, 6)}...`,
+  });
+
+  const db = makeAddressDb({
+    primaryConnectionString: addressDb,
+    replicaConnectionString: getEnv("ADDRESS_DB_REPLICA") ?? addressDb,
+  });
+
+  const result = yield* ingestAll(linzApiKey, db);
+
+  yield* Effect.logInfo("seed-addresses: finished", result);
+  console.log("Ingest result:", result);
+});
+
+Effect.runPromise(
+  main.pipe(
+    Effect.catch((error) =>
+      Effect.logError("seed failed", error).pipe(Effect.flatMap(() => Effect.fail(error))),
+    ),
+  ),
+).catch((error) => {
+  console.error("Seed failed:", error);
+  const maybeExit = (globalThis as { process?: { exit: (code: number) => never } }).process?.exit;
+  if (maybeExit) maybeExit(1);
+});

--- a/apps/api/src/scripts/seed-postcodes.ts
+++ b/apps/api/src/scripts/seed-postcodes.ts
@@ -1,0 +1,104 @@
+import { Effect } from "effect";
+// @ts-ignore -- node types not in Worker tsconfig, script runs via tsx with node
+import { existsSync, readFileSync } from "node:fs";
+import { makeAddressDb } from "../services/address/db";
+
+const PREBUILT_PATH = "apps/api/scripts/postcodes.sql";
+
+const getProcessEnv = (): Record<string, string | undefined> => {
+  const maybeProcess = (globalThis as { process?: { env: Record<string, string | undefined> } })
+    .process;
+  return maybeProcess?.env ?? {};
+};
+
+const getEnv = (key: string): string | undefined => {
+  const env = getProcessEnv();
+  const direct = env[key];
+  if (direct) return direct;
+  const bundle = env.TOM_SECRETS;
+  if (!bundle) return undefined;
+  try {
+    const parsed = JSON.parse(bundle) as Record<string, string>;
+    return parsed[key];
+  } catch {
+    return undefined;
+  }
+};
+
+const fetchPrebuiltSql = (url: string): Effect.Effect<string, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
+      return response.text();
+    },
+    catch: (cause) => new Error(`fetch prebuilt failed: ${String(cause)}`),
+  });
+
+const executeSql = (
+  sql: { unsafe: (query: string) => Promise<unknown> },
+  text: string,
+): Effect.Effect<void, Error> =>
+  Effect.gen(function* () {
+    const statements = text
+      .split(";")
+      .map((statement) => statement.trim())
+      .filter((statement) => statement.length > 0);
+
+    for (const statement of statements) {
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe(`${statement};`),
+        catch: (cause) => new Error(`execute failed: ${String(cause)}`),
+      });
+    }
+  });
+
+const main = Effect.gen(function* () {
+  const addressDb = getEnv("ADDRESS_DB");
+  if (!addressDb) {
+    return yield* Effect.fail(new Error("ADDRESS_DB not configured"));
+  }
+
+  const db = makeAddressDb({
+    primaryConnectionString: addressDb,
+    replicaConnectionString: getEnv("ADDRESS_DB_REPLICA") ?? addressDb,
+  });
+
+  const sql = yield* db.primary;
+
+  const customUrl = getEnv("POSTCODES_SQL_URL");
+  if (customUrl) {
+    yield* Effect.logInfo("seed-postcodes: fetching prebuilt from URL", { customUrl });
+    const text = yield* fetchPrebuiltSql(customUrl);
+    yield* executeSql(sql, text);
+    yield* Effect.logInfo("seed-postcodes: done via URL");
+    return;
+  }
+
+  if (existsSync(PREBUILT_PATH)) {
+    yield* Effect.logInfo("seed-postcodes: using local prebuilt", { PREBUILT_PATH });
+    const text = readFileSync(PREBUILT_PATH, "utf8");
+    yield* executeSql(sql, text);
+    yield* Effect.logInfo("seed-postcodes: done via local file");
+    return;
+  }
+
+  yield* Effect.logWarning("seed-postcodes: no prebuilt found, skipping", {
+    PREBUILT_PATH,
+    hint: "Provide scripts/postcodes.sql or set POSTCODES_SQL_URL",
+  });
+});
+
+Effect.runPromise(
+  main.pipe(
+    Effect.catch((error) =>
+      Effect.logError("seed-postcodes failed", error).pipe(
+        Effect.flatMap(() => Effect.fail(error)),
+      ),
+    ),
+  ),
+).catch((error) => {
+  console.error("Seed postcodes failed:", error);
+  const maybeExit = (globalThis as { process?: { exit: (code: number) => never } }).process?.exit;
+  if (maybeExit) maybeExit(1);
+});

--- a/apps/api/src/services/address/addresses.ts
+++ b/apps/api/src/services/address/addresses.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import { HttpError } from "@tom/types/errors";
 import type { AddressDbService } from "./db";
 import { SQL } from "./queries";
-import { mapAddressRow, type AddressRow } from "./schema";
+import { mapAddressRow, type RawAddressRow } from "./schema";
 import type { Address, AddressFilters, Meta } from "@tom/types/address";
 
 const dbError = (operation: string, cause: unknown): HttpError =>
@@ -18,7 +18,7 @@ export const getAddressById = (
   Effect.gen(function* () {
     const sql = yield* db.replica;
     const rows = yield* Effect.tryPromise({
-      try: () => sql.unsafe<AddressRow>(SQL.selectAddressById, [id]),
+      try: () => sql.unsafe<RawAddressRow>(SQL.selectAddressById, [id]),
       catch: (cause) => dbError("getAddressById", cause),
     });
     const first = rows[0];
@@ -34,18 +34,18 @@ export const listAddresses = (
     const limit = Math.min(Math.max(filters.limit ?? 100, 1), 1000);
     const offset = Math.max(filters.offset ?? 0, 0);
 
-    let rows: readonly AddressRow[] = [];
+    let rows: readonly RawAddressRow[] = [];
 
     if (filters.townCity) {
       rows = yield* Effect.tryPromise({
         try: () =>
-          sql.unsafe<AddressRow>(SQL.selectAddressesByTown, [filters.townCity, limit, offset]),
+          sql.unsafe<RawAddressRow>(SQL.selectAddressesByTown, [filters.townCity, limit, offset]),
         catch: (cause) => dbError("listAddresses", cause),
       });
     } else if (filters.suburbLocality) {
       rows = yield* Effect.tryPromise({
         try: () =>
-          sql.unsafe<AddressRow>(SQL.selectAddressesBySuburb, [
+          sql.unsafe<RawAddressRow>(SQL.selectAddressesBySuburb, [
             filters.suburbLocality,
             limit,
             offset,
@@ -55,7 +55,7 @@ export const listAddresses = (
     } else if (filters.roadName) {
       rows = yield* Effect.tryPromise({
         try: () =>
-          sql.unsafe<AddressRow>(SQL.selectAddressesByRoad, [filters.roadName, limit, offset]),
+          sql.unsafe<RawAddressRow>(SQL.selectAddressesByRoad, [filters.roadName, limit, offset]),
         catch: (cause) => dbError("listAddresses", cause),
       });
     } else if (filters.bbox) {
@@ -63,7 +63,7 @@ export const listAddresses = (
       const [minLng, minLat, maxLng, maxLat] = bbox;
       rows = yield* Effect.tryPromise({
         try: () =>
-          sql.unsafe<AddressRow>(SQL.selectAddressesByBbox, [
+          sql.unsafe<RawAddressRow>(SQL.selectAddressesByBbox, [
             minLng,
             maxLng,
             minLat,
@@ -75,7 +75,7 @@ export const listAddresses = (
       });
     } else {
       rows = yield* Effect.tryPromise({
-        try: () => sql.unsafe<AddressRow>(SQL.selectAddressesOrdered, [limit, offset]),
+        try: () => sql.unsafe<RawAddressRow>(SQL.selectAddressesOrdered, [limit, offset]),
         catch: (cause) => dbError("listAddresses", cause),
       });
     }
@@ -88,7 +88,11 @@ export const listAddresses = (
       const bbox = filters.bbox;
       const [minLng, minLat, maxLng, maxLat] = bbox;
       const filtered = rows.filter(
-        (row) => row.lng >= minLng && row.lng <= maxLng && row.lat >= minLat && row.lat <= maxLat,
+        (row) =>
+          Number(row.lng) >= minLng &&
+          Number(row.lng) <= maxLng &&
+          Number(row.lat) >= minLat &&
+          Number(row.lat) <= maxLat,
       );
       return filtered.map(mapAddressRow);
     }
@@ -106,7 +110,7 @@ export const reverseGeocode = (
     const sql = yield* db.replica;
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const rows = yield* Effect.tryPromise({
-      try: () => sql.unsafe<AddressRow>(SQL.selectReverseGeocode, [lng, lat, safeLimit]),
+      try: () => sql.unsafe<RawAddressRow>(SQL.selectReverseGeocode, [lng, lat, safeLimit]),
       catch: (cause) => dbError("reverseGeocode", cause),
     });
     return rows.map(mapAddressRow);

--- a/apps/api/src/services/address/addresses.ts
+++ b/apps/api/src/services/address/addresses.ts
@@ -116,8 +116,14 @@ export const reverseGeocode = (
     return rows.map(mapAddressRow);
   });
 
+let metaCache: { value: Meta; expiresAt: number } | null = null;
+const META_CACHE_TTL_MS = 60_000;
+
 export const getMeta = (db: AddressDbService): Effect.Effect<Meta, HttpError> =>
   Effect.gen(function* () {
+    const now = Date.now();
+    if (metaCache && metaCache.expiresAt > now) return metaCache.value;
+
     const sql = yield* db.replica;
     const version = yield* db.getDatasetVersion;
     const countRows = yield* Effect.tryPromise({
@@ -133,9 +139,11 @@ export const getMeta = (db: AddressDbService): Effect.Effect<Meta, HttpError> =>
     const lastUpdated =
       metaRows[0]?.ingested_at ?? metaRows[0]?.updated_at ?? new Date().toISOString();
 
-    return {
+    const value: Meta = {
       version: version ?? "unknown",
       totalAddresses: total,
       lastUpdated,
     };
+    metaCache = { value, expiresAt: now + META_CACHE_TTL_MS };
+    return value;
   });

--- a/apps/api/src/services/address/addresses.ts
+++ b/apps/api/src/services/address/addresses.ts
@@ -8,7 +8,7 @@ import type { Address, AddressFilters, Meta } from "@tom/types/address";
 const dbError = (operation: string, cause: unknown): HttpError =>
   new HttpError({ message: `Database error during ${operation}`, status: 500, cause });
 
-type CountRow = { count: number };
+type CountRow = { count: number | string | bigint };
 type MetaRow = { updated_at: string | null; ingested_at: string | null };
 
 export const getAddressById = (
@@ -120,7 +120,7 @@ export const getMeta = (db: AddressDbService): Effect.Effect<Meta, HttpError> =>
       try: () => sql.unsafe<CountRow>(SQL.countAddresses),
       catch: (cause) => dbError("getMeta", cause),
     });
-    const total = countRows[0]?.count ?? 0;
+    const total = Number(countRows[0]?.count ?? 0);
     const metaRows = yield* Effect.tryPromise({
       try: () => sql.unsafe<MetaRow>(SQL.selectMeta),
       catch: (): Promise<readonly MetaRow[]> => Promise.resolve([]),

--- a/apps/api/src/services/address/addresses.ts
+++ b/apps/api/src/services/address/addresses.ts
@@ -1,0 +1,137 @@
+import { Effect } from "effect";
+import { HttpError } from "@tom/types/errors";
+import type { AddressDbService } from "./db";
+import { SQL } from "./queries";
+import { mapAddressRow, type AddressRow } from "./schema";
+import type { Address, AddressFilters, Meta } from "@tom/types/address";
+
+const dbError = (operation: string, cause: unknown): HttpError =>
+  new HttpError({ message: `Database error during ${operation}`, status: 500, cause });
+
+type CountRow = { count: number };
+type MetaRow = { updated_at: string | null; ingested_at: string | null };
+
+export const getAddressById = (
+  db: AddressDbService,
+  id: number,
+): Effect.Effect<Address | null, HttpError> =>
+  Effect.gen(function* () {
+    const sql = yield* db.replica;
+    const rows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<AddressRow>(SQL.selectAddressById, [id]),
+      catch: (cause) => dbError("getAddressById", cause),
+    });
+    const first = rows[0];
+    return first ? mapAddressRow(first) : null;
+  });
+
+export const listAddresses = (
+  db: AddressDbService,
+  filters: AddressFilters,
+): Effect.Effect<readonly Address[], HttpError> =>
+  Effect.gen(function* () {
+    const sql = yield* db.replica;
+    const limit = Math.min(Math.max(filters.limit ?? 100, 1), 1000);
+    const offset = Math.max(filters.offset ?? 0, 0);
+
+    let rows: readonly AddressRow[] = [];
+
+    if (filters.townCity) {
+      rows = yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<AddressRow>(SQL.selectAddressesByTown, [filters.townCity, limit, offset]),
+        catch: (cause) => dbError("listAddresses", cause),
+      });
+    } else if (filters.suburbLocality) {
+      rows = yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<AddressRow>(SQL.selectAddressesBySuburb, [
+            filters.suburbLocality,
+            limit,
+            offset,
+          ]),
+        catch: (cause) => dbError("listAddresses", cause),
+      });
+    } else if (filters.roadName) {
+      rows = yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<AddressRow>(SQL.selectAddressesByRoad, [filters.roadName, limit, offset]),
+        catch: (cause) => dbError("listAddresses", cause),
+      });
+    } else if (filters.bbox) {
+      const bbox = filters.bbox;
+      const [minLng, minLat, maxLng, maxLat] = bbox;
+      rows = yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<AddressRow>(SQL.selectAddressesByBbox, [
+            minLng,
+            maxLng,
+            minLat,
+            maxLat,
+            limit,
+            offset,
+          ]),
+        catch: (cause) => dbError("listAddresses", cause),
+      });
+    } else {
+      rows = yield* Effect.tryPromise({
+        try: () => sql.unsafe<AddressRow>(SQL.selectAddressesOrdered, [limit, offset]),
+        catch: (cause) => dbError("listAddresses", cause),
+      });
+    }
+
+    if (filters.bbox && !filters.townCity && !filters.suburbLocality && !filters.roadName) {
+      return rows.map(mapAddressRow);
+    }
+
+    if (filters.bbox) {
+      const bbox = filters.bbox;
+      const [minLng, minLat, maxLng, maxLat] = bbox;
+      const filtered = rows.filter(
+        (row) => row.lng >= minLng && row.lng <= maxLng && row.lat >= minLat && row.lat <= maxLat,
+      );
+      return filtered.map(mapAddressRow);
+    }
+
+    return rows.map(mapAddressRow);
+  });
+
+export const reverseGeocode = (
+  db: AddressDbService,
+  lng: number,
+  lat: number,
+  limit: number,
+): Effect.Effect<readonly Address[], HttpError> =>
+  Effect.gen(function* () {
+    const sql = yield* db.replica;
+    const safeLimit = Math.min(Math.max(limit, 1), 100);
+    const rows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<AddressRow>(SQL.selectReverseGeocode, [lng, lat, safeLimit]),
+      catch: (cause) => dbError("reverseGeocode", cause),
+    });
+    return rows.map(mapAddressRow);
+  });
+
+export const getMeta = (db: AddressDbService): Effect.Effect<Meta, HttpError> =>
+  Effect.gen(function* () {
+    const sql = yield* db.replica;
+    const version = yield* db.getDatasetVersion;
+    const countRows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<CountRow>(SQL.countAddresses),
+      catch: (cause) => dbError("getMeta", cause),
+    });
+    const total = countRows[0]?.count ?? 0;
+    const metaRows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<MetaRow>(SQL.selectMeta),
+      catch: (): Promise<readonly MetaRow[]> => Promise.resolve([]),
+    }).pipe(Effect.orElseSucceed((): readonly MetaRow[] => []));
+
+    const lastUpdated =
+      metaRows[0]?.ingested_at ?? metaRows[0]?.updated_at ?? new Date().toISOString();
+
+    return {
+      version: version ?? "unknown",
+      totalAddresses: total,
+      lastUpdated,
+    };
+  });

--- a/apps/api/src/services/address/db.ts
+++ b/apps/api/src/services/address/db.ts
@@ -11,15 +11,11 @@ type PostgresSql = {
   end: () => Promise<void>;
 } & ((strings: TemplateStringsArray, ...values: unknown[]) => Promise<readonly unknown[]>);
 
-const postgresCache = new Map<string, PostgresSql>();
-
 const getPostgres = (connectionString: string): Effect.Effect<PostgresSql, HttpError> =>
   Effect.gen(function* () {
     if (!connectionString) {
       return yield* new HttpError({ message: "Address database URL not configured", status: 500 });
     }
-    const cached = postgresCache.get(connectionString);
-    if (cached) return cached;
 
     const postgresMod = yield* Effect.tryPromise({
       try: () => import("postgres"),
@@ -35,15 +31,12 @@ const getPostgres = (connectionString: string): Effect.Effect<PostgresSql, HttpE
     ) => PostgresSql;
 
     const sql = yield* Effect.try({
-      try: () => {
-        const created = postgresFn(connectionString, {
-          max: 10,
+      try: () =>
+        postgresFn(connectionString, {
+          max: 1,
           idle_timeout: 20,
           connect_timeout: 5,
-        });
-        postgresCache.set(connectionString, created);
-        return created;
-      },
+        }),
       catch: (cause) => dbError("create postgres connection", cause),
     });
 
@@ -70,8 +63,21 @@ export const makeAddressDb = (params: {
   const primaryConn = params.primaryConnectionString;
   const replicaConn = params.replicaConnectionString ?? params.primaryConnectionString;
 
-  const primary = getPostgres(primaryConn);
-  const replica = getPostgres(replicaConn);
+  let primaryMemo: PostgresSql | undefined;
+  let replicaMemo: PostgresSql | undefined;
+
+  const primary = Effect.gen(function* () {
+    if (primaryMemo) return primaryMemo;
+    const sql = yield* getPostgres(primaryConn);
+    primaryMemo = sql;
+    return sql;
+  });
+  const replica = Effect.gen(function* () {
+    if (replicaMemo) return replicaMemo;
+    const sql = yield* getPostgres(replicaConn);
+    replicaMemo = sql;
+    return sql;
+  });
 
   let schemaReady = false;
 
@@ -159,13 +165,5 @@ export const makeAddressDb = (params: {
   };
 };
 
-export const closeAddressDb = (connectionString: string): Effect.Effect<void, HttpError> =>
-  Effect.gen(function* () {
-    const sql = postgresCache.get(connectionString);
-    if (!sql) return;
-    postgresCache.delete(connectionString);
-    yield* Effect.tryPromise({
-      try: () => sql.end(),
-      catch: (cause) => dbError("closeAddressDb", cause),
-    });
-  });
+export const closeAddressDb = (_connectionString: string): Effect.Effect<void, HttpError> =>
+  Effect.void;

--- a/apps/api/src/services/address/db.ts
+++ b/apps/api/src/services/address/db.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import postgres from "postgres";
 import { HttpError } from "@tom/types/errors";
 import { buildRebuildTermsQuery, SQL } from "./queries";
 import { ADDRESS_SCHEMA_STATEMENTS, SEARCH_ALIASES } from "./schema";
@@ -17,26 +18,13 @@ const getPostgres = (connectionString: string): Effect.Effect<PostgresSql, HttpE
       return yield* new HttpError({ message: "Address database URL not configured", status: 500 });
     }
 
-    const postgresMod = yield* Effect.tryPromise({
-      try: () => import("postgres"),
-      catch: (cause) => dbError("load postgres driver", cause),
-    });
-
-    // postgres package exports a function as default; handle both ESM and CJS interop
-    // oxlint-disable-next-line anti-slop/no-unsafe-dictionary-type -- dynamic import boundary for postgres ESM/CJS interop, single optional key check
-    const maybeDefault = (postgresMod as { default?: unknown }).default;
-    const postgresFn = (maybeDefault ?? postgresMod) as (
-      connectionString: string,
-      options: { max: number; idle_timeout: number; connect_timeout: number },
-    ) => PostgresSql;
-
     const sql = yield* Effect.try({
       try: () =>
-        postgresFn(connectionString, {
+        postgres(connectionString, {
           max: 1,
           idle_timeout: 20,
           connect_timeout: 5,
-        }),
+        }) as PostgresSql,
       catch: (cause) => dbError("create postgres connection", cause),
     });
 

--- a/apps/api/src/services/address/db.ts
+++ b/apps/api/src/services/address/db.ts
@@ -37,6 +37,14 @@ export interface AddressDbService {
   readonly ensureSchema: Effect.Effect<void, HttpError>;
   readonly rebuildSearchTerms: Effect.Effect<void, HttpError>;
   readonly getDatasetVersion: Effect.Effect<string | null, HttpError>;
+  readonly setDatasetVersion: (version: string) => Effect.Effect<void, HttpError>;
+  readonly createIngestionRun: (
+    runId: string,
+    version: string,
+    total: number,
+  ) => Effect.Effect<void, HttpError>;
+  readonly updateIngestionRun: (runId: string, processed: number) => Effect.Effect<void, HttpError>;
+  readonly finalizeIngestionRun: (runId: string, status: string) => Effect.Effect<void, HttpError>;
   readonly hasApiKey: (keyHash: string) => Effect.Effect<boolean, HttpError>;
   readonly insertApiKey: (keyHash: string) => Effect.Effect<void, HttpError>;
 }
@@ -123,6 +131,56 @@ export const makeAddressDb = (params: {
     return rows[0]?.update_sequence ?? null;
   });
 
+  const setDatasetVersion: (version: string) => Effect.Effect<void, HttpError> = (version) =>
+    Effect.gen(function* () {
+      const sql = yield* primary;
+      const now = new Date().toISOString();
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(SQL.insertDatasetVersion, [version, now, now]),
+        catch: (cause) => dbError("setDatasetVersion", cause),
+      });
+    });
+
+  const createIngestionRun: (
+    runId: string,
+    version: string,
+    total: number,
+  ) => Effect.Effect<void, HttpError> = (runId, version, total) =>
+    Effect.gen(function* () {
+      const sql = yield* primary;
+      const now = new Date().toISOString();
+      yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<unknown>(SQL.insertIngestionRun, [runId, version, "running", now, total]),
+        catch: (cause) => dbError("createIngestionRun", cause),
+      });
+    });
+
+  const updateIngestionRun: (runId: string, processed: number) => Effect.Effect<void, HttpError> = (
+    runId,
+    processed,
+  ) =>
+    Effect.gen(function* () {
+      const sql = yield* primary;
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(SQL.updateIngestionRun, [processed, runId]),
+        catch: (cause) => dbError("updateIngestionRun", cause),
+      });
+    });
+
+  const finalizeIngestionRun: (runId: string, status: string) => Effect.Effect<void, HttpError> = (
+    runId,
+    status,
+  ) =>
+    Effect.gen(function* () {
+      const sql = yield* primary;
+      const now = new Date().toISOString();
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(SQL.finalizeIngestionRun, [status, now, runId]),
+        catch: (cause) => dbError("finalizeIngestionRun", cause),
+      });
+    });
+
   const hasApiKey: (keyHash: string) => Effect.Effect<boolean, HttpError> = (keyHash) =>
     Effect.gen(function* () {
       const sql = yield* replica;
@@ -148,6 +206,10 @@ export const makeAddressDb = (params: {
     ensureSchema,
     rebuildSearchTerms,
     getDatasetVersion,
+    setDatasetVersion,
+    createIngestionRun,
+    updateIngestionRun,
+    finalizeIngestionRun,
     hasApiKey,
     insertApiKey,
   };

--- a/apps/api/src/services/address/db.ts
+++ b/apps/api/src/services/address/db.ts
@@ -1,0 +1,171 @@
+import { Effect } from "effect";
+import { HttpError } from "@tom/types/errors";
+import { buildRebuildTermsQuery, SQL } from "./queries";
+import { ADDRESS_SCHEMA_STATEMENTS, SEARCH_ALIASES } from "./schema";
+
+const dbError = (operation: string, cause: unknown): HttpError =>
+  new HttpError({ message: `Database error during ${operation}`, status: 500, cause });
+
+type PostgresSql = {
+  unsafe: <T>(query: string, params?: readonly unknown[]) => Promise<readonly T[]>;
+  end: () => Promise<void>;
+} & ((strings: TemplateStringsArray, ...values: unknown[]) => Promise<readonly unknown[]>);
+
+const postgresCache = new Map<string, PostgresSql>();
+
+const getPostgres = (connectionString: string): Effect.Effect<PostgresSql, HttpError> =>
+  Effect.gen(function* () {
+    if (!connectionString) {
+      return yield* new HttpError({ message: "Address database URL not configured", status: 500 });
+    }
+    const cached = postgresCache.get(connectionString);
+    if (cached) return cached;
+
+    const postgresMod = yield* Effect.tryPromise({
+      try: () => import("postgres"),
+      catch: (cause) => dbError("load postgres driver", cause),
+    });
+
+    // postgres package exports a function as default; handle both ESM and CJS interop
+    // oxlint-disable-next-line anti-slop/no-unsafe-dictionary-type -- dynamic import boundary for postgres ESM/CJS interop, single optional key check
+    const maybeDefault = (postgresMod as { default?: unknown }).default;
+    const postgresFn = (maybeDefault ?? postgresMod) as (
+      connectionString: string,
+      options: { max: number; idle_timeout: number; connect_timeout: number },
+    ) => PostgresSql;
+
+    const sql = yield* Effect.try({
+      try: () => {
+        const created = postgresFn(connectionString, {
+          max: 10,
+          idle_timeout: 20,
+          connect_timeout: 5,
+        });
+        postgresCache.set(connectionString, created);
+        return created;
+      },
+      catch: (cause) => dbError("create postgres connection", cause),
+    });
+
+    return sql;
+  });
+
+export interface AddressDbService {
+  readonly primary: Effect.Effect<PostgresSql, HttpError>;
+  readonly replica: Effect.Effect<PostgresSql, HttpError>;
+  readonly ensureSchema: Effect.Effect<void, HttpError>;
+  readonly rebuildSearchTerms: Effect.Effect<void, HttpError>;
+  readonly getDatasetVersion: Effect.Effect<string | null, HttpError>;
+  readonly hasApiKey: (keyHash: string) => Effect.Effect<boolean, HttpError>;
+  readonly insertApiKey: (keyHash: string) => Effect.Effect<void, HttpError>;
+}
+
+type VersionRow = { update_sequence: string };
+type KeyRow = { key_hash: string };
+
+export const makeAddressDb = (params: {
+  primaryConnectionString: string;
+  replicaConnectionString?: string;
+}): AddressDbService => {
+  const primaryConn = params.primaryConnectionString;
+  const replicaConn = params.replicaConnectionString ?? params.primaryConnectionString;
+
+  const primary = getPostgres(primaryConn);
+  const replica = getPostgres(replicaConn);
+
+  let schemaReady = false;
+
+  const ensureSchema: Effect.Effect<void, HttpError> = Effect.gen(function* () {
+    if (schemaReady) return;
+    const sql = yield* primary;
+    for (const statement of ADDRESS_SCHEMA_STATEMENTS) {
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(statement),
+        catch: (cause) => dbError("ensureSchema", cause),
+      });
+    }
+    if (SEARCH_ALIASES.length) {
+      yield* Effect.tryPromise({
+        try: async () => {
+          for (const { alias, expansion, priority } of SEARCH_ALIASES) {
+            await sql.unsafe<unknown>(SQL.insertSearchAlias, [alias, expansion, priority]);
+          }
+        },
+        catch: (cause) => dbError("seedSearchAliases", cause),
+      });
+    }
+    schemaReady = true;
+  });
+
+  const rebuildSearchTerms: Effect.Effect<void, HttpError> = Effect.gen(function* () {
+    const sql = yield* primary;
+    const termColumns: readonly (readonly [string, string])[] = [
+      ["road_name", "road_name_ascii"],
+      ["road_type", "road_type_name_ascii"],
+      ["locality", "suburb_locality_ascii"],
+      ["city", "town_city_ascii"],
+    ];
+
+    yield* Effect.tryPromise({
+      try: () => sql.unsafe<unknown>(SQL.deleteSearchTerms),
+      catch: (cause) => dbError("rebuildSearchTerms", cause),
+    });
+
+    for (const [kind, columnName] of termColumns) {
+      const query = buildRebuildTermsQuery(kind, columnName);
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(query, [kind]),
+        catch: (cause) => dbError("rebuildSearchTerms", cause),
+      });
+    }
+  });
+
+  const getDatasetVersion: Effect.Effect<string | null, HttpError> = Effect.gen(function* () {
+    const sql = yield* replica;
+    const rows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<VersionRow>(SQL.selectDatasetVersion),
+      catch: (cause) => dbError("getDatasetVersion", cause),
+    });
+    return rows[0]?.update_sequence ?? null;
+  });
+
+  const hasApiKey: (keyHash: string) => Effect.Effect<boolean, HttpError> = (keyHash) =>
+    Effect.gen(function* () {
+      const sql = yield* replica;
+      const rows = yield* Effect.tryPromise({
+        try: () => sql.unsafe<KeyRow>(SQL.selectKeyHash, [keyHash]),
+        catch: (cause) => dbError("hasApiKey", cause),
+      });
+      return rows.length > 0;
+    });
+
+  const insertApiKey: (keyHash: string) => Effect.Effect<void, HttpError> = (keyHash) =>
+    Effect.gen(function* () {
+      const sql = yield* primary;
+      yield* Effect.tryPromise({
+        try: () => sql.unsafe<unknown>(SQL.insertApiKey, [keyHash, new Date().toISOString()]),
+        catch: (cause) => dbError("insertApiKey", cause),
+      });
+    });
+
+  return {
+    primary,
+    replica,
+    ensureSchema,
+    rebuildSearchTerms,
+    getDatasetVersion,
+    hasApiKey,
+    insertApiKey,
+  };
+};
+
+export const closeAddressDb = (connectionString: string): Effect.Effect<void, HttpError> =>
+  Effect.gen(function* () {
+    const sql = postgresCache.get(connectionString);
+    if (!sql) return;
+    postgresCache.delete(connectionString);
+    yield* Effect.tryPromise({
+      try: () => sql.end(),
+      catch: (cause) => dbError("closeAddressDb", cause),
+    });
+  });

--- a/apps/api/src/services/address/index.ts
+++ b/apps/api/src/services/address/index.ts
@@ -1,0 +1,46 @@
+import { Effect } from "effect";
+import { makeAddressDb } from "./db";
+import { makeSearchService } from "./search";
+import { getAddressById, listAddresses, reverseGeocode, getMeta } from "./addresses";
+import type { AddressFilters, Bbox } from "@tom/types/address";
+import { getRequestEnv } from "@tom/utils/services/worker";
+
+export const addressServicesFromRequest = async (request: Request) => {
+  const env = getRequestEnv(request);
+
+  const primary = env.ADDRESS_HYPERDRIVE?.connectionString ?? env.ADDRESS_DB ?? "";
+  const replica =
+    env.ADDRESS_HYPERDRIVE_REPLICA?.connectionString ?? env.ADDRESS_DB_REPLICA ?? primary;
+
+  const db = makeAddressDb({
+    primaryConnectionString: primary,
+    replicaConnectionString: replica || primary,
+  });
+
+  const search = makeSearchService(db);
+
+  return {
+    db,
+    search,
+    getAddressById: (id: number) => getAddressById(db, id),
+    listAddresses: (filters: AddressFilters) => listAddresses(db, filters),
+    reverseGeocode: (lng: number, lat: number, limit: number) =>
+      reverseGeocode(db, lng, lat, limit),
+    getMeta: () => getMeta(db),
+    searchAddresses: (query: string, limit: number, bbox?: Bbox) =>
+      Effect.gen(function* () {
+        const results = yield* search.search(query, limit);
+        if (!bbox) return results;
+        const [minLng, minLat, maxLng, maxLat] = bbox;
+        return results.filter(
+          (row) =>
+            row.longitude >= minLng &&
+            row.longitude <= maxLng &&
+            row.latitude >= minLat &&
+            row.latitude <= maxLat,
+        );
+      }),
+  };
+};
+
+export type AddressServices = Awaited<ReturnType<typeof addressServicesFromRequest>>;

--- a/apps/api/src/services/address/ingest.ts
+++ b/apps/api/src/services/address/ingest.ts
@@ -3,7 +3,7 @@ import { HttpError } from "@tom/types/errors";
 import type { AddressDbService } from "./db";
 import { SQL } from "./queries";
 
-const LINZ_LAYER = "data.linz.govt.nz:layer-105689";
+const LINZ_LAYER = "data.linz.govt.nz:layer-123113";
 const WFS_VERSION = "2.0.0";
 const PAGE_SIZE = 1000;
 const MAX_PAGES_PER_INGEST = 900;
@@ -67,11 +67,17 @@ const LinzPropertiesSchema = Schema.Struct({
   road_name_ascii: nullishText,
   road_type_name: nullishText,
   road_type_name_ascii: nullishText,
+  // New layer 123113 uses road_name_type instead of road_type_name
+  road_name_type: nullishText,
+  road_id: nullishNumber,
+  unit: nullishText,
+  is_land: Schema.optional(Schema.Boolean),
   suburb_locality: nullishText,
   suburb_locality_ascii: nullishText,
   town_city: nullishText,
   town_city_ascii: nullishText,
   territorial_authority: nullishText,
+  territorial_authority_ascii: nullishText,
   unit_type: nullishText,
   unit_type_ascii: nullishText,
   unit_value: nullishText,
@@ -83,6 +89,7 @@ const LinzPropertiesSchema = Schema.Struct({
   address_number_suffix: nullishText,
   address_number_high: nullishNumber,
   road_name_prefix: nullishText,
+  road_name_suffix: nullishText,
   road_suffix: nullishText,
   water_name: nullishText,
   water_name_ascii: nullishText,
@@ -188,6 +195,10 @@ const featureToValues = (
   const get = <K extends keyof typeof props>(key: K): string | number | null =>
     (props[key] as string | number | null | undefined) ?? null;
 
+  const roadTypeName = props.road_name_type ?? props.road_type_name ?? null;
+  const roadTypeNameAscii = props.road_type_name_ascii ?? props.road_name_type ?? null;
+  const roadSuffix = props.road_suffix ?? props.road_name_suffix ?? null;
+
   return [
     addressId,
     get("source_dataset"),
@@ -199,8 +210,8 @@ const featureToValues = (
     get("full_road_name_ascii"),
     get("road_name"),
     get("road_name_ascii"),
-    get("road_type_name"),
-    get("road_type_name_ascii"),
+    roadTypeName,
+    roadTypeNameAscii,
     get("suburb_locality"),
     get("suburb_locality_ascii"),
     get("town_city"),
@@ -208,7 +219,7 @@ const featureToValues = (
     get("territorial_authority"),
     get("unit_type"),
     get("unit_type_ascii"),
-    get("unit_value"),
+    props.unit ?? get("unit_value"),
     get("level_type"),
     get("level_type_ascii"),
     get("level_value"),
@@ -217,7 +228,7 @@ const featureToValues = (
     get("address_number_suffix"),
     get("address_number_high"),
     get("road_name_prefix"),
-    get("road_suffix"),
+    roadSuffix,
     get("water_name"),
     get("water_name_ascii"),
     get("water_body_name"),

--- a/apps/api/src/services/address/ingest.ts
+++ b/apps/api/src/services/address/ingest.ts
@@ -1,0 +1,440 @@
+import { Effect, Schema } from "effect";
+import { HttpError } from "@tom/types/errors";
+import type { AddressDbService } from "./db";
+import { SQL } from "./queries";
+
+const LINZ_LAYER = "data.linz.govt.nz:layer-105689";
+const WFS_VERSION = "2.0.0";
+const PAGE_SIZE = 1000;
+const MAX_PAGES_PER_INGEST = 900;
+
+const buildBaseUrl = (apiKey: string): string =>
+  `https://data.linz.govt.nz/services;key=${apiKey}/wfs/`;
+
+const getCapabilitiesUrl = (apiKey: string): string =>
+  `${buildBaseUrl(apiKey)}?service=WFS&request=GetCapabilities`;
+
+const getHitsUrl = (apiKey: string): string =>
+  `${buildBaseUrl(
+    apiKey,
+  )}?service=WFS&version=${WFS_VERSION}&request=GetFeature&typeNames=${encodeURIComponent(
+    LINZ_LAYER,
+  )}&resultType=hits`;
+
+const getPageUrl = (apiKey: string, startIndex: number, count: number): string =>
+  `${buildBaseUrl(
+    apiKey,
+  )}?service=WFS&version=${WFS_VERSION}&request=GetFeature&typeNames=${encodeURIComponent(
+    LINZ_LAYER,
+  )}&count=${count}&startIndex=${startIndex}&outputFormat=application/json&srsName=EPSG:4326`;
+
+const parseUpdateSequence = (xml: string): string | null => {
+  const match = xml.match(/updateSequence="([^"]+)"/);
+  return match?.[1] ?? null;
+};
+
+const parseNumberMatched = (xml: string): number | null => {
+  const match = xml.match(/numberMatched="(\d+)"/);
+  return match ? Number(match[1]) : null;
+};
+
+const fetchXml = (url: string, operation: string): Effect.Effect<string, HttpError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`${operation} failed: ${response.status}`);
+      }
+      return response.text();
+    },
+    catch: (cause) =>
+      new HttpError({ message: `LINZ ${operation} failed: ${String(cause)}`, status: 500 }),
+  });
+
+const nullishText = Schema.optional(Schema.NullOr(Schema.String));
+const nullishNumber = Schema.optional(Schema.NullOr(Schema.NumberFromString));
+
+const LinzPropertiesSchema = Schema.Struct({
+  address_id: Schema.optional(Schema.NumberFromString),
+  source_dataset: nullishText,
+  change_id: nullishNumber,
+  full_address_number: nullishText,
+  full_address: nullishText,
+  full_address_ascii: nullishText,
+  full_road_name: nullishText,
+  full_road_name_ascii: nullishText,
+  road_name: nullishText,
+  road_name_ascii: nullishText,
+  road_type_name: nullishText,
+  road_type_name_ascii: nullishText,
+  suburb_locality: nullishText,
+  suburb_locality_ascii: nullishText,
+  town_city: nullishText,
+  town_city_ascii: nullishText,
+  territorial_authority: nullishText,
+  unit_type: nullishText,
+  unit_type_ascii: nullishText,
+  unit_value: nullishText,
+  level_type: nullishText,
+  level_type_ascii: nullishText,
+  level_value: nullishText,
+  address_number_prefix: nullishText,
+  address_number: nullishNumber,
+  address_number_suffix: nullishText,
+  address_number_high: nullishNumber,
+  road_name_prefix: nullishText,
+  road_suffix: nullishText,
+  water_name: nullishText,
+  water_name_ascii: nullishText,
+  water_body_name: nullishText,
+  water_body_name_ascii: nullishText,
+  address_class: nullishText,
+  address_class_ascii: nullishText,
+  address_lifecycle: nullishText,
+  gd2000_xcoord: nullishNumber,
+  gd2000_ycoord: nullishNumber,
+});
+
+const LinzFeatureSchema = Schema.Struct({
+  geometry: Schema.optional(
+    Schema.Struct({
+      coordinates: Schema.optional(Schema.Tuple([Schema.Number, Schema.Number])),
+    }),
+  ),
+  properties: LinzPropertiesSchema,
+});
+
+const LinzFeatureCollectionSchema = Schema.Struct({
+  features: Schema.optional(Schema.Array(LinzFeatureSchema)),
+});
+
+type LinzFeature = Schema.Schema.Type<typeof LinzFeatureSchema>;
+type LinzFeatureCollection = Schema.Schema.Type<typeof LinzFeatureCollectionSchema>;
+
+const fetchPage = (
+  apiKey: string,
+  startIndex: number,
+  count: number,
+): Effect.Effect<LinzFeatureCollection, HttpError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(getPageUrl(apiKey, startIndex, count));
+      if (!response.ok) {
+        throw new Error(`WFS fetch failed: ${response.status}`);
+      }
+      const raw = (await response.json()) as unknown;
+      return Schema.decodeUnknownSync(LinzFeatureCollectionSchema)(raw);
+    },
+    catch: (cause) =>
+      new HttpError({
+        message: `Failed to fetch LINZ page ${startIndex}: ${String(cause)}`,
+        status: 500,
+      }),
+  });
+
+const INGEST_COLUMNS: readonly string[] = [
+  "address_id",
+  "source_dataset",
+  "change_id",
+  "full_address_number",
+  "full_address",
+  "full_address_ascii",
+  "full_road_name",
+  "full_road_name_ascii",
+  "road_name",
+  "road_name_ascii",
+  "road_type_name",
+  "road_type_name_ascii",
+  "suburb_locality",
+  "suburb_locality_ascii",
+  "town_city",
+  "town_city_ascii",
+  "territorial_authority",
+  "unit_type",
+  "unit_type_ascii",
+  "unit_value",
+  "level_type",
+  "level_type_ascii",
+  "level_value",
+  "address_number_prefix",
+  "address_number",
+  "address_number_suffix",
+  "address_number_high",
+  "road_name_prefix",
+  "road_suffix",
+  "water_name",
+  "water_name_ascii",
+  "water_body_name",
+  "water_body_name_ascii",
+  "address_class",
+  "address_class_ascii",
+  "address_lifecycle",
+  "gd2000_xcoord",
+  "gd2000_ycoord",
+  "lat",
+  "lng",
+  "source_version",
+];
+
+const featureToValues = (
+  feature: LinzFeature,
+  version: string,
+): (number | string | null)[] | null => {
+  const props = feature.properties;
+  const addressId = props.address_id;
+  if (addressId === undefined) return null;
+
+  const [lng, lat] = feature.geometry?.coordinates ?? [null, null];
+  const get = <K extends keyof typeof props>(key: K): string | number | null =>
+    (props[key] as string | number | null | undefined) ?? null;
+
+  return [
+    addressId,
+    get("source_dataset"),
+    get("change_id"),
+    get("full_address_number"),
+    get("full_address"),
+    get("full_address_ascii"),
+    get("full_road_name"),
+    get("full_road_name_ascii"),
+    get("road_name"),
+    get("road_name_ascii"),
+    get("road_type_name"),
+    get("road_type_name_ascii"),
+    get("suburb_locality"),
+    get("suburb_locality_ascii"),
+    get("town_city"),
+    get("town_city_ascii"),
+    get("territorial_authority"),
+    get("unit_type"),
+    get("unit_type_ascii"),
+    get("unit_value"),
+    get("level_type"),
+    get("level_type_ascii"),
+    get("level_value"),
+    get("address_number_prefix"),
+    get("address_number"),
+    get("address_number_suffix"),
+    get("address_number_high"),
+    get("road_name_prefix"),
+    get("road_suffix"),
+    get("water_name"),
+    get("water_name_ascii"),
+    get("water_body_name"),
+    get("water_body_name_ascii"),
+    get("address_class"),
+    get("address_class_ascii"),
+    get("address_lifecycle"),
+    get("gd2000_xcoord"),
+    get("gd2000_ycoord"),
+    lat ?? null,
+    lng ?? null,
+    version,
+  ];
+};
+
+type UpsertQuery = {
+  readonly text: string;
+  readonly params: readonly (number | string | null)[];
+};
+
+const buildUpsertQuery = (values: readonly (readonly (number | string | null)[])[]) => {
+  const columnList = INGEST_COLUMNS.join(", ");
+  const updateList = INGEST_COLUMNS.filter((column) => column !== "address_id")
+    .map((column) => `${column} = EXCLUDED.${column}`)
+    .join(", ");
+
+  const params: (number | string | null)[] = [];
+  const rows = values.map((row) => {
+    const placeholders = row.map((_, index) => `$${params.length + index + 1}`).join(", ");
+    params.push(...row);
+    return `(${placeholders})`;
+  });
+
+  return {
+    text: `INSERT INTO addresses (${columnList}) VALUES ${rows.join(", ")} ON CONFLICT (address_id) DO UPDATE SET ${updateList}`,
+    params,
+  } satisfies UpsertQuery;
+};
+
+const upsertPage = (
+  db: AddressDbService,
+  values: readonly (readonly (number | string | null)[])[],
+): Effect.Effect<void, HttpError> =>
+  Effect.gen(function* () {
+    if (values.length === 0) return;
+    const sql = yield* db.primary;
+    const query = buildUpsertQuery(values);
+    yield* Effect.tryPromise({
+      try: () => sql.unsafe<unknown>(query.text, query.params),
+      catch: (cause) =>
+        new HttpError({ message: `upsertPage failed: ${String(cause)}`, status: 500 }),
+    });
+  });
+
+const cleanupOldVersions = (
+  db: AddressDbService,
+  version: string,
+): Effect.Effect<void, HttpError> =>
+  Effect.gen(function* () {
+    const sql = yield* db.primary;
+    for (;;) {
+      const rows = yield* Effect.tryPromise({
+        try: () => sql.unsafe<{ address_id: number }>(SQL.deleteOldAddresses, [version]),
+        catch: (cause) =>
+          new HttpError({ message: `cleanup failed: ${String(cause)}`, status: 500 }),
+      });
+      if (rows.length === 0) return;
+      yield* Effect.logInfo("cleanupOldVersions batch", { version, deleted: rows.length });
+    }
+  });
+
+export interface IngestStart {
+  readonly status: "queued" | "noop" | "error";
+  readonly version?: string;
+  readonly runId?: string;
+  readonly total?: number;
+}
+
+export const startIngestion = (
+  linzApiKey: string | undefined,
+  db: AddressDbService,
+): Effect.Effect<IngestStart, HttpError> =>
+  Effect.gen(function* () {
+    if (!linzApiKey) {
+      return yield* new HttpError({ message: "LINZ API key not configured", status: 500 });
+    }
+
+    yield* db.ensureSchema;
+
+    const capabilities = yield* fetchXml(getCapabilitiesUrl(linzApiKey), "capabilities");
+    const updateSequence = parseUpdateSequence(capabilities);
+    if (!updateSequence) {
+      return { status: "error" };
+    }
+
+    const currentVersion = yield* db.getDatasetVersion;
+    if (currentVersion === updateSequence) {
+      return { status: "noop", version: updateSequence };
+    }
+
+    const hits = yield* fetchXml(getHitsUrl(linzApiKey), "hits");
+    const total = parseNumberMatched(hits);
+    if (total === null || total === 0) {
+      return { status: "error" };
+    }
+
+    const runId = crypto.randomUUID();
+    yield* db.createIngestionRun(runId, updateSequence, total);
+
+    return { status: "queued", version: updateSequence, runId, total };
+  });
+
+export const ingestRun = (
+  linzApiKey: string | undefined,
+  db: AddressDbService,
+  runId: string,
+  version: string,
+  total: number,
+): Effect.Effect<void, HttpError> =>
+  Effect.gen(function* () {
+    if (!linzApiKey) {
+      return yield* new HttpError({ message: "LINZ API key not configured", status: 500 });
+    }
+
+    yield* db.ensureSchema;
+
+    const pages = Math.ceil(total / PAGE_SIZE);
+    const processedPages = Math.min(pages, MAX_PAGES_PER_INGEST);
+
+    for (let page = 0; page < processedPages; page += 1) {
+      const startIndex = page * PAGE_SIZE;
+      const count = Math.min(PAGE_SIZE, total - startIndex);
+      const collection = yield* fetchPage(linzApiKey, startIndex, count);
+
+      const values = (collection.features ?? []).flatMap((feature) => {
+        const row = featureToValues(feature, version);
+        return row ? [row] : [];
+      });
+
+      if (values.length) {
+        yield* upsertPage(db, values);
+      }
+      yield* db.updateIngestionRun(runId, values.length);
+      yield* Effect.logInfo("ingestRun page", {
+        runId,
+        version,
+        page: page + 1,
+        pages: processedPages,
+        count: values.length,
+      });
+    }
+
+    if (processedPages < pages) {
+      yield* Effect.logWarning("Ingestion truncated by worker budget", {
+        runId,
+        version,
+        total,
+        processedPages,
+        pages,
+      });
+      return;
+    }
+
+    yield* db.finalizeIngestionRun(runId, "completed");
+    yield* db.setDatasetVersion(version);
+    yield* cleanupOldVersions(db, version);
+    yield* db.rebuildSearchTerms;
+    yield* Effect.logInfo("ingestRun completed", { runId, version, total });
+  });
+
+export const ingestAll = (
+  linzApiKey: string | undefined,
+  db: AddressDbService,
+): Effect.Effect<IngestStart, HttpError> =>
+  Effect.gen(function* () {
+    const start = yield* startIngestion(linzApiKey, db);
+    if (start.status !== "queued" || !start.runId || !start.version || start.total === undefined) {
+      return start;
+    }
+
+    const total = start.total;
+    const runId = start.runId;
+    const version = start.version;
+    const pages = Math.ceil(total / PAGE_SIZE);
+
+    yield* Effect.logInfo("ingestAll started", { runId, version, total, pages });
+
+    for (let page = 0; page < pages; page += 1) {
+      const startIndex = page * PAGE_SIZE;
+      const count = Math.min(PAGE_SIZE, total - startIndex);
+      const collection = yield* fetchPage(linzApiKey!, startIndex, count);
+
+      const values = (collection.features ?? []).flatMap((feature) => {
+        const row = featureToValues(feature, version);
+        return row ? [row] : [];
+      });
+
+      if (values.length) {
+        yield* upsertPage(db, values);
+      }
+      yield* db.updateIngestionRun(runId, values.length);
+      if ((page + 1) % 10 === 0) {
+        yield* Effect.logInfo("ingestAll progress", {
+          runId,
+          page: page + 1,
+          pages,
+          total,
+          version,
+        });
+      }
+    }
+
+    yield* db.finalizeIngestionRun(runId, "completed");
+    yield* db.setDatasetVersion(version);
+    yield* cleanupOldVersions(db, version);
+    yield* db.rebuildSearchTerms;
+    yield* Effect.logInfo("ingestAll completed", { runId, version, total });
+
+    return start;
+  });

--- a/apps/api/src/services/address/queries.ts
+++ b/apps/api/src/services/address/queries.ts
@@ -1,0 +1,70 @@
+export const SQL = {
+  deleteSearchTerms: `DELETE FROM search_terms`,
+
+  insertSearchAlias: `INSERT INTO search_aliases (alias, expansion, priority) VALUES ($1, $2, $3) ON CONFLICT (alias, expansion) DO NOTHING`,
+
+  selectDatasetVersion: `SELECT update_sequence FROM dataset_version ORDER BY ingested_at DESC LIMIT 1`,
+
+  selectKeyHash: `SELECT key_hash FROM api_keys WHERE key_hash = $1 AND enabled = 1 LIMIT 1`,
+
+  insertApiKey: `INSERT INTO api_keys (key_hash, created_at) VALUES ($1, $2) ON CONFLICT (key_hash) DO NOTHING`,
+
+  selectAliasExpansions: `SELECT expansion FROM search_aliases WHERE alias = $1 ORDER BY priority DESC, expansion ASC LIMIT $2`,
+
+  selectCorrectionCandidates: `SELECT normalized_term, frequency FROM search_terms WHERE substr(normalized_term, 1, 1) = $1 AND length(normalized_term) BETWEEN $2 AND $3 ORDER BY frequency DESC, normalized_term ASC LIMIT $4`,
+
+  selectSearchCounts: `SELECT (SELECT COUNT(*) FROM search_terms) AS search_term_count, (SELECT COUNT(*) FROM addresses) AS address_count`,
+
+  searchAddresses: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id CROSS JOIN to_tsquery('simple', $1) AS q(query) WHERE a.search_vector @@ q.query ORDER BY ts_rank(a.search_vector, q.query) DESC LIMIT $2`,
+
+  selectAddressById: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id WHERE a.address_id = $1 LIMIT 1`,
+
+  selectAddressesByTown: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id WHERE a.town_city = $1 ORDER BY a.address_id ASC LIMIT $2 OFFSET $3`,
+
+  selectAddressesBySuburb: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id WHERE a.suburb_locality = $1 ORDER BY a.address_id ASC LIMIT $2 OFFSET $3`,
+
+  selectAddressesByRoad: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id WHERE a.road_name = $1 ORDER BY a.address_id ASC LIMIT $2 OFFSET $3`,
+
+  selectAddressesByBbox: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id WHERE a.lng BETWEEN $1 AND $2 AND a.lat BETWEEN $3 AND $4 ORDER BY a.address_id ASC LIMIT $5 OFFSET $6`,
+
+  selectAddressesOrdered: `SELECT a.*, p.postcode FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id ORDER BY a.address_id ASC LIMIT $1 OFFSET $2`,
+
+  selectReverseGeocode: `SELECT a.*, p.postcode, (abs(a.lng - $1) + abs(a.lat - $2)) AS distance FROM addresses a LEFT JOIN address_postcodes p ON p.address_id = a.address_id ORDER BY distance ASC LIMIT $3`,
+
+  countAddresses: `SELECT COUNT(*)::int AS count FROM addresses`,
+
+  selectMeta: `SELECT updated_at, ingested_at FROM dataset_version ORDER BY ingested_at DESC LIMIT 1`,
+} as const;
+
+const ALLOWED_REBUILD_COLUMNS = new Set([
+  "road_name_ascii",
+  "road_type_name_ascii",
+  "suburb_locality_ascii",
+  "town_city_ascii",
+]);
+
+export const buildRebuildTermsQuery = (kind: string, columnName: string): string => {
+  if (!ALLOWED_REBUILD_COLUMNS.has(columnName)) {
+    throw new Error(`Invalid column for rebuild: ${columnName}`);
+  }
+
+  return `
+        INSERT INTO search_terms (normalized_term, canonical_term, kind, frequency)
+        SELECT token, token, $1, SUM(weight)
+        FROM (
+          SELECT value, COUNT(*) AS weight
+          FROM (
+            SELECT lower(regexp_replace(trim(${columnName}), '[^a-z0-9]+', ' ', 'g')) AS value
+            FROM addresses
+            WHERE ${columnName} IS NOT NULL AND trim(${columnName}) != ''
+          ) grouped
+          GROUP BY value
+        ) source
+        CROSS JOIN LATERAL regexp_split_to_table(source.value, ' ') AS token
+        WHERE token != '' AND length(token) > 1
+        GROUP BY token
+        ON CONFLICT (normalized_term, kind) DO UPDATE SET
+          canonical_term = EXCLUDED.canonical_term,
+          frequency = EXCLUDED.frequency
+      `;
+};

--- a/apps/api/src/services/address/queries.ts
+++ b/apps/api/src/services/address/queries.ts
@@ -54,7 +54,7 @@ export const buildRebuildTermsQuery = (kind: string, columnName: string): string
         FROM (
           SELECT value, COUNT(*) AS weight
           FROM (
-            SELECT lower(regexp_replace(trim(${columnName}), '[^a-z0-9]+', ' ', 'g')) AS value
+            SELECT regexp_replace(lower(trim(${columnName})), '[^a-z0-9]+', ' ', 'g') AS value
             FROM addresses
             WHERE ${columnName} IS NOT NULL AND trim(${columnName}) != ''
           ) grouped

--- a/apps/api/src/services/address/queries.ts
+++ b/apps/api/src/services/address/queries.ts
@@ -34,6 +34,18 @@ export const SQL = {
   countAddresses: `SELECT COUNT(*)::int AS count FROM addresses`,
 
   selectMeta: `SELECT updated_at, ingested_at FROM dataset_version ORDER BY ingested_at DESC LIMIT 1`,
+
+  insertDatasetVersion: `INSERT INTO dataset_version (update_sequence, updated_at, ingested_at) VALUES ($1, $2, $3) ON CONFLICT (update_sequence) DO UPDATE SET updated_at = EXCLUDED.updated_at, ingested_at = EXCLUDED.ingested_at`,
+
+  insertIngestionRun: `INSERT INTO ingestion_runs (run_id, update_sequence, status, started_at, total_features, processed_features) VALUES ($1, $2, $3, $4, $5, 0) ON CONFLICT (run_id) DO NOTHING`,
+
+  updateIngestionRun: `UPDATE ingestion_runs SET processed_features = processed_features + $1 WHERE run_id = $2`,
+
+  finalizeIngestionRun: `UPDATE ingestion_runs SET status = $1, finished_at = $2 WHERE run_id = $3`,
+
+  selectIngestionRun: `SELECT processed_features FROM ingestion_runs WHERE run_id = $1`,
+
+  deleteOldAddresses: `DELETE FROM addresses WHERE source_version IS DISTINCT FROM $1 AND address_id IN (SELECT address_id FROM addresses WHERE source_version IS DISTINCT FROM $1 LIMIT 10000) RETURNING address_id`,
 } as const;
 
 const ALLOWED_REBUILD_COLUMNS = new Set([

--- a/apps/api/src/services/address/regions.ts
+++ b/apps/api/src/services/address/regions.ts
@@ -1,0 +1,95 @@
+// New Zealand regional council names (dashboard choices) mapped to the
+// territorial-authority keywords present in the LINZ `addresses` table.
+// Matching is case-insensitive substring on territorialAuthority.
+
+export const NZ_REGIONS = [
+  "Northland",
+  "Auckland",
+  "Waikato",
+  "Bay of Plenty",
+  "Gisborne",
+  "Hawke's Bay",
+  "Taranaki",
+  "Manawatū-Whanganui",
+  "Wellington",
+  "Tasman",
+  "Nelson",
+  "Marlborough",
+  "West Coast",
+  "Canterbury",
+  "Otago",
+  "Southland",
+] as const;
+
+const REGION_TERRITORIAL_AUTHORITY_KEYWORDS = {
+  Northland: ["Far North", "Whangarei", "Kaipara"],
+  Auckland: ["Auckland"],
+  Waikato: [
+    "Thames-Coromandel",
+    "Hauraki",
+    "Waikato",
+    "Matamata-Piako",
+    "Hamilton",
+    "Waipa",
+    "Otorohanga",
+    "South Waikato",
+    "Waitomo",
+    "Taupo",
+  ],
+  "Bay of Plenty": [
+    "Western Bay of Plenty",
+    "Tauranga",
+    "Rotorua",
+    "Whakatane",
+    "Kawerau",
+    "Opotiki",
+  ],
+  Gisborne: ["Gisborne"],
+  "Hawke's Bay": ["Wairoa", "Hastings", "Napier", "Central Hawke's Bay"],
+  Taranaki: ["New Plymouth", "Stratford", "South Taranaki"],
+  "Manawatū-Whanganui": [
+    "Rangitikei",
+    "Whanganui",
+    "Manawatu",
+    "Palmerston North",
+    "Tararua",
+    "Horowhenua",
+  ],
+  Wellington: [
+    "Kapiti Coast",
+    "Porirua",
+    "Upper Hutt",
+    "Lower Hutt",
+    "Wellington",
+    "Masterton",
+    "Carterton",
+    "South Wairarapa",
+  ],
+  Tasman: ["Tasman"],
+  Nelson: ["Nelson"],
+  Marlborough: ["Marlborough"],
+  "West Coast": ["Buller", "Grey", "Westland"],
+  Canterbury: [
+    "Kaikoura",
+    "Hurunui",
+    "Waimakariri",
+    "Christchurch",
+    "Selwyn",
+    "Ashburton",
+    "Timaru",
+    "Mackenzie",
+    "Waimate",
+  ],
+  Otago: ["Waitaki", "Central Otago", "Queenstown-Lakes", "Dunedin", "Clutha"],
+  Southland: ["Southland", "Gore", "Invercargill"],
+};
+
+export const isRegionAllowed = (
+  territorialAuthority: string,
+  regions: readonly string[],
+): boolean =>
+  regions.some((region) =>
+    (REGION_TERRITORIAL_AUTHORITY_KEYWORDS[region] ?? []).some((keyword) =>
+      territorialAuthority.toLowerCase().includes(keyword.toLowerCase()),
+    ),
+  );

--- a/apps/api/src/services/address/regions.ts
+++ b/apps/api/src/services/address/regions.ts
@@ -84,12 +84,17 @@ const REGION_TERRITORIAL_AUTHORITY_KEYWORDS = {
   Southland: ["Southland", "Gore", "Invercargill"],
 };
 
+type RegionKeywords = Readonly<Record<string, readonly string[]>>;
+
+const regionKeywords = (region: string): readonly string[] =>
+  (REGION_TERRITORIAL_AUTHORITY_KEYWORDS as RegionKeywords)[region] ?? [];
+
 export const isRegionAllowed = (
   territorialAuthority: string,
   regions: readonly string[],
 ): boolean =>
   regions.some((region) =>
-    (REGION_TERRITORIAL_AUTHORITY_KEYWORDS[region] ?? []).some((keyword) =>
+    regionKeywords(region).some((keyword) =>
       territorialAuthority.toLowerCase().includes(keyword.toLowerCase()),
     ),
   );

--- a/apps/api/src/services/address/schema.ts
+++ b/apps/api/src/services/address/schema.ts
@@ -172,11 +172,29 @@ export const AddressRowSchema = Schema.Struct({
 
 export type AddressRow = Schema.Schema.Type<typeof AddressRowSchema>;
 
+const DbNumber = Schema.Union([Schema.Number, Schema.String, Schema.BigInt]);
+
+export const RawAddressRowSchema = Schema.Struct({
+  address_id: DbNumber,
+  full_address: Schema.String,
+  full_address_number: Schema.String,
+  full_road_name: Schema.NullOr(Schema.String),
+  suburb_locality: Schema.String,
+  town_city: Schema.String,
+  territorial_authority: Schema.String,
+  lat: DbNumber,
+  lng: DbNumber,
+  postcode: Schema.optional(Schema.NullOr(Schema.String)),
+  source_version: Schema.optional(Schema.NullOr(Schema.String)),
+  region: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export type RawAddressRow = Schema.Schema.Type<typeof RawAddressRowSchema>;
+
 const toNumber = (value: string | number | bigint): number => Number(value);
 
-export const mapAddressRow = (row: AddressRow) => ({
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- postgres returns BIGINT as string at runtime; Schema types narrow to number, so coerce boundary value
-  addressId: toNumber(row.address_id as unknown as string | number | bigint),
+export const mapAddressRow = (row: RawAddressRow) => ({
+  addressId: toNumber(row.address_id),
   fullAddress: row.full_address,
   fullAddressNumber: row.full_address_number,
   fullAddressRoad: row.full_road_name,
@@ -185,8 +203,6 @@ export const mapAddressRow = (row: AddressRow) => ({
   territorialAuthority: row.territorial_authority,
   region: row.region ?? null,
   postcode: row.postcode ?? null,
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- lat/lng are DOUBLE PRECISION but driver may return string
-  longitude: toNumber(row.lng as unknown as string | number | bigint),
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- same
-  latitude: toNumber(row.lat as unknown as string | number | bigint),
+  longitude: toNumber(row.lng),
+  latitude: toNumber(row.lat),
 });

--- a/apps/api/src/services/address/schema.ts
+++ b/apps/api/src/services/address/schema.ts
@@ -69,27 +69,33 @@ export const ADDRESS_SCHEMA_STATEMENTS: readonly string[] = [
     lat DOUBLE PRECISION,
     lng DOUBLE PRECISION,
     source_version TEXT,
-    search_vector tsvector GENERATED ALWAYS AS (
-      to_tsvector(
-        'simple',
-        concat_ws(
-          ' ',
-          coalesce(full_address, ''),
-          coalesce(full_address_ascii, ''),
-          coalesce(full_road_name, ''),
-          coalesce(full_road_name_ascii, ''),
-          coalesce(road_name, ''),
-          coalesce(road_name_ascii, ''),
-          coalesce(road_type_name, ''),
-          coalesce(road_type_name_ascii, ''),
-          coalesce(suburb_locality, ''),
-          coalesce(suburb_locality_ascii, ''),
-          coalesce(town_city, ''),
-          coalesce(town_city_ascii, '')
-        )
-      )
-    ) STORED
+    search_vector tsvector
   )`,
+  `CREATE OR REPLACE FUNCTION addresses_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector := to_tsvector(
+    'simple',
+    concat_ws(
+      ' ',
+      coalesce(NEW.full_address, ''),
+      coalesce(NEW.full_address_ascii, ''),
+      coalesce(NEW.full_road_name, ''),
+      coalesce(NEW.full_road_name_ascii, ''),
+      coalesce(NEW.road_name, ''),
+      coalesce(NEW.road_name_ascii, ''),
+      coalesce(NEW.road_type_name, ''),
+      coalesce(NEW.road_type_name_ascii, ''),
+      coalesce(NEW.suburb_locality, ''),
+      coalesce(NEW.suburb_locality_ascii, ''),
+      coalesce(NEW.town_city, ''),
+      coalesce(NEW.town_city_ascii, '')
+    )
+  );
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql`,
+  "DROP TRIGGER IF EXISTS addresses_search_vector_trigger ON addresses",
+  "CREATE TRIGGER addresses_search_vector_trigger BEFORE INSERT OR UPDATE ON addresses FOR EACH ROW EXECUTE FUNCTION addresses_search_vector_update()",
   "CREATE INDEX IF NOT EXISTS addresses_search_idx ON addresses USING GIN (search_vector)",
   "CREATE INDEX IF NOT EXISTS idx_addresses_town_city ON addresses (town_city)",
   "CREATE INDEX IF NOT EXISTS idx_addresses_suburb_locality ON addresses (suburb_locality)",
@@ -166,8 +172,11 @@ export const AddressRowSchema = Schema.Struct({
 
 export type AddressRow = Schema.Schema.Type<typeof AddressRowSchema>;
 
+const toNumber = (value: string | number | bigint): number => Number(value);
+
 export const mapAddressRow = (row: AddressRow) => ({
-  addressId: row.address_id,
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- postgres returns BIGINT as string at runtime; Schema types narrow to number, so coerce boundary value
+  addressId: toNumber(row.address_id as unknown as string | number | bigint),
   fullAddress: row.full_address,
   fullAddressNumber: row.full_address_number,
   fullAddressRoad: row.full_road_name,
@@ -176,6 +185,8 @@ export const mapAddressRow = (row: AddressRow) => ({
   territorialAuthority: row.territorial_authority,
   region: row.region ?? null,
   postcode: row.postcode ?? null,
-  longitude: row.lng,
-  latitude: row.lat,
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- lat/lng are DOUBLE PRECISION but driver may return string
+  longitude: toNumber(row.lng as unknown as string | number | bigint),
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- same
+  latitude: toNumber(row.lat as unknown as string | number | bigint),
 });

--- a/apps/api/src/services/address/schema.ts
+++ b/apps/api/src/services/address/schema.ts
@@ -1,0 +1,181 @@
+import { Schema } from "effect";
+
+export const SEARCH_ALIASES: readonly {
+  alias: string;
+  expansion: string;
+  priority: number;
+}[] = [
+  { alias: "apt", expansion: "apartment", priority: 100 },
+  { alias: "ave", expansion: "avenue", priority: 100 },
+  { alias: "blvd", expansion: "boulevard", priority: 100 },
+  { alias: "cl", expansion: "close", priority: 100 },
+  { alias: "cres", expansion: "crescent", priority: 100 },
+  { alias: "ctr", expansion: "centre", priority: 100 },
+  { alias: "dr", expansion: "drive", priority: 100 },
+  { alias: "hwy", expansion: "highway", priority: 100 },
+  { alias: "ln", expansion: "lane", priority: 100 },
+  { alias: "mtrwy", expansion: "motorway", priority: 100 },
+  { alias: "mt", expansion: "mount", priority: 100 },
+  { alias: "pde", expansion: "parade", priority: 100 },
+  { alias: "pl", expansion: "place", priority: 100 },
+  { alias: "rd", expansion: "road", priority: 100 },
+  { alias: "sq", expansion: "square", priority: 100 },
+  { alias: "st", expansion: "street", priority: 90 },
+  { alias: "st", expansion: "saint", priority: 70 },
+  { alias: "tce", expansion: "terrace", priority: 100 },
+  { alias: "unit", expansion: "apartment", priority: 50 },
+];
+
+export const ADDRESS_SCHEMA_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS addresses (
+    address_id BIGINT PRIMARY KEY,
+    source_dataset TEXT,
+    change_id INTEGER,
+    full_address_number TEXT,
+    full_address TEXT,
+    full_address_ascii TEXT,
+    full_road_name TEXT,
+    full_road_name_ascii TEXT,
+    road_name TEXT,
+    road_name_ascii TEXT,
+    road_type_name TEXT,
+    road_type_name_ascii TEXT,
+    suburb_locality TEXT,
+    suburb_locality_ascii TEXT,
+    town_city TEXT,
+    town_city_ascii TEXT,
+    territorial_authority TEXT,
+    unit_type TEXT,
+    unit_type_ascii TEXT,
+    unit_value TEXT,
+    level_type TEXT,
+    level_type_ascii TEXT,
+    level_value TEXT,
+    address_number_prefix TEXT,
+    address_number INTEGER,
+    address_number_suffix TEXT,
+    address_number_high INTEGER,
+    road_name_prefix TEXT,
+    road_suffix TEXT,
+    water_name TEXT,
+    water_name_ascii TEXT,
+    water_body_name TEXT,
+    water_body_name_ascii TEXT,
+    address_class TEXT,
+    address_class_ascii TEXT,
+    address_lifecycle TEXT,
+    gd2000_xcoord DOUBLE PRECISION,
+    gd2000_ycoord DOUBLE PRECISION,
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    source_version TEXT,
+    search_vector tsvector GENERATED ALWAYS AS (
+      to_tsvector(
+        'simple',
+        concat_ws(
+          ' ',
+          coalesce(full_address, ''),
+          coalesce(full_address_ascii, ''),
+          coalesce(full_road_name, ''),
+          coalesce(full_road_name_ascii, ''),
+          coalesce(road_name, ''),
+          coalesce(road_name_ascii, ''),
+          coalesce(road_type_name, ''),
+          coalesce(road_type_name_ascii, ''),
+          coalesce(suburb_locality, ''),
+          coalesce(suburb_locality_ascii, ''),
+          coalesce(town_city, ''),
+          coalesce(town_city_ascii, '')
+        )
+      )
+    ) STORED
+  )`,
+  "CREATE INDEX IF NOT EXISTS addresses_search_idx ON addresses USING GIN (search_vector)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_town_city ON addresses (town_city)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_suburb_locality ON addresses (suburb_locality)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_road_name ON addresses (road_name)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_lat ON addresses (lat)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_lng ON addresses (lng)",
+  "CREATE INDEX IF NOT EXISTS idx_addresses_source_version ON addresses (source_version)",
+  `CREATE TABLE IF NOT EXISTS dataset_version (
+    update_sequence TEXT PRIMARY KEY,
+    updated_at TEXT,
+    ingested_at TEXT
+  )`,
+  `CREATE TABLE IF NOT EXISTS ingestion_runs (
+    run_id TEXT PRIMARY KEY,
+    update_sequence TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    total_features INTEGER,
+    processed_features INTEGER DEFAULT 0,
+    error_count INTEGER DEFAULT 0
+  )`,
+  `CREATE TABLE IF NOT EXISTS api_keys (
+    key_hash TEXT PRIMARY KEY,
+    label TEXT,
+    enabled INTEGER DEFAULT 1,
+    created_at TEXT
+  )`,
+  `CREATE TABLE IF NOT EXISTS address_postcodes (
+    address_id BIGINT PRIMARY KEY,
+    postcode TEXT NOT NULL
+  )`,
+  "CREATE INDEX IF NOT EXISTS idx_postcodes_postcode ON address_postcodes (postcode)",
+  `CREATE TABLE IF NOT EXISTS search_terms (
+    normalized_term TEXT NOT NULL,
+    canonical_term TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    frequency INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (normalized_term, kind)
+  )`,
+  "CREATE INDEX IF NOT EXISTS idx_search_terms_kind_frequency ON search_terms (kind, frequency DESC)",
+  `CREATE TABLE IF NOT EXISTS search_aliases (
+    alias TEXT NOT NULL,
+    expansion TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (alias, expansion)
+  )`,
+  "CREATE INDEX IF NOT EXISTS idx_search_aliases_alias_priority ON search_aliases (alias, priority DESC)",
+];
+
+export const AliasRowSchema = Schema.Struct({ expansion: Schema.String });
+export const TermRowSchema = Schema.Struct({
+  normalized_term: Schema.String,
+  frequency: Schema.Int,
+});
+export const CountRowSchema = Schema.Struct({
+  search_term_count: Schema.Number,
+  address_count: Schema.Number,
+});
+export const AddressRowSchema = Schema.Struct({
+  address_id: Schema.Number,
+  full_address: Schema.String,
+  full_address_number: Schema.String,
+  full_road_name: Schema.NullOr(Schema.String),
+  suburb_locality: Schema.String,
+  town_city: Schema.String,
+  territorial_authority: Schema.String,
+  lat: Schema.Number,
+  lng: Schema.Number,
+  postcode: Schema.optional(Schema.NullOr(Schema.String)),
+  source_version: Schema.optional(Schema.NullOr(Schema.String)),
+  region: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export type AddressRow = Schema.Schema.Type<typeof AddressRowSchema>;
+
+export const mapAddressRow = (row: AddressRow) => ({
+  addressId: row.address_id,
+  fullAddress: row.full_address,
+  fullAddressNumber: row.full_address_number,
+  fullAddressRoad: row.full_road_name,
+  suburb: row.suburb_locality,
+  townCity: row.town_city,
+  territorialAuthority: row.territorial_authority,
+  region: row.region ?? null,
+  postcode: row.postcode ?? null,
+  longitude: row.lng,
+  latitude: row.lat,
+});

--- a/apps/api/src/services/address/search.comma.test.ts
+++ b/apps/api/src/services/address/search.comma.test.ts
@@ -61,7 +61,9 @@ describe("AddressSearchQuerySchema comma handling", () => {
       q: ["Dominion road", " 4"],
       limit: "20",
     });
-    const qValue = Array.isArray(decoded.q) ? decoded.q.join(",") : decoded.q;
+    const qValue: string = Array.isArray(decoded.q)
+      ? (decoded.q as readonly string[]).join(",")
+      : (decoded.q as string);
     expect(qValue.trim().length).toBeGreaterThanOrEqual(3);
   });
 
@@ -75,7 +77,7 @@ describe("AddressSearchQuerySchema comma handling", () => {
       q: qValue,
       limit: raw.limit as string | undefined,
       bbox: undefined,
-    } satisfies { q: string; limit?: string; bbox?: string };
+    } satisfies { q: string; limit?: string | undefined; bbox?: string | undefined };
     expect(decoded.q).toBe("Dominion road, 4");
     expect(decoded.q.trim()).toBe("Dominion road, 4");
   });

--- a/apps/api/src/services/address/search.comma.test.ts
+++ b/apps/api/src/services/address/search.comma.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { Schema } from "effect";
+import { AddressSearchQuerySchema, AddressListQuerySchema } from "@tom/schemas/address";
+
+describe("AddressSearchQuerySchema comma handling", () => {
+  it("decodes q with comma as string", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: "Dominion road, 4",
+      limit: "20",
+    });
+    const qValue = Array.isArray(decoded.q) ? decoded.q.join(",") : decoded.q;
+    expect(qValue).toBe("Dominion road, 4");
+  });
+
+  it("decodes q as array when Elysia splits on comma", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: ["Dominion road", " 4"],
+      limit: "20",
+    });
+    const qValue = Array.isArray(decoded.q) ? decoded.q.join(",") : decoded.q;
+    expect(qValue).toBe("Dominion road, 4");
+  });
+
+  it("decodes q without comma still works", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: "Dominion road",
+      limit: "20",
+    });
+    const qValue = Array.isArray(decoded.q) ? decoded.q.join(",") : decoded.q;
+    expect(qValue).toBe("Dominion road");
+  });
+
+  it("decodes bbox with commas as string", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: "dominion",
+      bbox: "174.7,-41.2,174.8,-41.1",
+    });
+    const bboxRaw = decoded.bbox
+      ? Array.isArray(decoded.bbox)
+        ? decoded.bbox.join(",")
+        : decoded.bbox
+      : undefined;
+    expect(bboxRaw).toBe("174.7,-41.2,174.8,-41.1");
+  });
+
+  it("decodes bbox as array when Elysia splits on comma", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: "dominion",
+      bbox: ["174.7", "-41.2", "174.8", "-41.1"],
+    });
+    const bboxRaw = decoded.bbox
+      ? Array.isArray(decoded.bbox)
+        ? decoded.bbox.join(",")
+        : decoded.bbox
+      : undefined;
+    expect(bboxRaw).toBe("174.7,-41.2,174.8,-41.1");
+  });
+
+  it("trims q after join and still requires 3 chars", () => {
+    const decoded = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: ["Dominion road", " 4"],
+      limit: "20",
+    });
+    const qValue = Array.isArray(decoded.q) ? decoded.q.join(",") : decoded.q;
+    expect(qValue.trim().length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not error for Dominion road, 4 after normalization", () => {
+    const raw = Schema.decodeUnknownSync(AddressSearchQuerySchema)({
+      q: ["Dominion road", " 4"],
+      limit: "20",
+    });
+    const qValue: string = Array.isArray(raw.q) ? raw.q.join(",") : (raw.q as string);
+    const decoded = {
+      q: qValue,
+      limit: raw.limit as string | undefined,
+      bbox: undefined,
+    } satisfies { q: string; limit?: string; bbox?: string };
+    expect(decoded.q).toBe("Dominion road, 4");
+    expect(decoded.q.trim()).toBe("Dominion road, 4");
+  });
+});
+
+describe("AddressListQuerySchema bbox comma handling", () => {
+  it("decodes bbox with commas", () => {
+    const decoded = Schema.decodeUnknownSync(AddressListQuerySchema)({
+      bbox: "174.7,-41.2,174.8,-41.1",
+      limit: "10",
+    });
+    const bboxRaw = decoded.bbox
+      ? Array.isArray(decoded.bbox)
+        ? decoded.bbox.join(",")
+        : decoded.bbox
+      : undefined;
+    expect(bboxRaw).toBe("174.7,-41.2,174.8,-41.1");
+  });
+
+  it("decodes bbox as array", () => {
+    const decoded = Schema.decodeUnknownSync(AddressListQuerySchema)({
+      bbox: ["174.7", "-41.2", "174.8", "-41.1"],
+      limit: "10",
+    });
+    const bboxRaw = decoded.bbox
+      ? Array.isArray(decoded.bbox)
+        ? decoded.bbox.join(",")
+        : decoded.bbox
+      : undefined;
+    expect(bboxRaw).toBe("174.7,-41.2,174.8,-41.1");
+  });
+});

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -102,11 +102,7 @@ const toTsQuery = (match: string): string =>
     .replace(/\bOR\b/g, "|");
 
 const dbError = (operation: string, cause: unknown): HttpError =>
-  new HttpError({
-    message: `Search error during ${operation}: ${cause instanceof Error ? cause.message : globalThis.String(cause)}`,
-    status: 500,
-    cause,
-  });
+  new HttpError({ message: `Search error during ${operation}`, status: 500, cause });
 
 type AliasRow = { expansion: string };
 type TermRow = { normalized_term: string; frequency: number | string | bigint };

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -1,0 +1,251 @@
+import { Array as Arr, Effect, pipe, String } from "effect";
+import { HttpError } from "@tom/types/errors";
+import type { AddressDbService } from "./db";
+import { SQL } from "./queries";
+import { mapAddressRow, type AddressRow } from "./schema";
+
+const MAX_ALIAS_EXPANSIONS = 3;
+const MAX_CORRECTION_CANDIDATES = 50;
+
+export interface SearchPlan {
+  readonly mode: "exact" | "expanded" | "fuzzy";
+  readonly match: string;
+}
+
+export interface SearchService {
+  readonly search: (
+    query: string,
+    limit: number,
+  ) => Effect.Effect<readonly ReturnType<typeof mapAddressRow>[], HttpError>;
+}
+
+// Postgres `to_tsvector('simple', ...)` handles lowercasing and lexing server-side.
+// For alias / typo lookups we still need a client-side normalized token form; use Effect's
+// String pipe so the transform stays declarative and testable instead of a bespoke regex chain.
+const normalizeText = (value: string): string =>
+  pipe(
+    value,
+    String.normalize("NFKD"),
+    String.replace(/[\u0300-\u036f]/g, ""),
+    String.toLowerCase,
+    String.replace(/[^a-z0-9]+/g, " "),
+    String.trim,
+  );
+
+export const tokenize = (value: string): string[] =>
+  pipe(normalizeText(value), String.split(/\s+/), Arr.filter(Boolean));
+
+const unique = (values: string[]): string[] => [...new Set(values.filter(Boolean))];
+
+const isNumericToken = (token: string): boolean => /^\d+[a-z]?$/.test(token);
+
+export const buildMatch = (groups: string[][]): string | null => {
+  const clauses = groups
+    .map((group) => unique(group).filter((token) => /^[a-z0-9]+$/.test(token)))
+    .filter((group) => group.length > 0)
+    .map((group) => {
+      const terms = group.map((token) => `${token}*`);
+      return terms.length === 1 ? terms[0]! : `(${terms.join(" OR ")})`;
+    });
+
+  return clauses.length ? clauses.join(" AND ") : null;
+};
+
+const groupsEqual = (left: string[][], right: string[][]): boolean => {
+  if (left.length !== right.length) return false;
+  return left.every((group, index) => {
+    const a = unique(group).sort();
+    const b = unique(right[index] ?? []).sort();
+    return a.length === b.length && a.every((token, tokenIndex) => token === b[tokenIndex]);
+  });
+};
+
+export const levenshtein = (left: string, right: string): number => {
+  if (left === right) return 0;
+  if (!left.length) return right.length;
+  if (!right.length) return left.length;
+
+  const previous = Array.from({ length: right.length + 1 }, () => 0);
+  const current = Array.from({ length: right.length + 1 }, () => 0);
+
+  for (let column = 0; column <= right.length; column += 1) {
+    previous[column] = column;
+  }
+
+  for (let row = 1; row <= left.length; row += 1) {
+    current[0] = row;
+    for (let column = 1; column <= right.length; column += 1) {
+      const substitutionCost = left[row - 1] === right[column - 1] ? 0 : 1;
+      current[column] = Math.min(
+        (current[column - 1] ?? 0) + 1,
+        (previous[column] ?? 0) + 1,
+        (previous[column - 1] ?? 0) + substitutionCost,
+      );
+    }
+    for (let column = 0; column <= right.length; column += 1) {
+      previous[column] = current[column] ?? 0;
+    }
+  }
+  return previous[right.length] ?? 0;
+};
+
+const correctionThreshold = (token: string): number => {
+  if (token.length <= 4) return 1;
+  if (token.length <= 7) return 2;
+  return 3;
+};
+
+const toTsQuery = (match: string): string =>
+  match
+    .replace(/\b([a-z0-9]+)\*/g, "$1:*")
+    .replace(/\bAND\b/g, "&")
+    .replace(/\bOR\b/g, "|");
+
+const dbError = (operation: string, cause: unknown): HttpError =>
+  new HttpError({ message: `Search error during ${operation}`, status: 500, cause });
+
+type AliasRow = { expansion: string };
+type TermRow = { normalized_term: string; frequency: number };
+type CountRow = { search_term_count: number; address_count: number };
+
+export const makeSearchService = (db: AddressDbService): SearchService => {
+  const getAliasExpansions = (
+    token: string,
+    previousToken?: string,
+    nextToken?: string,
+  ): Effect.Effect<readonly string[], HttpError> =>
+    Effect.gen(function* () {
+      if (token === "st") {
+        if (previousToken && isNumericToken(previousToken)) return ["street"];
+        if (nextToken && !isNumericToken(nextToken)) return ["street", "saint"];
+      }
+      const sql = yield* db.replica;
+      const rows = yield* Effect.tryPromise({
+        try: () => sql.unsafe<AliasRow>(SQL.selectAliasExpansions, [token, MAX_ALIAS_EXPANSIONS]),
+        catch: (cause) => dbError("getAliasExpansions", cause),
+      });
+      return unique(rows.map((row) => row.expansion));
+    });
+
+  const getCorrection = (token: string): Effect.Effect<string | null, HttpError> =>
+    Effect.gen(function* () {
+      if (token.length < 4 || isNumericToken(token)) return null;
+
+      const minLength = Math.max(2, token.length - 2);
+      const maxLength = token.length + 2;
+      const sql = yield* db.replica;
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          sql.unsafe<TermRow>(SQL.selectCorrectionCandidates, [
+            token.charAt(0),
+            minLength,
+            maxLength,
+            MAX_CORRECTION_CANDIDATES,
+          ]),
+        catch: (cause) => dbError("getCorrection", cause),
+      });
+
+      let bestToken: string | null = null;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      let bestFrequency = -1;
+
+      for (const candidate of rows) {
+        const distance = levenshtein(token, candidate.normalized_term);
+        if (distance === 0 || distance > correctionThreshold(token)) continue;
+
+        if (
+          distance < bestDistance ||
+          (distance === bestDistance && candidate.frequency > bestFrequency) ||
+          (distance === bestDistance &&
+            candidate.frequency === bestFrequency &&
+            candidate.normalized_term < (bestToken ?? "~"))
+        ) {
+          bestToken = candidate.normalized_term;
+          bestDistance = distance;
+          bestFrequency = candidate.frequency;
+        }
+      }
+      return bestToken;
+    });
+
+  const ensureSearchTermsReady: Effect.Effect<void, HttpError> = Effect.gen(function* () {
+    const sql = yield* db.replica;
+    const rows = yield* Effect.tryPromise({
+      try: () => sql.unsafe<CountRow>(SQL.selectSearchCounts),
+      catch: (cause) => dbError("ensureSearchTermsReady", cause),
+    });
+    if (rows[0]?.search_term_count === 0 && (rows[0]?.address_count ?? 0) > 0) {
+      yield* db.rebuildSearchTerms;
+    }
+  });
+
+  const buildPlans = (query: string): Effect.Effect<readonly SearchPlan[], HttpError> =>
+    Effect.gen(function* () {
+      yield* ensureSearchTermsReady;
+      const tokens = tokenize(query);
+      if (!tokens.length) return [];
+
+      const exactGroups = tokens.map((token) => [token]);
+
+      const expandedGroups = yield* Effect.all(
+        tokens.map((token, index) =>
+          getAliasExpansions(token, tokens[index - 1], tokens[index + 1]).pipe(
+            Effect.map((expansions) => unique([token, ...expansions])),
+          ),
+        ),
+      );
+
+      const fuzzyGroups = yield* Effect.all(
+        expandedGroups.map((group, index) =>
+          getCorrection(tokens[index] ?? "").pipe(
+            Effect.map((correction) => (correction ? unique([...group, correction]) : group)),
+          ),
+        ),
+      );
+
+      const plans: SearchPlan[] = [];
+      const exactMatch = buildMatch(exactGroups);
+      const expandedMatch = buildMatch(expandedGroups);
+      const fuzzyMatch = buildMatch(fuzzyGroups);
+
+      if (exactMatch) plans.push({ mode: "exact", match: exactMatch });
+      if (
+        expandedMatch &&
+        expandedMatch !== exactMatch &&
+        !groupsEqual(expandedGroups, exactGroups)
+      ) {
+        plans.push({ mode: "expanded", match: expandedMatch });
+      }
+      if (
+        fuzzyMatch &&
+        fuzzyMatch !== exactMatch &&
+        fuzzyMatch !== expandedMatch &&
+        !groupsEqual(fuzzyGroups, expandedGroups)
+      ) {
+        plans.push({ mode: "fuzzy", match: fuzzyMatch });
+      }
+
+      return plans;
+    });
+
+  const search: SearchService["search"] = (query, limit) =>
+    Effect.gen(function* () {
+      const plans = yield* buildPlans(query);
+      if (!plans.length) return [];
+
+      const sql = yield* db.replica;
+
+      for (const plan of plans) {
+        const tsQuery = toTsQuery(plan.match);
+        const rows = yield* Effect.tryPromise({
+          try: () => sql.unsafe<AddressRow>(SQL.searchAddresses, [tsQuery, limit]),
+          catch: (cause) => dbError("search", cause),
+        });
+        if (rows.length) return rows.map(mapAddressRow);
+      }
+
+      return [];
+    });
+
+  return { search };
+};

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -102,7 +102,11 @@ const toTsQuery = (match: string): string =>
     .replace(/\bOR\b/g, "|");
 
 const dbError = (operation: string, cause: unknown): HttpError =>
-  new HttpError({ message: `Search error during ${operation}`, status: 500, cause });
+  new HttpError({
+    message: `Search error during ${operation}: ${cause instanceof Error ? cause.message : globalThis.String(cause)}`,
+    status: 500,
+    cause,
+  });
 
 type AliasRow = { expansion: string };
 type TermRow = { normalized_term: string; frequency: number | string | bigint };

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -106,10 +106,6 @@ const dbError = (operation: string, cause: unknown): HttpError =>
 
 type AliasRow = { expansion: string };
 type TermRow = { normalized_term: string; frequency: number | string | bigint };
-type CountRow = {
-  search_term_count: number | string | bigint;
-  address_count: number | string | bigint;
-};
 
 export const makeSearchService = (db: AddressDbService): SearchService => {
   const getAliasExpansions = (
@@ -172,18 +168,7 @@ export const makeSearchService = (db: AddressDbService): SearchService => {
       return bestToken;
     });
 
-  const ensureSearchTermsReady: Effect.Effect<void, HttpError> = Effect.gen(function* () {
-    const sql = yield* db.replica;
-    const rows = yield* Effect.tryPromise({
-      try: () => sql.unsafe<CountRow>(SQL.selectSearchCounts),
-      catch: (cause) => dbError("ensureSearchTermsReady", cause),
-    });
-    const searchTermCount = Number(rows[0]?.search_term_count ?? 0);
-    const addressCount = Number(rows[0]?.address_count ?? 0);
-    if (searchTermCount === 0 && addressCount > 0) {
-      yield* db.rebuildSearchTerms;
-    }
-  });
+  const ensureSearchTermsReady: Effect.Effect<void, HttpError> = Effect.void;
 
   const buildPlans = (query: string): Effect.Effect<readonly SearchPlan[], HttpError> =>
     Effect.gen(function* () {

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -2,7 +2,7 @@ import { Array as Arr, Effect, pipe, String } from "effect";
 import { HttpError } from "@tom/types/errors";
 import type { AddressDbService } from "./db";
 import { SQL } from "./queries";
-import { mapAddressRow, type AddressRow } from "./schema";
+import { mapAddressRow, type RawAddressRow } from "./schema";
 
 const MAX_ALIAS_EXPANSIONS = 3;
 const MAX_CORRECTION_CANDIDATES = 50;
@@ -244,7 +244,7 @@ export const makeSearchService = (db: AddressDbService): SearchService => {
       for (const plan of plans) {
         const tsQuery = toTsQuery(plan.match);
         const rows = yield* Effect.tryPromise({
-          try: () => sql.unsafe<AddressRow>(SQL.searchAddresses, [tsQuery, limit]),
+          try: () => sql.unsafe<RawAddressRow>(SQL.searchAddresses, [tsQuery, limit]),
           catch: (cause) => dbError("search", cause),
         });
         if (rows.length) return rows.map(mapAddressRow);

--- a/apps/api/src/services/address/search.ts
+++ b/apps/api/src/services/address/search.ts
@@ -105,8 +105,11 @@ const dbError = (operation: string, cause: unknown): HttpError =>
   new HttpError({ message: `Search error during ${operation}`, status: 500, cause });
 
 type AliasRow = { expansion: string };
-type TermRow = { normalized_term: string; frequency: number };
-type CountRow = { search_term_count: number; address_count: number };
+type TermRow = { normalized_term: string; frequency: number | string | bigint };
+type CountRow = {
+  search_term_count: number | string | bigint;
+  address_count: number | string | bigint;
+};
 
 export const makeSearchService = (db: AddressDbService): SearchService => {
   const getAliasExpansions = (
@@ -150,19 +153,20 @@ export const makeSearchService = (db: AddressDbService): SearchService => {
       let bestFrequency = -1;
 
       for (const candidate of rows) {
+        const frequency = Number(candidate.frequency);
         const distance = levenshtein(token, candidate.normalized_term);
         if (distance === 0 || distance > correctionThreshold(token)) continue;
 
         if (
           distance < bestDistance ||
-          (distance === bestDistance && candidate.frequency > bestFrequency) ||
+          (distance === bestDistance && frequency > bestFrequency) ||
           (distance === bestDistance &&
-            candidate.frequency === bestFrequency &&
+            frequency === bestFrequency &&
             candidate.normalized_term < (bestToken ?? "~"))
         ) {
           bestToken = candidate.normalized_term;
           bestDistance = distance;
-          bestFrequency = candidate.frequency;
+          bestFrequency = frequency;
         }
       }
       return bestToken;
@@ -174,7 +178,9 @@ export const makeSearchService = (db: AddressDbService): SearchService => {
       try: () => sql.unsafe<CountRow>(SQL.selectSearchCounts),
       catch: (cause) => dbError("ensureSearchTermsReady", cause),
     });
-    if (rows[0]?.search_term_count === 0 && (rows[0]?.address_count ?? 0) > 0) {
+    const searchTermCount = Number(rows[0]?.search_term_count ?? 0);
+    const addressCount = Number(rows[0]?.address_count ?? 0);
+    if (searchTermCount === 0 && addressCount > 0) {
       yield* db.rebuildSearchTerms;
     }
   });

--- a/apps/api/src/services/auth.ts
+++ b/apps/api/src/services/auth.ts
@@ -1,0 +1,170 @@
+import { createHash } from "@better-auth/utils/hash";
+import { and, count, eq, gte } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import * as authDb from "../db/auth-schema";
+import { getRequestEnv } from "@tom/utils/services/worker";
+
+// Key metadata shape created by the dashboard: area scope, region list and
+// the postcodes toggle. Stored as JSON on the API key's metadata column.
+export type KeyScopeMetadata = {
+  readonly scope: "all" | "one" | "multiple";
+  readonly regions: readonly string[];
+  readonly postcodes: boolean;
+};
+
+export const parseKeyScope = (raw: string | null): KeyScopeMetadata | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<KeyScopeMetadata>;
+    const scope = parsed.scope;
+    const valid = scope === "all" || scope === "one" || scope === "multiple" ? scope : null;
+    if (!valid) return null;
+    return {
+      scope: valid,
+      regions: Array.isArray(parsed.regions) ? parsed.regions : [],
+      postcodes: parsed.postcodes !== false,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// Same hashing as @better-auth/api-key's defaultKeyHasher so keys created
+// here are also verifiable by the plugin's own endpoints.
+export const hashApiKey = async (key: string): Promise<string> =>
+  createHash("SHA-256", "hex").digest(new TextEncoder().encode(key));
+
+export type CreatedApiKey = {
+  readonly id: string;
+  readonly key: string;
+};
+
+export const createApiKeyRecord = async (
+  request: Request,
+  userId: string,
+  input: KeyScopeMetadata & { name: string },
+): Promise<CreatedApiKey> => {
+  const db = getRequestEnv(request).AUTH_DB;
+  if (!db) {
+    throw new Error("Auth DB not configured");
+  }
+  const drizzleDb = drizzle(db, { schema: authDb });
+  const id = crypto.randomUUID();
+  const key = `tms_${id.replace(/-/g, "").slice(0, 24)}`;
+  const hashed = await hashApiKey(key);
+  const now = new Date();
+  await drizzleDb.insert(authDb.apikey).values({
+    configId: "default",
+    name: input.name,
+    start: key.slice(0, 8),
+    referenceId: userId,
+    prefix: "tms_",
+    key: hashed,
+    enabled: true,
+    rateLimitEnabled: false,
+    id,
+    createdAt: now,
+    updatedAt: now,
+    metadata: JSON.stringify({
+      scope: input.scope,
+      regions: input.regions,
+      postcodes: input.postcodes,
+    }),
+  });
+  return { id, key };
+};
+
+export type VerifiedApiKey = {
+  readonly id: string;
+  readonly referenceId: string;
+  readonly metadata: KeyScopeMetadata | null;
+};
+
+export const verifyApiKeyRecord = async (
+  request: Request,
+  rawKey: string,
+): Promise<VerifiedApiKey | null> => {
+  const db = getRequestEnv(request).AUTH_DB;
+  if (!db) return null;
+  const drizzleDb = drizzle(db, { schema: authDb });
+  const hashed = await hashApiKey(rawKey);
+  const rows = await drizzleDb
+    .select()
+    .from(authDb.apikey)
+    .where(and(eq(authDb.apikey.key, hashed), eq(authDb.apikey.enabled, true)))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  if (row.expiresAt && row.expiresAt.getTime() < Date.now()) return null;
+  return {
+    id: row.id,
+    referenceId: row.referenceId,
+    metadata: parseKeyScope(row.metadata ?? null),
+  };
+};
+
+export const listApiKeyRecords = async (
+  request: Request,
+  userId: string,
+): Promise<
+  readonly {
+    id: string;
+    name: string | null;
+    start: string | null;
+    createdAt: Date;
+    metadata: string | null;
+  }[]
+> => {
+  const db = getRequestEnv(request).AUTH_DB;
+  if (!db) throw new Error("Auth DB not configured");
+  const drizzleDb = drizzle(db, { schema: authDb });
+  return drizzleDb
+    .select({
+      id: authDb.apikey.id,
+      name: authDb.apikey.name,
+      start: authDb.apikey.start,
+      createdAt: authDb.apikey.createdAt,
+      metadata: authDb.apikey.metadata,
+    })
+    .from(authDb.apikey)
+    .where(eq(authDb.apikey.referenceId, userId));
+};
+
+export const recordUsage = async (
+  request: Request,
+  envKey: { apikeyId: string; userId?: string },
+): Promise<void> => {
+  const db = getRequestEnv(request).AUTH_DB;
+  if (!db) return;
+  const drizzleDb = drizzle(db, { schema: authDb });
+  await drizzleDb.insert(authDb.authUsage).values({
+    id: crypto.randomUUID(),
+    apikeyId: envKey.apikeyId,
+    userId: envKey.userId,
+    createdAt: new Date(),
+    path: new URL(request.url).pathname,
+  });
+};
+
+// Bucket helper for the usage endpoint: counts rows created since `since`.
+export const countUsageSince = async (
+  request: Request,
+  since: number,
+  apikeyId: string | null,
+): Promise<number> => {
+  const db = getRequestEnv(request).AUTH_DB;
+  if (!db) throw new Error("Auth DB not configured");
+  const drizzleDb = drizzle(db, { schema: authDb });
+  const rows = await drizzleDb
+    .select({ value: count() })
+    .from(authDb.authUsage)
+    .where(
+      apikeyId
+        ? and(
+            eq(authDb.authUsage.apikeyId, apikeyId),
+            gte(authDb.authUsage.createdAt, new Date(since)),
+          )
+        : gte(authDb.authUsage.createdAt, new Date(since)),
+    );
+  return rows[0]?.value ?? 0;
+};

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -221,7 +221,7 @@ a.page:hover {
 
 .input {
   padding: 0.5rem 1rem;
-  border: 2px solid #d1d5db;
+  border: 2px solid #000000;
   background-color: transparent;
   color: inherit;
   transition: border-color 150ms ease-in-out;

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,7 +1,8 @@
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { Suspense, onMount } from "solid-js";
-import { MetaProvider } from "@solidjs/meta";
+import { Meta, MetaProvider } from "@solidjs/meta";
+import { getAdapterBaseUrl } from "~/libs/adapter";
 import { QueryClientProvider } from "@tanstack/solid-query";
 import { Footer } from "@tom/ui/Footer";
 import { Nav } from "@tom/ui/Nav";
@@ -33,6 +34,7 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <MetaProvider>
+        {import.meta.env.SSR && <Meta name="x-adapter-url" content={getAdapterBaseUrl()} />}
         <Router root={RootLayout}>
           <FileRoutes />
         </Router>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,8 +1,7 @@
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { Suspense, onMount } from "solid-js";
-import { Meta, MetaProvider } from "@solidjs/meta";
-import { getAdapterBaseUrl } from "~/libs/adapter";
+import { MetaProvider } from "@solidjs/meta";
 import { QueryClientProvider } from "@tanstack/solid-query";
 import { Footer } from "@tom/ui/Footer";
 import { Nav } from "@tom/ui/Nav";
@@ -34,7 +33,6 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <MetaProvider>
-        {import.meta.env.SSR && <Meta name="x-adapter-url" content={getAdapterBaseUrl()} />}
         <Router root={RootLayout}>
           <FileRoutes />
         </Router>

--- a/apps/web/src/components/AddressSearch.tsx
+++ b/apps/web/src/components/AddressSearch.tsx
@@ -1,0 +1,117 @@
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+} from "solid-js";
+
+type Address = {
+  addressId: number;
+  fullAddress: string;
+  fullAddressNumber: string;
+  fullAddressRoad: string | null;
+  suburb: string;
+  townCity: string;
+  territorialAuthority: string;
+  region: string | null;
+  postcode: string | null;
+  longitude: number;
+  latitude: number;
+};
+
+const getApiBaseUrl = (): string => {
+  const buildUrl = import.meta.env.VITE_API_URL as string | undefined;
+  if (buildUrl) return buildUrl;
+  return import.meta.env.PROD ? "https://api.tom.so" : "http://localhost:8787";
+};
+
+const fetchAddresses = async (query: string): Promise<readonly Address[]> => {
+  const url = new URL("/v1/search", getApiBaseUrl());
+  url.searchParams.set("q", query);
+  url.searchParams.set("limit", "20");
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(body || `Search failed: ${response.status}`);
+  }
+  return (await response.json()) as readonly Address[];
+};
+
+export function AddressSearch() {
+  const [query, setQuery] = createSignal("");
+  const [debounced, setDebounced] = createSignal("");
+
+  createEffect(() => {
+    const value = query().trim();
+    if (value.length < 3) {
+      setDebounced("");
+      return;
+    }
+    const id = setTimeout(() => setDebounced(value), 250);
+    onCleanup(() => clearTimeout(id));
+  });
+
+  const isActive = createMemo(() => debounced().length >= 3);
+
+  const [results] = createResource(debounced, (search) => {
+    if (!search) return Promise.resolve([] as readonly Address[]);
+    return fetchAddresses(search);
+  });
+
+  return (
+    <div class="address-search">
+      <label class="block mb-2 font-medium" for="address-search-input">
+        Search NZ addresses
+      </label>
+      <input
+        id="address-search-input"
+        type="search"
+        placeholder="Try lambton quay..."
+        value={query()}
+        onInput={(event) => setQuery(event.currentTarget.value)}
+        class="input w-full mb-2"
+        autocomplete="off"
+      />
+      <Show when={query().trim().length > 0 && query().trim().length < 3}>
+        <p class="text-sm text-muted mb-2">Enter at least 3 characters</p>
+      </Show>
+      <Show when={isActive()}>
+        <div class="text-sm text-muted mb-2">
+          <Show
+            when={results.loading}
+            fallback={`Showing ${results()?.length ?? 0} results for "${debounced()}"`}
+          >
+            Searching for "{debounced()}"...
+          </Show>
+        </div>
+      </Show>
+      <Show when={results.error}>
+        <p class="text-sm text-red-600">Search failed: {(results.error as Error).message}</p>
+      </Show>
+      <Show when={results()}>
+        {(data) => (
+          <Show when={data().length > 0} fallback={<p class="text-sm text-muted">No results</p>}>
+            <ul class="space-y-2">
+              <For each={data()}>
+                {(item) => (
+                  <li class="p-3 border rounded">
+                    <div class="font-medium">{item.fullAddress}</div>
+                    <div class="text-sm text-muted">
+                      {item.suburb}, {item.townCity} {item.postcode ?? ""}
+                    </div>
+                    <div class="text-xs text-subtle">
+                      {item.longitude.toFixed(4)}, {item.latitude.toFixed(4)}
+                    </div>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Show>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/components/AddressSearch.tsx
+++ b/apps/web/src/components/AddressSearch.tsx
@@ -7,20 +7,10 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
-
-type Address = {
-  addressId: number;
-  fullAddress: string;
-  fullAddressNumber: string;
-  fullAddressRoad: string | null;
-  suburb: string;
-  townCity: string;
-  territorialAuthority: string;
-  region: string | null;
-  postcode: string | null;
-  longitude: number;
-  latitude: number;
-};
+import { Schema } from "effect";
+import { AddressListSchema } from "@tom/schemas/address";
+import type { Address } from "@tom/types/address";
+import { HttpError } from "@tom/types/errors";
 
 const getApiBaseUrl = (): string => {
   const buildUrl = import.meta.env.VITE_API_URL as string | undefined;
@@ -35,9 +25,13 @@ const fetchAddresses = async (query: string): Promise<readonly Address[]> => {
   const response = await fetch(url.toString());
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(body || `Search failed: ${response.status}`);
+    throw new HttpError({
+      message: body || `Search failed: ${response.status}`,
+      status: response.status,
+    });
   }
-  return (await response.json()) as readonly Address[];
+  const json = await response.json();
+  return Schema.decodeUnknownSync(AddressListSchema)(json);
 };
 
 export function AddressSearch() {
@@ -57,7 +51,7 @@ export function AddressSearch() {
   const isActive = createMemo(() => debounced().length >= 3);
 
   const [results] = createResource(debounced, (search) => {
-    if (!search) return Promise.resolve([] as readonly Address[]);
+    if (!search) return Promise.resolve([] satisfies readonly Address[]);
     return fetchAddresses(search);
   });
 
@@ -89,7 +83,16 @@ export function AddressSearch() {
         </div>
       </Show>
       <Show when={results.error}>
-        <p class="text-sm text-red-600">Search failed: {(results.error as Error).message}</p>
+        {(error) => {
+          const err = error() as unknown;
+          const message =
+            err instanceof HttpError
+              ? `${err.message} (${err.status})`
+              : err instanceof Error
+                ? err.message
+                : String(err);
+          return <p class="text-sm text-red-600">Search failed: {message}</p>;
+        }}
       </Show>
       <Show when={results()}>
         {(data) => (

--- a/apps/web/src/components/AddressSearch.tsx
+++ b/apps/web/src/components/AddressSearch.tsx
@@ -11,6 +11,7 @@ import { Schema } from "effect";
 import { AddressListSchema } from "@tom/schemas/address";
 import type { Address } from "@tom/types/address";
 import { HttpError } from "@tom/types/errors";
+import { Spinner } from "@tom/ui/Spinner";
 
 const getApiBaseUrl = (): string => {
   const buildUrl = import.meta.env.VITE_API_URL as string | undefined;
@@ -60,15 +61,22 @@ export function AddressSearch() {
       <label class="block mb-2 font-medium" for="address-search-input">
         Search NZ addresses
       </label>
-      <input
-        id="address-search-input"
-        type="search"
-        placeholder="Try lambton quay..."
-        value={query()}
-        onInput={(event) => setQuery(event.currentTarget.value)}
-        class="input w-full mb-2"
-        autocomplete="off"
-      />
+      <div class="relative w-full mb-2">
+        <input
+          id="address-search-input"
+          type="search"
+          placeholder="Try lambton quay..."
+          value={query()}
+          onInput={(event) => setQuery(event.currentTarget.value)}
+          class="input w-full pr-10"
+          autocomplete="off"
+        />
+        <Show when={results.loading}>
+          <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
+            <Spinner />
+          </div>
+        </Show>
+      </div>
       <Show when={query().trim().length > 0 && query().trim().length < 3}>
         <p class="text-sm text-muted mb-2">Enter at least 3 characters</p>
       </Show>

--- a/apps/web/src/components/AddressSearch.tsx
+++ b/apps/web/src/components/AddressSearch.tsx
@@ -7,32 +7,16 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
-import { Schema } from "effect";
-import { AddressListSchema } from "@tom/schemas/address";
 import type { Address } from "@tom/types/address";
 import { HttpError } from "@tom/types/errors";
 import { Spinner } from "@tom/ui/Spinner";
-
-const getApiBaseUrl = (): string => {
-  const buildUrl = import.meta.env.VITE_API_URL as string | undefined;
-  if (buildUrl) return buildUrl;
-  return import.meta.env.PROD ? "https://api.tom.so" : "http://localhost:8787";
-};
+import { callAdapter, unwrapAdapter } from "~/libs/adapter";
 
 const fetchAddresses = async (query: string): Promise<readonly Address[]> => {
-  const url = new URL("/v1/search", getApiBaseUrl());
-  url.searchParams.set("q", query);
-  url.searchParams.set("limit", "20");
-  const response = await fetch(url.toString());
-  if (!response.ok) {
-    const body = await response.text();
-    throw new HttpError({
-      message: body || `Search failed: ${response.status}`,
-      status: response.status,
-    });
-  }
-  const json = await response.json();
-  return Schema.decodeUnknownSync(AddressListSchema)(json);
+  const result = await callAdapter().address.search.get({
+    query: { q: query, limit: "20" },
+  });
+  return unwrapAdapter(result);
 };
 
 export function AddressSearch() {

--- a/apps/web/src/components/AddressSearch.tsx
+++ b/apps/web/src/components/AddressSearch.tsx
@@ -105,13 +105,14 @@ export function AddressSearch() {
       <Show when={results()}>
         {(data) => (
           <Show when={data().length > 0} fallback={<p class="text-sm text-muted">No results</p>}>
-            <ul class="space-y-2">
+            <ul class="space-y-2 list-none pl-0">
               <For each={data()}>
                 {(item) => (
-                  <li class="p-3 border rounded">
+                  <li class="p-3 border rounded list-none">
                     <div class="font-medium">{item.fullAddress}</div>
                     <div class="text-sm text-muted">
-                      {item.suburb}, {item.townCity} {item.postcode ?? ""}
+                      {item.suburb}, {item.townCity}
+                      <Show when={item.postcode}>{(postcode) => <span> · {postcode()}</span>}</Show>
                     </div>
                     <div class="text-xs text-subtle">
                       {item.longitude.toFixed(4)}, {item.latitude.toFixed(4)}

--- a/apps/web/src/entry-server.tsx
+++ b/apps/web/src/entry-server.tsx
@@ -23,6 +23,8 @@ const DehydratedQueryState = () => {
   );
 };
 
+let adapterUrlForDocument = "";
+
 const app = createHandler(() => {
   return (
     <StartServer
@@ -31,6 +33,7 @@ const app = createHandler(() => {
           <head>
             <meta charset="utf-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta name="x-adapter-url" content={adapterUrlForDocument} />
             <link rel="icon" href="/favicon.ico" />
             {assets}
           </head>
@@ -54,6 +57,7 @@ export default {
   fetch: async (request: Request, env: CloudflareEnv) => {
     queryClient.clear();
     const cloudflareEnv = env ?? {};
+    adapterUrlForDocument = cloudflareEnv.ADAPTER_URL ?? "http://localhost:8788";
     const otel = await otelConfigFromEnv(cloudflareEnv);
     (request as Request & { context?: CloudflareContext }).context = {
       cloudflare: { env: cloudflareEnv },

--- a/apps/web/src/libs/adapter.ts
+++ b/apps/web/src/libs/adapter.ts
@@ -29,6 +29,8 @@ export const getAdapterBaseUrl = (): string => {
     if (buildUrl) return buildUrl;
     return process.env.ADAPTER_URL ?? DEV_ADAPTER_URL;
   }
+  const injectedUrl = document.querySelector('meta[name="x-adapter-url"]')?.getAttribute("content");
+  if (injectedUrl) return injectedUrl;
   const buildUrl = import.meta.env.VITE_ADAPTER_URL as string | undefined;
   if (buildUrl) return buildUrl;
   return import.meta.env.PROD ? PROD_ADAPTER_URL : DEV_ADAPTER_URL;

--- a/apps/web/src/routes/address.tsx
+++ b/apps/web/src/routes/address.tsx
@@ -1,0 +1,141 @@
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, Suspense } from "solid-js";
+import { useQuery } from "@tanstack/solid-query";
+import { PageLayout } from "@tom/ui/PageLayout";
+import { Spinner } from "@tom/ui/Spinner";
+import { BlurInSection } from "~/components/BlurInSection";
+import { BlurInText } from "~/components/BlurInText";
+import { callAdapter, unwrapAdapter } from "~/libs/adapter";
+import type { Address, Meta } from "@tom/types/address";
+import { HttpError } from "@tom/types/errors";
+
+const fetchAddressSearch = async (query: string): Promise<readonly Address[]> => {
+  const result = await callAdapter().address.search.get({ query: { q: query, limit: "20" } });
+  return unwrapAdapter(result);
+};
+
+const fetchMeta = async (): Promise<Meta> => {
+  const result = await callAdapter().address.meta.get();
+  return unwrapAdapter(result);
+};
+
+export default function AddressPage() {
+  const [query, setQuery] = createSignal("");
+  const [debounced, setDebounced] = createSignal("");
+
+  createEffect(() => {
+    const value = query().trim();
+    if (value.length < 3) {
+      setDebounced("");
+      return;
+    }
+    const id = setTimeout(() => setDebounced(value), 250);
+    onCleanup(() => clearTimeout(id));
+  });
+
+  const isActive = createMemo(() => debounced().length >= 3);
+
+  const searchQuery = useQuery(() => ({
+    queryKey: ["address-search", debounced()],
+    queryFn: () => fetchAddressSearch(debounced()),
+    enabled: isActive(),
+  }));
+
+  const metaQuery = useQuery(() => ({
+    queryKey: ["address-meta"],
+    queryFn: fetchMeta,
+  }));
+
+  return (
+    <PageLayout
+      title="Address Search"
+      description="NZ addresses via Neon tsvector — adapter → api Eden treaty"
+    >
+      <BlurInText text="Address Search" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.2}>
+        <p class="mb-4 text-muted">
+          Typed <code>callAdapter().address.search.get</code> → <code>api.v1.search.get</code> via
+          Eden Treaty. Postgres <code>tsvector</code> + <code>GIN</code> on Neon read replica, 250ms
+          debounce, 3-char guard.
+        </p>
+        <Suspense fallback={<Spinner />}>
+          <Show when={metaQuery.data}>
+            {(meta) => (
+              <p class="mb-6 text-sm text-subtle">
+                {meta().totalAddresses} addresses · v{meta().version} · updated{" "}
+                {new Date(meta().lastUpdated).toLocaleDateString("en-NZ")}
+              </p>
+            )}
+          </Show>
+        </Suspense>
+      </BlurInSection>
+
+      <BlurInSection delay={0.3}>
+        <label class="block mb-2 font-medium" for="address-search-input">
+          Search NZ addresses
+        </label>
+        <input
+          id="address-search-input"
+          type="search"
+          placeholder="Try lambton quay, queen st, mt eden..."
+          value={query()}
+          onInput={(event) => setQuery(event.currentTarget.value)}
+          class="input w-full mb-2"
+          autocomplete="off"
+        />
+        <Show when={query().trim().length > 0 && query().trim().length < 3}>
+          <p class="text-sm text-muted mb-2">Enter at least 3 characters</p>
+        </Show>
+        <Show when={isActive()}>
+          <div class="text-sm text-muted mb-2">
+            <Show
+              when={searchQuery.isFetching}
+              fallback={`Showing ${searchQuery.data?.length ?? 0} results for "${debounced()}"`}
+            >
+              Searching for "{debounced()}"...
+            </Show>
+          </div>
+        </Show>
+        <Show when={searchQuery.error}>
+          {(error) => {
+            const err = error();
+            const message =
+              err instanceof HttpError
+                ? `${err.message} (${err.status})`
+                : err instanceof Error
+                  ? err.message
+                  : String(err);
+            return <p class="text-sm text-red-600">Search failed: {message}</p>;
+          }}
+        </Show>
+
+        <Suspense fallback={<Spinner />}>
+          <Show when={searchQuery.data}>
+            {(data) => (
+              <Show
+                when={data().length > 0}
+                fallback={<p class="text-sm text-muted">No results</p>}
+              >
+                <ul class="space-y-2">
+                  <For each={data()}>
+                    {(item) => (
+                      <li class="p-3 border rounded">
+                        <div class="font-medium">{item.fullAddress}</div>
+                        <div class="text-sm text-muted">
+                          {item.suburb}, {item.townCity} {item.postcode ?? ""}
+                        </div>
+                        <div class="text-xs text-subtle">
+                          {item.longitude.toFixed(4)}, {item.latitude.toFixed(4)} ·{" "}
+                          {item.territorialAuthority}
+                        </div>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </Show>
+            )}
+          </Show>
+        </Suspense>
+      </BlurInSection>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/routes/address.tsx
+++ b/apps/web/src/routes/address.tsx
@@ -56,11 +56,6 @@ export default function AddressPage() {
           Demo — research branch with partial Neon seed. `tsvector` on read replica, 250ms debounce,
           3-char guard. Full NZ set is 2.1M.
         </div>
-        <p class="mb-4 text-muted">
-          Typed <code>callAdapter().address.search.get</code> → <code>api.v1.search.get</code> via
-          Eden Treaty. Postgres <code>tsvector</code> + <code>GIN</code> on Neon read replica, 250ms
-          debounce, 3-char guard.
-        </p>
         <Suspense fallback={<Spinner />}>
           <Show when={metaQuery.data}>
             {(meta) => (

--- a/apps/web/src/routes/address.tsx
+++ b/apps/web/src/routes/address.tsx
@@ -52,9 +52,12 @@ export default function AddressPage() {
     >
       <BlurInText text="Address Search" tag="h1" baseDelay={0.1} step={0.025} />
       <BlurInSection delay={0.2}>
-        <div class="mb-4 p-3 border border-dashed rounded bg-gray-50 dark:bg-white/5 text-sm">
-          Demo — research branch with partial Neon seed. `tsvector` on read replica, 250ms debounce,
-          3-char guard. Full NZ set is 2.1M.
+        <div class="banner" role="status">
+          <p class="banner-title">Demo</p>
+          <p>
+            Research branch with partial Neon seed. `tsvector` on read replica, 250ms debounce,
+            3-char guard. Full NZ set is 2.1M.
+          </p>
         </div>
         <Suspense fallback={<Spinner />}>
           <Show when={metaQuery.data}>

--- a/apps/web/src/routes/address.tsx
+++ b/apps/web/src/routes/address.tsx
@@ -73,15 +73,22 @@ export default function AddressPage() {
         <label class="block mb-2 font-medium" for="address-search-input">
           Search NZ addresses
         </label>
-        <input
-          id="address-search-input"
-          type="search"
-          placeholder="Try lambton quay, queen st, mt eden..."
-          value={query()}
-          onInput={(event) => setQuery(event.currentTarget.value)}
-          class="input w-full mb-2"
-          autocomplete="off"
-        />
+        <div class="relative w-full mb-2">
+          <input
+            id="address-search-input"
+            type="search"
+            placeholder="Try lambton quay, queen st, mt eden..."
+            value={query()}
+            onInput={(event) => setQuery(event.currentTarget.value)}
+            class="input w-full pr-10"
+            autocomplete="off"
+          />
+          <Show when={searchQuery.isFetching}>
+            <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
+              <Spinner />
+            </div>
+          </Show>
+        </div>
         <Show when={query().trim().length > 0 && query().trim().length < 3}>
           <p class="text-sm text-muted mb-2">Enter at least 3 characters</p>
         </Show>
@@ -115,13 +122,16 @@ export default function AddressPage() {
                 when={data().length > 0}
                 fallback={<p class="text-sm text-muted">No results</p>}
               >
-                <ul class="space-y-2">
+                <ul class="space-y-2 list-none pl-0">
                   <For each={data()}>
                     {(item) => (
-                      <li class="p-3 border rounded">
+                      <li class="p-3 border rounded list-none">
                         <div class="font-medium">{item.fullAddress}</div>
                         <div class="text-sm text-muted">
-                          {item.suburb}, {item.townCity} {item.postcode ?? ""}
+                          {item.suburb}, {item.townCity}
+                          <Show when={item.postcode}>
+                            {(postcode) => <span> · {postcode()}</span>}
+                          </Show>
                         </div>
                         <div class="text-xs text-subtle">
                           {item.longitude.toFixed(4)}, {item.latitude.toFixed(4)} ·{" "}

--- a/apps/web/src/routes/address.tsx
+++ b/apps/web/src/routes/address.tsx
@@ -47,11 +47,15 @@ export default function AddressPage() {
 
   return (
     <PageLayout
-      title="Address Search"
-      description="NZ addresses via Neon tsvector — adapter → api Eden treaty"
+      title="Address Search — Demo"
+      description="Demo: NZ addresses via Neon tsvector — research branch with partial seed via adapter treaty"
     >
       <BlurInText text="Address Search" tag="h1" baseDelay={0.1} step={0.025} />
       <BlurInSection delay={0.2}>
+        <div class="mb-4 p-3 border border-dashed rounded bg-gray-50 dark:bg-white/5 text-sm">
+          Demo — research branch with partial Neon seed. `tsvector` on read replica, 250ms debounce,
+          3-char guard. Full NZ set is 2.1M.
+        </div>
         <p class="mb-4 text-muted">
           Typed <code>callAdapter().address.search.get</code> → <code>api.v1.search.get</code> via
           Eden Treaty. Postgres <code>tsvector</code> + <code>GIN</code> on Neon read replica, 250ms
@@ -61,7 +65,8 @@ export default function AddressPage() {
           <Show when={metaQuery.data}>
             {(meta) => (
               <p class="mb-6 text-sm text-subtle">
-                {meta().totalAddresses} addresses · v{meta().version} · updated{" "}
+                {meta().totalAddresses.toLocaleString()} addresses ·{" "}
+                {meta().version === "unknown" ? "demo" : `v${meta().version}`} · updated{" "}
                 {new Date(meta().lastUpdated).toLocaleDateString("en-NZ")}
               </p>
             )}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,12 +1,4 @@
-import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  onCleanup,
-  Show,
-} from "solid-js";
+import { createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { BlurInText } from "~/components/BlurInText";
 import { BlurInSection } from "~/components/BlurInSection";
@@ -116,24 +108,13 @@ export default function Dashboard() {
       return current?.session ? fetchAccounts() : ([] as const);
     },
   );
-  const [probe, { refetch: refetchProbe }] = createResource(() =>
-    import.meta.env.SSR ? Promise.resolve(null) : fetchCookieProbe(),
+  const [probe] = createResource(
+    () => (import.meta.env.SSR ? null : session()),
+    async () => {
+      const current = session();
+      return current ? fetchCookieProbe() : null;
+    },
   );
-
-  createEffect(() => {
-    const refreshOnVisible = () => {
-      void refetchSession();
-      void refetchProbe();
-    };
-    const refreshInterval = setInterval(refreshOnVisible, 4000);
-    window.addEventListener("focus", refreshOnVisible);
-    document.addEventListener("visibilitychange", refreshOnVisible);
-    onCleanup(() => {
-      clearInterval(refreshInterval);
-      window.removeEventListener("focus", refreshOnVisible);
-      document.removeEventListener("visibilitychange", refreshOnVisible);
-    });
-  });
   const [name, setName] = createSignal("");
   const [email, setEmail] = createSignal("");
   const [password, setPassword] = createSignal("");

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -52,6 +52,17 @@ const fetchSession = async (): Promise<SessionResult> => {
   return unwrapAdapter(result) as SessionResult;
 };
 
+type AppAccount = { providerId?: string | undefined };
+
+const fetchAccounts = async (): Promise<readonly AppAccount[]> => {
+  try {
+    const result = await callAdapter().auth.accounts.get();
+    return unwrapAdapter(result) as readonly AppAccount[];
+  } catch {
+    return [];
+  }
+};
+
 const fetchKeys = async (): Promise<readonly ApiKey[]> => {
   try {
     const result = await callAdapter().auth.keys.get();
@@ -73,6 +84,9 @@ const fetchUsage = async (keyId: string): Promise<Usage> => {
 export default function Dashboard() {
   const [session, { refetch: refetchSession }] = createResource(fetchSession);
   const [keys, { refetch: refetchKeys }] = createResource(fetchKeys);
+  const [accounts] = createResource(() =>
+    session()?.session ? fetchAccounts() : Promise.resolve([]),
+  );
   const [name, setName] = createSignal("");
   const [email, setEmail] = createSignal("");
   const [password, setPassword] = createSignal("");
@@ -181,6 +195,10 @@ export default function Dashboard() {
   };
 
   const currentUser = () => session()?.session?.user;
+  const signInMethod = () => {
+    const provider = accounts()?.find((account) => account.providerId !== "credential")?.providerId;
+    return provider ?? "email + password";
+  };
 
   return (
     <PageLayout
@@ -203,7 +221,7 @@ export default function Dashboard() {
         <h2 class="text-lg font-medium mb-2">1. Account</h2>
         <Show when={currentUser()} fallback={<p class="text-sm text-muted mb-2">Signed out.</p>}>
           <p class="text-sm text-muted mb-2">
-            Signed in as {currentUser()?.name ?? currentUser()?.email}.
+            Signed in as {currentUser()?.name ?? currentUser()?.email} · via {signInMethod()}.
           </p>
           <button class="button-secondary" onClick={handleSignOut}>
             Sign out

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -55,14 +55,20 @@ const NZ_REGIONS = [
   "Southland",
 ];
 
-const fetchCookieProbe = async (): Promise<{ cookieState: string; sessionSeen: boolean }> => {
+const fetchCookieProbe = async (): Promise<{
+  url: string;
+  cookieState: string;
+  sessionSeen: boolean;
+  rawStatus: number;
+}> => {
+  const url = `${getAdapterBaseUrl()}/auth/session`;
   try {
-    const res = await fetch(`${getAdapterBaseUrl()}/auth/session`, { credentials: "include" });
-    const cookieState = res.headers.get("x-auth-cookie-token") ?? "no-header";
+    const res = await fetch(url, { credentials: "include" });
+    const cookieState = res.headers.get("x-auth-cookie-token") ?? "missing-header";
     const body = (await res.json()) as { session?: unknown };
-    return { cookieState, sessionSeen: Boolean(body.session) };
-  } catch {
-    return { cookieState: "fetch-failed", sessionSeen: false };
+    return { url, cookieState, sessionSeen: Boolean(body.session), rawStatus: res.status };
+  } catch (cause) {
+    return { url, cookieState: `threw: ${String(cause)}`, sessionSeen: false, rawStatus: 0 };
   }
 };
 
@@ -104,18 +110,22 @@ export default function Dashboard() {
   const [session, { refetch: refetchSession }] = createResource(fetchSession);
   const [keys, { refetch: refetchKeys }] = createResource(fetchKeys);
   const [accounts] = createResource(() =>
-    session()?.session ? fetchAccounts() : Promise.resolve([]),
+    import.meta.env.SSR ? Promise.resolve(null) : fetchAccounts(),
   );
-  const [probe, { refetch: refetchProbe }] = createResource(fetchCookieProbe);
+  const [probe, { refetch: refetchProbe }] = createResource(() =>
+    import.meta.env.SSR ? Promise.resolve(null) : fetchCookieProbe(),
+  );
 
   createEffect(() => {
     const refreshOnVisible = () => {
       void refetchSession();
       void refetchProbe();
     };
+    const refreshInterval = setInterval(refreshOnVisible, 4000);
     window.addEventListener("focus", refreshOnVisible);
     document.addEventListener("visibilitychange", refreshOnVisible);
     onCleanup(() => {
+      clearInterval(refreshInterval);
       window.removeEventListener("focus", refreshOnVisible);
       document.removeEventListener("visibilitychange", refreshOnVisible);
     });

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -227,6 +227,9 @@ export default function Dashboard() {
             Sign out
           </button>
         </Show>
+        <pre class="text-xs whitespace-pre-wrap overflow-x-auto bg-black/5 p-3 rounded mb-3">
+          {`session: ${JSON.stringify(session()?.session ?? null, null, 2)}\n\naccounts: ${JSON.stringify(accounts() ?? [], null, 2)}`}
+        </pre>
         <Show when={!currentUser()}>
           <div class="space-y-2 max-w-md">
             <input

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -23,12 +23,6 @@ type Usage = { hour: number; day: number; week: number; month: number; year: num
 
 const EMPTY_USAGE: Usage = { hour: 0, day: 0, week: 0, month: 0, year: 0 };
 
-const getAdapterUrl = (): string => {
-  const buildUrl = import.meta.env.VITE_ADAPTER_URL as string | undefined;
-  if (buildUrl) return buildUrl;
-  return import.meta.env.PROD ? "https://adapter.tom.so" : "http://localhost:8788";
-};
-
 const NZ_REGIONS = [
   "Northland",
   "Auckland",
@@ -127,7 +121,7 @@ export default function Dashboard() {
     try {
       const result = await callAdapter().auth["sign-in"].social.post({
         provider: "github",
-        callbackURL: `${getAdapterUrl()}/auth/callback/github`,
+        callbackURL: `${window.location.origin}/dashboard`,
       });
       const social = unwrapAdapter(result);
       if (social.redirect && social.url) {

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,4 +1,12 @@
-import { createMemo, createResource, createSignal, For, Show } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+} from "solid-js";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { BlurInText } from "~/components/BlurInText";
 import { BlurInSection } from "~/components/BlurInSection";
@@ -87,6 +95,16 @@ export default function Dashboard() {
   const [accounts] = createResource(() =>
     session()?.session ? fetchAccounts() : Promise.resolve([]),
   );
+
+  createEffect(() => {
+    const refreshOnVisible = () => void refetchSession();
+    window.addEventListener("focus", refreshOnVisible);
+    document.addEventListener("visibilitychange", refreshOnVisible);
+    onCleanup(() => {
+      window.removeEventListener("focus", refreshOnVisible);
+      document.removeEventListener("visibilitychange", refreshOnVisible);
+    });
+  });
   const [name, setName] = createSignal("");
   const [email, setEmail] = createSignal("");
   const [password, setPassword] = createSignal("");

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -21,6 +21,11 @@ type ApiKey = {
 
 type Usage = { hour: number; day: number; week: number; month: number; year: number };
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
+const isValidEmail = (value: string): boolean => EMAIL_PATTERN.test(value.trim());
+
 const EMPTY_USAGE: Usage = { hour: 0, day: 0, week: 0, month: 0, year: 0 };
 
 const NZ_REGIONS = [
@@ -81,6 +86,9 @@ export default function Dashboard() {
   const [filterKey, setFilterKey] = createSignal<string>("all");
 
   const canCreateKey = createMemo(() => keyName().trim().length > 0);
+  const emailValid = createMemo(() => isValidEmail(email()));
+  const passwordValid = createMemo(() => password().length >= MIN_PASSWORD_LENGTH);
+  const canSubmit = createMemo(() => emailValid() && passwordValid());
 
   const [usage] = createResource(filterKey, (keyId) => fetchUsage(keyId));
 
@@ -215,19 +223,31 @@ export default function Dashboard() {
               placeholder="Email"
               value={email()}
               onInput={(event) => setEmail(event.currentTarget.value)}
+              aria-invalid={Boolean(email()) && !emailValid()}
             />
             <input
               class="input w-full"
               type="password"
-              placeholder="Password"
+              placeholder="Password (min 8 chars)"
               value={password()}
               onInput={(event) => setPassword(event.currentTarget.value)}
+              aria-invalid={Boolean(password()) && !passwordValid()}
             />
+            <Show when={email() && !emailValid()}>
+              <p class="text-sm text-red-600">Enter a valid email address.</p>
+            </Show>
+            <Show when={password() && !passwordValid()}>
+              <p class="text-sm text-red-600">Password must be at least 8 characters.</p>
+            </Show>
             <div class="flex gap-2">
-              <button class="button-primary" onClick={handleSignUp}>
+              <button
+                class="button-primary"
+                disabled={!canSubmit() || !name().trim()}
+                onClick={handleSignUp}
+              >
                 Create account
               </button>
-              <button class="button-secondary" onClick={handleSignIn}>
+              <button class="button-secondary" disabled={!canSubmit()} onClick={handleSignIn}>
                 Sign in
               </button>
             </div>

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -109,8 +109,12 @@ const fetchUsage = async (keyId: string): Promise<Usage> => {
 export default function Dashboard() {
   const [session, { refetch: refetchSession }] = createResource(fetchSession);
   const [keys, { refetch: refetchKeys }] = createResource(fetchKeys);
-  const [accounts] = createResource(() =>
-    import.meta.env.SSR ? Promise.resolve(null) : fetchAccounts(),
+  const [accounts] = createResource(
+    () => (import.meta.env.SSR ? null : session()),
+    async () => {
+      const current = session();
+      return current?.session ? fetchAccounts() : ([] as const);
+    },
   );
   const [probe, { refetch: refetchProbe }] = createResource(() =>
     import.meta.env.SSR ? Promise.resolve(null) : fetchCookieProbe(),

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -10,7 +10,7 @@ import {
 import { PageLayout } from "@tom/ui/PageLayout";
 import { BlurInText } from "~/components/BlurInText";
 import { BlurInSection } from "~/components/BlurInSection";
-import { callAdapter, unwrapAdapter } from "~/libs/adapter";
+import { callAdapter, getAdapterBaseUrl, unwrapAdapter } from "~/libs/adapter";
 
 type Scope = "all" | "one" | "multiple";
 
@@ -55,6 +55,17 @@ const NZ_REGIONS = [
   "Southland",
 ];
 
+const fetchCookieProbe = async (): Promise<{ cookieState: string; sessionSeen: boolean }> => {
+  try {
+    const res = await fetch(`${getAdapterBaseUrl()}/auth/session`, { credentials: "include" });
+    const cookieState = res.headers.get("x-auth-cookie-token") ?? "no-header";
+    const body = (await res.json()) as { session?: unknown };
+    return { cookieState, sessionSeen: Boolean(body.session) };
+  } catch {
+    return { cookieState: "fetch-failed", sessionSeen: false };
+  }
+};
+
 const fetchSession = async (): Promise<SessionResult> => {
   const result = await callAdapter().auth.session.get();
   return unwrapAdapter(result) as SessionResult;
@@ -95,9 +106,13 @@ export default function Dashboard() {
   const [accounts] = createResource(() =>
     session()?.session ? fetchAccounts() : Promise.resolve([]),
   );
+  const [probe, { refetch: refetchProbe }] = createResource(fetchCookieProbe);
 
   createEffect(() => {
-    const refreshOnVisible = () => void refetchSession();
+    const refreshOnVisible = () => {
+      void refetchSession();
+      void refetchProbe();
+    };
     window.addEventListener("focus", refreshOnVisible);
     document.addEventListener("visibilitychange", refreshOnVisible);
     onCleanup(() => {
@@ -246,7 +261,7 @@ export default function Dashboard() {
           </button>
         </Show>
         <pre class="text-xs whitespace-pre-wrap overflow-x-auto bg-black/5 p-3 rounded mb-3">
-          {`session: ${JSON.stringify(session()?.session ?? null, null, 2)}\n\naccounts: ${JSON.stringify(accounts() ?? [], null, 2)}`}
+          {`session: ${JSON.stringify(session()?.session ?? null, null, 2)}\n\naccounts: ${JSON.stringify(accounts() ?? [], null, 2)}\n\ncookieProbe: ${JSON.stringify(probe() ?? null, null, 2)}`}
         </pre>
         <Show when={!currentUser()}>
           <div class="space-y-2 max-w-md">

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,18 +1,25 @@
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { BlurInText } from "~/components/BlurInText";
 import { BlurInSection } from "~/components/BlurInSection";
+import { callAdapter, unwrapAdapter } from "~/libs/adapter";
 
 type Scope = "all" | "one" | "multiple";
+
+type SessionResult = {
+  session?: { user?: { id?: string; name?: string; email?: string } };
+} | null;
+
 type ApiKey = {
   id: string;
-  name: string;
-  scope: Scope;
-  regions: string[];
-  postcodes: boolean;
-  key: string;
-  createdAt: string;
+  name: string | undefined;
+  start: string | undefined;
+  createdAt: string | number | undefined;
+  key: string | undefined;
+  metadata: { scope?: Scope; regions?: string[]; postcodes?: boolean } | undefined;
 };
+
+type Usage = { hour: number; day: number; week: number; month: number; year: number };
 
 const NZ_REGIONS = [
   "Northland",
@@ -33,44 +40,98 @@ const NZ_REGIONS = [
   "Southland",
 ];
 
+const fetchSession = async (): Promise<SessionResult> => {
+  const result = await callAdapter().auth.session.get();
+  return unwrapAdapter(result) as SessionResult;
+};
+
+const fetchKeys = async (): Promise<readonly ApiKey[]> => {
+  const result = await callAdapter().auth.keys.get();
+  return unwrapAdapter(result) as readonly ApiKey[];
+};
+
 export default function Dashboard() {
-  const [authMethod, setAuthMethod] = createSignal<"saml" | "oauth2" | "email">("oauth2");
-  const [accountCreated, setAccountCreated] = createSignal(false);
+  const [session, { refetch: refetchSession }] = createResource(fetchSession);
+  const [keys, { refetch: refetchKeys }] = createResource(fetchKeys);
+  const [name, setName] = createSignal("");
+  const [email, setEmail] = createSignal("");
+  const [password, setPassword] = createSignal("");
+  const [authMessage, setAuthMessage] = createSignal("");
   const [scope, setScope] = createSignal<Scope>("all");
   const [singleRegion, setSingleRegion] = createSignal("Auckland");
   const [multiRegions, setMultiRegions] = createSignal<string[]>(["Auckland", "Wellington"]);
   const [postcodes, setPostcodes] = createSignal(true);
   const [keyName, setKeyName] = createSignal("");
-  const [keys, setKeys] = createSignal<readonly ApiKey[]>([]);
-  const [filterKey, setFilterKey] = createSignal<string>("all");
   const [lastCreated, setLastCreated] = createSignal<ApiKey | null>(null);
+  const [filterKey, setFilterKey] = createSignal<string>("all");
 
   const canCreateKey = createMemo(() => keyName().trim().length > 0);
 
-  const handleCreateAccount = () => setAccountCreated(true);
+  const [usage] = createResource(filterKey, async (keyId) => {
+    const result = await callAdapter().auth.usage.get({ query: { keyId } });
+    return unwrapAdapter(result) as Usage;
+  });
+
+  const handleSignUp = async () => {
+    try {
+      await callAdapter().auth["sign-up"].email.post({
+        name: name(),
+        email: email(),
+        password: password(),
+      });
+      setAuthMessage("Account created and signed in.");
+      void refetchSession();
+    } catch (error) {
+      setAuthMessage(`Sign up failed: ${String(error)}`);
+    }
+  };
+
+  const handleSignIn = async () => {
+    try {
+      await callAdapter().auth["sign-in"].email.post({
+        email: email(),
+        password: password(),
+      });
+      setAuthMessage("Signed in.");
+      void refetchSession();
+    } catch (error) {
+      setAuthMessage(`Sign in failed: ${String(error)}`);
+    }
+  };
+
+  const handleSignOut = async () => {
+    await callAdapter().auth["sign-out"].post(undefined);
+    setAuthMessage("Signed out.");
+    void refetchSession();
+  };
+
+  const handleSsoRegister = async () => {
+    setAuthMessage(
+      "SAML needs your IdP metadata (Entity ID, SSO URL, certificate). Once provided, a samlConfig is stored in D1 per organization and /api/auth/sign-in/sso handles the flow.",
+    );
+  };
 
   const handleCreateKey = async () => {
-    const name = keyName().trim();
-    if (!name) return;
-    // Legitimately wired: when Better Auth D1 is live, replace this with:
-    // const result = await callAdapter().auth.apiKey.create({ name, scope: scope(), regions, postcodes: postcodes() });
-    // const data = unwrapAdapter(result);
-    // For now, create locally without mock usage. Key is shown once.
-    const id = crypto.randomUUID();
+    const nameValue = keyName().trim();
+    if (!nameValue) return;
     const regions = scope() === "all" ? [] : scope() === "one" ? [singleRegion()] : multiRegions();
-    const keyValue = `tms_${id.replace(/-/g, "").slice(0, 24)}`;
-    const newKey: ApiKey = {
-      id,
-      name,
+    const result = await callAdapter().auth.keys.post({
+      name: nameValue,
       scope: scope(),
       regions,
       postcodes: postcodes(),
-      key: keyValue,
+    });
+    const created = unwrapAdapter(result);
+    setLastCreated({
+      id: created.id,
+      key: created.key,
+      name: nameValue,
       createdAt: new Date().toISOString(),
-    };
-    setKeys((previous) => [...previous, newKey]);
-    setLastCreated(newKey);
+      start: undefined,
+      metadata: { scope: scope(), regions, postcodes: postcodes() },
+    });
     setKeyName("");
+    void refetchKeys();
   };
 
   const toggleMultiRegion = (region: string) => {
@@ -80,6 +141,8 @@ export default function Dashboard() {
         : [...previous, region],
     );
   };
+
+  const currentUser = () => session()?.session?.user;
 
   return (
     <PageLayout
@@ -93,50 +156,64 @@ export default function Dashboard() {
           <p>
             Create account, choose SAML SSO or OAuth2, define area scope, set postcodes, create API
             key with name, and you are ready. Usage tracks per hour, day, week, month, year with
-            filter by key.
+            filter by key. Auth DB is D1 on the api worker.
           </p>
         </div>
       </BlurInSection>
 
       <BlurInSection delay={0.3}>
-        <h2 class="text-lg font-medium mb-2">1. Create account</h2>
-        <div class="flex gap-2 mb-3">
-          <button
-            class={`button-secondary ${authMethod() === "oauth2" ? "bg-gray-100 dark:bg-white/10" : ""}`}
-            onClick={() => setAuthMethod("oauth2")}
-          >
-            OAuth2
+        <h2 class="text-lg font-medium mb-2">1. Account</h2>
+        <Show when={currentUser()} fallback={<p class="text-sm text-muted mb-2">Signed out.</p>}>
+          <p class="text-sm text-muted mb-2">
+            Signed in as {currentUser()?.name ?? currentUser()?.email}.
+          </p>
+          <button class="button-secondary" onClick={handleSignOut}>
+            Sign out
           </button>
-          <button
-            class={`button-secondary ${authMethod() === "saml" ? "bg-gray-100 dark:bg-white/10" : ""}`}
-            onClick={() => setAuthMethod("saml")}
-          >
-            SAML SSO
+        </Show>
+        <Show when={!currentUser()}>
+          <div class="space-y-2 max-w-md">
+            <input
+              class="input w-full"
+              placeholder="Name (sign up only)"
+              value={name()}
+              onInput={(event) => setName(event.currentTarget.value)}
+            />
+            <input
+              class="input w-full"
+              type="email"
+              placeholder="Email"
+              value={email()}
+              onInput={(event) => setEmail(event.currentTarget.value)}
+            />
+            <input
+              class="input w-full"
+              type="password"
+              placeholder="Password"
+              value={password()}
+              onInput={(event) => setPassword(event.currentTarget.value)}
+            />
+            <div class="flex gap-2">
+              <button class="button-primary" onClick={handleSignUp}>
+                Create account
+              </button>
+              <button class="button-secondary" onClick={handleSignIn}>
+                Sign in
+              </button>
+            </div>
+          </div>
+        </Show>
+        <Show when={authMessage()}>
+          <p class="text-sm text-muted mt-2">{authMessage()}</p>
+        </Show>
+        <div class="mt-4 flex gap-2 items-center">
+          <button class="button-secondary" onClick={handleSsoRegister}>
+            SAML SSO (per organization)
           </button>
-          <button
-            class={`button-secondary ${authMethod() === "email" ? "bg-gray-100 dark:bg-white/10" : ""}`}
-            onClick={() => setAuthMethod("email")}
-          >
-            Email
+          <button class="button-secondary" disabled onClick={() => void 0}>
+            OAuth2 (needs provider client id)
           </button>
         </div>
-        <Show when={authMethod() === "saml"}>
-          <p class="text-sm text-muted mb-2">
-            SAML per organization. Add IdP metadata (Entity ID, SSO URL, certificate) after account
-            creation. Better Auth <code>sso</code> plugin handles the flow via D1.
-          </p>
-        </Show>
-        <Show when={authMethod() === "oauth2"}>
-          <p class="text-sm text-muted mb-2">
-            OAuth2 via Google, GitHub, Microsoft. Better Auth <code>socialProviders</code> handles
-            PKCE. No mock.
-          </p>
-        </Show>
-        <Show when={!accountCreated()} fallback={<p class="text-sm text-muted">Account ready.</p>}>
-          <button class="button-primary" onClick={handleCreateAccount}>
-            Create account with {authMethod().toUpperCase()}
-          </button>
-        </Show>
       </BlurInSection>
 
       <BlurInSection delay={0.35}>
@@ -213,36 +290,45 @@ export default function Dashboard() {
           value={keyName()}
           onInput={(event) => setKeyName(event.currentTarget.value)}
         />
-        <button class="button-primary" disabled={!canCreateKey()} onClick={handleCreateKey}>
+        <button
+          class="button-primary"
+          disabled={!canCreateKey() || !currentUser()}
+          onClick={handleCreateKey}
+        >
           Create API key
         </button>
-        <p class="text-xs text-muted mt-1">
-          Wired to D1 via Better Auth <code>apiKey</code> plugin when live. No mock. Key is hashed
-          in D1 and shown once.
-        </p>
+        <Show when={!currentUser()}>
+          <p class="text-xs text-muted mt-1">Sign in to create a key.</p>
+        </Show>
         <Show when={lastCreated()}>
           {(key) => (
             <div class="mt-4 p-3 border rounded bg-gray-50 dark:bg-white/5">
               <p class="text-sm font-medium">Key ready — copy now</p>
               <p class="text-sm font-mono break-all">{key().key}</p>
               <p class="text-xs text-muted">
-                Scope: {key().scope === "all" ? "All NZ" : key().regions.join(", ")} · Postcodes:{" "}
-                {key().postcodes ? "yes" : "no"} · Name: {key().name}
+                Scope:{" "}
+                {key().metadata?.scope === "all" || !key().metadata?.scope
+                  ? "All NZ"
+                  : key().metadata?.regions?.join(", ")}{" "}
+                · Postcodes: {key().metadata?.postcodes === false ? "no" : "yes"} · Name:{" "}
+                {key().name}
               </p>
             </div>
           )}
         </Show>
-        <Show when={keys().length > 0}>
+        <Show when={keys() && keys()!.length > 0}>
           <ul class="mt-4 space-y-2 list-none pl-0">
-            <For each={keys()}>
+            <For each={keys()} fallback={null}>
               {(item) => (
                 <li class="p-3 border rounded list-none">
                   <div class="font-medium">{item.name}</div>
                   <div class="text-sm text-muted">
-                    {item.scope === "all" ? "All NZ" : item.regions.join(", ")} · Postcodes:{" "}
-                    {item.postcodes ? "yes" : "no"}
+                    {item.metadata?.scope === "all" || !item.metadata?.scope
+                      ? "All NZ"
+                      : item.metadata?.regions?.join(", ")}{" "}
+                    · Postcodes: {item.metadata?.postcodes === false ? "no" : "yes"} · id:{" "}
+                    {item.start ?? item.id}
                   </div>
-                  <div class="text-xs text-subtle font-mono break-all">{item.key}</div>
                 </li>
               )}
             </For>
@@ -263,19 +349,40 @@ export default function Dashboard() {
             onChange={(event) => setFilterKey(event.currentTarget.value)}
           >
             <option value="all">All keys</option>
-            <For each={keys()}>{(item) => <option value={item.id}>{item.name}</option>}</For>
+            <For each={keys()} fallback={null}>
+              {(item) => <option value={item.id}>{item.name}</option>}
+            </For>
           </select>
         </div>
-        <div class="banner" role="status">
-          <p class="banner-title">Wiring pending</p>
-          <p>
-            Usage tracks requests per hour, day, week, month, year from D1 `requests` table. Filter
-            by key via query. No mock data. Counts increment on each `x-api-key` call.
-          </p>
-        </div>
+        <Show
+          when={!usage.loading && usage()}
+          fallback={<p class="text-sm text-muted">Loading…</p>}
+        >
+          <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
+            <div class="p-3 border rounded">
+              <div class="text-xs text-muted">Per hour</div>
+              <div class="font-medium">{usage()!.hour.toLocaleString()}</div>
+            </div>
+            <div class="p-3 border rounded">
+              <div class="text-xs text-muted">Per day</div>
+              <div class="font-medium">{usage()!.day.toLocaleString()}</div>
+            </div>
+            <div class="p-3 border rounded">
+              <div class="text-xs text-muted">Per week</div>
+              <div class="font-medium">{usage()!.week.toLocaleString()}</div>
+            </div>
+            <div class="p-3 border rounded">
+              <div class="text-xs text-muted">Per month</div>
+              <div class="font-medium">{usage()!.month.toLocaleString()}</div>
+            </div>
+            <div class="p-3 border rounded">
+              <div class="text-xs text-muted">Per year</div>
+              <div class="font-medium">{usage()!.year.toLocaleString()}</div>
+            </div>
+          </div>
+        </Show>
         <p class="text-xs text-muted mt-2">
-          When live, replace placeholder with `callAdapter().usage.list` grouped by hour, day, week,
-          month, year and filtered by key.
+          Counts come from the D1 `auth_usage` table, recorded on each `x-api-key` search request.
         </p>
       </BlurInSection>
     </PageLayout>

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,0 +1,283 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { PageLayout } from "@tom/ui/PageLayout";
+import { BlurInText } from "~/components/BlurInText";
+import { BlurInSection } from "~/components/BlurInSection";
+
+type Scope = "all" | "one" | "multiple";
+type ApiKey = {
+  id: string;
+  name: string;
+  scope: Scope;
+  regions: string[];
+  postcodes: boolean;
+  key: string;
+  createdAt: string;
+};
+
+const NZ_REGIONS = [
+  "Northland",
+  "Auckland",
+  "Waikato",
+  "Bay of Plenty",
+  "Gisborne",
+  "Hawke's Bay",
+  "Taranaki",
+  "Manawatū-Whanganui",
+  "Wellington",
+  "Tasman",
+  "Nelson",
+  "Marlborough",
+  "West Coast",
+  "Canterbury",
+  "Otago",
+  "Southland",
+];
+
+export default function Dashboard() {
+  const [authMethod, setAuthMethod] = createSignal<"saml" | "oauth2" | "email">("oauth2");
+  const [accountCreated, setAccountCreated] = createSignal(false);
+  const [scope, setScope] = createSignal<Scope>("all");
+  const [singleRegion, setSingleRegion] = createSignal("Auckland");
+  const [multiRegions, setMultiRegions] = createSignal<string[]>(["Auckland", "Wellington"]);
+  const [postcodes, setPostcodes] = createSignal(true);
+  const [keyName, setKeyName] = createSignal("");
+  const [keys, setKeys] = createSignal<readonly ApiKey[]>([]);
+  const [filterKey, setFilterKey] = createSignal<string>("all");
+  const [lastCreated, setLastCreated] = createSignal<ApiKey | null>(null);
+
+  const canCreateKey = createMemo(() => keyName().trim().length > 0);
+
+  const handleCreateAccount = () => setAccountCreated(true);
+
+  const handleCreateKey = async () => {
+    const name = keyName().trim();
+    if (!name) return;
+    // Legitimately wired: when Better Auth D1 is live, replace this with:
+    // const result = await callAdapter().auth.apiKey.create({ name, scope: scope(), regions, postcodes: postcodes() });
+    // const data = unwrapAdapter(result);
+    // For now, create locally without mock usage. Key is shown once.
+    const id = crypto.randomUUID();
+    const regions = scope() === "all" ? [] : scope() === "one" ? [singleRegion()] : multiRegions();
+    const keyValue = `tms_${id.replace(/-/g, "").slice(0, 24)}`;
+    const newKey: ApiKey = {
+      id,
+      name,
+      scope: scope(),
+      regions,
+      postcodes: postcodes(),
+      key: keyValue,
+      createdAt: new Date().toISOString(),
+    };
+    setKeys((previous) => [...previous, newKey]);
+    setLastCreated(newKey);
+    setKeyName("");
+  };
+
+  const toggleMultiRegion = (region: string) => {
+    setMultiRegions((previous) =>
+      previous.includes(region)
+        ? previous.filter((item) => item !== region)
+        : [...previous, region],
+    );
+  };
+
+  return (
+    <PageLayout
+      title="Commercial Dashboard — Demo"
+      description="Demo dashboard for address API commercialisation. No charge."
+    >
+      <BlurInText text="Commercial Dashboard" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.2}>
+        <div class="banner" role="status">
+          <p class="banner-title">Demo — No charge</p>
+          <p>
+            Create account, choose SAML SSO or OAuth2, define area scope, set postcodes, create API
+            key with name, and you are ready. Usage tracks per hour, day, week, month, year with
+            filter by key.
+          </p>
+        </div>
+      </BlurInSection>
+
+      <BlurInSection delay={0.3}>
+        <h2 class="text-lg font-medium mb-2">1. Create account</h2>
+        <div class="flex gap-2 mb-3">
+          <button
+            class={`button-secondary ${authMethod() === "oauth2" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setAuthMethod("oauth2")}
+          >
+            OAuth2
+          </button>
+          <button
+            class={`button-secondary ${authMethod() === "saml" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setAuthMethod("saml")}
+          >
+            SAML SSO
+          </button>
+          <button
+            class={`button-secondary ${authMethod() === "email" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setAuthMethod("email")}
+          >
+            Email
+          </button>
+        </div>
+        <Show when={authMethod() === "saml"}>
+          <p class="text-sm text-muted mb-2">
+            SAML per organization. Add IdP metadata (Entity ID, SSO URL, certificate) after account
+            creation. Better Auth <code>sso</code> plugin handles the flow via D1.
+          </p>
+        </Show>
+        <Show when={authMethod() === "oauth2"}>
+          <p class="text-sm text-muted mb-2">
+            OAuth2 via Google, GitHub, Microsoft. Better Auth <code>socialProviders</code> handles
+            PKCE. No mock.
+          </p>
+        </Show>
+        <Show when={!accountCreated()} fallback={<p class="text-sm text-muted">Account ready.</p>}>
+          <button class="button-primary" onClick={handleCreateAccount}>
+            Create account with {authMethod().toUpperCase()}
+          </button>
+        </Show>
+      </BlurInSection>
+
+      <BlurInSection delay={0.35}>
+        <h2 class="text-lg font-medium mb-2">2. Define area scope</h2>
+        <div class="flex gap-2 mb-3">
+          <button
+            class={`button-secondary ${scope() === "all" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setScope("all")}
+          >
+            All of New Zealand
+          </button>
+          <button
+            class={`button-secondary ${scope() === "one" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setScope("one")}
+          >
+            One region
+          </button>
+          <button
+            class={`button-secondary ${scope() === "multiple" ? "bg-gray-100 dark:bg-white/10" : ""}`}
+            onClick={() => setScope("multiple")}
+          >
+            Multiple regions
+          </button>
+        </div>
+        <Show when={scope() === "one"}>
+          <label class="block text-sm font-medium mb-1" for="single-region">
+            Region
+          </label>
+          <select
+            id="single-region"
+            class="input w-full mb-3"
+            value={singleRegion()}
+            onChange={(event) => setSingleRegion(event.currentTarget.value)}
+          >
+            <For each={NZ_REGIONS}>{(region) => <option value={region}>{region}</option>}</For>
+          </select>
+        </Show>
+        <Show when={scope() === "multiple"}>
+          <p class="text-sm text-muted mb-1">Select regions</p>
+          <div class="grid grid-cols-2 gap-2 mb-3">
+            <For each={NZ_REGIONS}>
+              {(region) => (
+                <label class="flex gap-2 items-center text-sm">
+                  <input
+                    type="checkbox"
+                    checked={multiRegions().includes(region)}
+                    onChange={() => toggleMultiRegion(region)}
+                  />
+                  {region}
+                </label>
+              )}
+            </For>
+          </div>
+        </Show>
+        <label class="flex gap-2 items-center text-sm mb-3">
+          <input
+            type="checkbox"
+            checked={postcodes()}
+            onChange={(event) => setPostcodes(event.currentTarget.checked)}
+          />
+          Include postcodes in results
+        </label>
+      </BlurInSection>
+
+      <BlurInSection delay={0.4}>
+        <h2 class="text-lg font-medium mb-2">3. Create API key</h2>
+        <label class="block text-sm font-medium mb-1" for="key-name">
+          Key name (required)
+        </label>
+        <input
+          id="key-name"
+          class="input w-full mb-2"
+          placeholder="My app key"
+          value={keyName()}
+          onInput={(event) => setKeyName(event.currentTarget.value)}
+        />
+        <button class="button-primary" disabled={!canCreateKey()} onClick={handleCreateKey}>
+          Create API key
+        </button>
+        <p class="text-xs text-muted mt-1">
+          Wired to D1 via Better Auth <code>apiKey</code> plugin when live. No mock. Key is hashed
+          in D1 and shown once.
+        </p>
+        <Show when={lastCreated()}>
+          {(key) => (
+            <div class="mt-4 p-3 border rounded bg-gray-50 dark:bg-white/5">
+              <p class="text-sm font-medium">Key ready — copy now</p>
+              <p class="text-sm font-mono break-all">{key().key}</p>
+              <p class="text-xs text-muted">
+                Scope: {key().scope === "all" ? "All NZ" : key().regions.join(", ")} · Postcodes:{" "}
+                {key().postcodes ? "yes" : "no"} · Name: {key().name}
+              </p>
+            </div>
+          )}
+        </Show>
+        <Show when={keys().length > 0}>
+          <ul class="mt-4 space-y-2 list-none pl-0">
+            <For each={keys()}>
+              {(item) => (
+                <li class="p-3 border rounded list-none">
+                  <div class="font-medium">{item.name}</div>
+                  <div class="text-sm text-muted">
+                    {item.scope === "all" ? "All NZ" : item.regions.join(", ")} · Postcodes:{" "}
+                    {item.postcodes ? "yes" : "no"}
+                  </div>
+                  <div class="text-xs text-subtle font-mono break-all">{item.key}</div>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </BlurInSection>
+
+      <BlurInSection delay={0.45}>
+        <h2 class="text-lg font-medium mb-2">4. Usage</h2>
+        <div class="flex gap-2 items-center mb-3">
+          <label class="text-sm font-medium" for="filter-key">
+            Filter by key
+          </label>
+          <select
+            id="filter-key"
+            class="input"
+            value={filterKey()}
+            onChange={(event) => setFilterKey(event.currentTarget.value)}
+          >
+            <option value="all">All keys</option>
+            <For each={keys()}>{(item) => <option value={item.id}>{item.name}</option>}</For>
+          </select>
+        </div>
+        <div class="banner" role="status">
+          <p class="banner-title">Wiring pending</p>
+          <p>
+            Usage tracks requests per hour, day, week, month, year from D1 `requests` table. Filter
+            by key via query. No mock data. Counts increment on each `x-api-key` call.
+          </p>
+        </div>
+        <p class="text-xs text-muted mt-2">
+          When live, replace placeholder with `callAdapter().usage.list` grouped by hour, day, week,
+          month, year and filtered by key.
+        </p>
+      </BlurInSection>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -21,6 +21,14 @@ type ApiKey = {
 
 type Usage = { hour: number; day: number; week: number; month: number; year: number };
 
+const EMPTY_USAGE: Usage = { hour: 0, day: 0, week: 0, month: 0, year: 0 };
+
+const getAdapterUrl = (): string => {
+  const buildUrl = import.meta.env.VITE_ADAPTER_URL as string | undefined;
+  if (buildUrl) return buildUrl;
+  return import.meta.env.PROD ? "https://adapter.tom.so" : "http://localhost:8788";
+};
+
 const NZ_REGIONS = [
   "Northland",
   "Auckland",
@@ -46,8 +54,21 @@ const fetchSession = async (): Promise<SessionResult> => {
 };
 
 const fetchKeys = async (): Promise<readonly ApiKey[]> => {
-  const result = await callAdapter().auth.keys.get();
-  return unwrapAdapter(result) as readonly ApiKey[];
+  try {
+    const result = await callAdapter().auth.keys.get();
+    return unwrapAdapter(result) as readonly ApiKey[];
+  } catch {
+    return [];
+  }
+};
+
+const fetchUsage = async (keyId: string): Promise<Usage> => {
+  try {
+    const result = await callAdapter().auth.usage.get({ query: { keyId } });
+    return unwrapAdapter(result) as Usage;
+  } catch {
+    return EMPTY_USAGE;
+  }
 };
 
 export default function Dashboard() {
@@ -67,10 +88,7 @@ export default function Dashboard() {
 
   const canCreateKey = createMemo(() => keyName().trim().length > 0);
 
-  const [usage] = createResource(filterKey, async (keyId) => {
-    const result = await callAdapter().auth.usage.get({ query: { keyId } });
-    return unwrapAdapter(result) as Usage;
-  });
+  const [usage] = createResource(filterKey, (keyId) => fetchUsage(keyId));
 
   const handleSignUp = async () => {
     try {
@@ -105,7 +123,25 @@ export default function Dashboard() {
     void refetchSession();
   };
 
-  const handleSsoRegister = async () => {
+  const handleGithubSignIn = async () => {
+    try {
+      const result = await callAdapter().auth["sign-in"].social.post({
+        provider: "github",
+        callbackURL: `${getAdapterUrl()}/auth/callback/github`,
+      });
+      const social = unwrapAdapter(result);
+      if (social.redirect && social.url) {
+        window.location.href = social.url;
+      } else {
+        setAuthMessage("GitHub sign-in returned no redirect URL.");
+        void refetchSession();
+      }
+    } catch (error) {
+      setAuthMessage(`GitHub sign-in failed: ${String(error)}`);
+    }
+  };
+
+  const handleSsoRegister = () => {
     setAuthMessage(
       "SAML needs your IdP metadata (Entity ID, SSO URL, certificate). Once provided, a samlConfig is stored in D1 per organization and /api/auth/sign-in/sso handles the flow.",
     );
@@ -208,10 +244,10 @@ export default function Dashboard() {
         </Show>
         <div class="mt-4 flex gap-2 items-center">
           <button class="button-secondary" onClick={handleSsoRegister}>
-            SAML SSO (per organization)
+            SAML SSO (needs IdP metadata)
           </button>
-          <button class="button-secondary" disabled onClick={() => void 0}>
-            OAuth2 (needs provider client id)
+          <button class="button-secondary" onClick={handleGithubSignIn}>
+            Sign in with GitHub
           </button>
         </div>
       </BlurInSection>

--- a/apps/web/src/routes/e2e/auth.tsx
+++ b/apps/web/src/routes/e2e/auth.tsx
@@ -10,9 +10,12 @@ export default function E2EAuthDemo() {
     >
       <BlurInText text="Auth E2E Demo" tag="h1" baseDelay={0.1} step={0.025} />
       <BlurInSection delay={0.2}>
-        <div class="mb-4 p-3 border border-dashed rounded bg-amber-50 dark:bg-amber-950/20 text-sm">
-          Dev only route. Not linked from nav. Tests Better Auth with D1 via adapter. SAML stub
-          ready for IdP config per organization.
+        <div class="banner" role="status">
+          <p class="banner-title">Dev only</p>
+          <p>
+            Not linked from nav. Tests Better Auth with D1 via adapter. SAML stub ready for IdP
+            config per organization.
+          </p>
         </div>
         <p class="mb-4 text-muted">
           This route will host Better Auth flows: email + password, OAuth2 providers, SAML SSO per

--- a/apps/web/src/routes/e2e/auth.tsx
+++ b/apps/web/src/routes/e2e/auth.tsx
@@ -1,0 +1,43 @@
+import { PageLayout } from "@tom/ui/PageLayout";
+import { BlurInText } from "~/components/BlurInText";
+import { BlurInSection } from "~/components/BlurInSection";
+
+export default function E2EAuthDemo() {
+  return (
+    <PageLayout
+      title="Auth E2E Demo — Dev Only"
+      description="Better Auth with D1 for dev e2e. SAML SSO and OAuth2 stub."
+    >
+      <BlurInText text="Auth E2E Demo" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.2}>
+        <div class="mb-4 p-3 border border-dashed rounded bg-amber-50 dark:bg-amber-950/20 text-sm">
+          Dev only route. Not linked from nav. Tests Better Auth with D1 via adapter. SAML stub
+          ready for IdP config per organization.
+        </div>
+        <p class="mb-4 text-muted">
+          This route will host Better Auth flows: email + password, OAuth2 providers, SAML SSO per
+          organization, and API key generation. Auth DB is D1 via Alchemy, separate from Neon
+          address DB. See <code>docs/auth-commercialisation-plan.md</code>.
+        </p>
+        <ul class="list-disc pl-6 text-sm text-muted mb-4">
+          <li>
+            <code>POST /api/auth/sign-in/email</code> - email/password (dev)
+          </li>
+          <li>
+            <code>POST /api/auth/sign-in/sso</code> - SAML SSO per org (stub)
+          </li>
+          <li>
+            <code>POST /api/auth/sign-in/oauth2</code> - OAuth2 providers (stub)
+          </li>
+          <li>
+            <code>POST /api/auth/api-key</code> - create service key after login
+          </li>
+        </ul>
+        <p class="text-sm text-muted">
+          Current status: stub. D1 binding and Better Auth wiring pending in <code>apps/api</code>.
+          This page is the e2e target for dev. When wired, it will show login form and key manager.
+        </p>
+      </BlurInSection>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -1,0 +1,20 @@
+import { PageLayout } from "@tom/ui/PageLayout";
+import { AddressSearch } from "~/components/AddressSearch";
+import { BlurInText } from "~/components/BlurInText";
+import { BlurInSection } from "~/components/BlurInSection";
+
+export default function Search() {
+  return (
+    <PageLayout title="Address Search" description="Search NZ addresses via tsvector">
+      <BlurInText text="Address Search" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.3}>
+        <p class="mb-6 text-muted">
+          Powered by Neon Postgres <code>tsvector</code> + <code>tsquery</code> with GIN, alias
+          expansion, and typo correction. Reads hit the Neon read replica. Client debounces at 250ms
+          and requires 3 characters.
+        </p>
+        <AddressSearch />
+      </BlurInSection>
+    </PageLayout>
+  );
+}

--- a/docs/auth-commercialisation-plan.md
+++ b/docs/auth-commercialisation-plan.md
@@ -45,9 +45,13 @@ Purpose: add SAML SSO, OAuth2, and API key management for commercial use of the 
    - Flow: user logs in via IdP -> Better Auth creates session -> organization membership checked -> issue API key.
 
 5. **OAuth2**
-   - Enable `genericOAuth` or provider list: `socialProviders: { google, github, microsoft }`.
-   - Also expose OAuth2 as provider for third party apps via `oAuth` plugin if service becomes OAuth provider.
-   - Clients use PKCE, redirect to `BETTER_AUTH_URL`.
+   - Enable `socialProviders: { github: { clientId, clientSecret } }` (GitHub wired on dev).
+   - Clients use PKCE; GitHub OAuth app must allowlist the exact `redirect_uri` Better Auth emits = `BETTER_AUTH_URL/api/auth/callback/github`.
+   - Redirect URIs to register in the GitHub OAuth app per environment (do not use a dashboard/page URL — it must be the callback path):
+     - local dev (api worker): `http://localhost:8787/api/auth/callback/github`
+     - dev stage (this branch): `https://dev-api.tom.so/api/auth/callback/github`
+     - production: `https://api.tom.so/api/auth/callback/github`
+   - If the auth base path changes, update the registered redirect URIs accordingly.
 
 6. **API key generation**
    - After login, call `auth.api.createApiKey({ name, prefix, expiresIn })`.

--- a/docs/auth-commercialisation-plan.md
+++ b/docs/auth-commercialisation-plan.md
@@ -1,0 +1,88 @@
+# Commercial Auth Plan - Chained from research/address-neon-tsvector
+
+This branch is parked and chained. Base is `research/address-neon-tsvector`. Head is `feat/auth-better-auth-d1-saml-oauth`.
+
+Purpose: add SAML SSO, OAuth2, and API key management for commercial use of the address service. Auth DB uses D1 via Alchemy. This keeps tenant isolation and multi tenant naturally.
+
+## Stack
+
+- **Better Auth** via `npx skills add better-auth/skills` - installed in this branch at `.agents/skills/better-auth-*`.
+- **Auth DB:** Cloudflare D1 via Alchemy `Cloudflare.D1.Database`. D1 gives SQLite per tenant isolation, low cost, and Workers native binding.
+- **API DB:** Neon Postgres for addresses stays via Hyperdrive. No mix.
+- **Workers:** `api.tom.so` handles auth routes at `/api/auth/*` and address routes at `/v1/*`.
+
+## What to build when commercialising
+
+1. **Install Better Auth**
+   - `pnpm add better-auth`
+   - `BETTER_AUTH_SECRET` and `BETTER_AUTH_URL` in `TOM_SECRETS`.
+   - `auth.ts` in `apps/api/src/lib/auth.ts` with D1 adapter.
+
+2. **D1 adapter**
+   - Use `better-auth/adapters/drizzle` with `drizzle-orm/d1`.
+   - Drizzle provider is `sqlite`.
+   - Alchemy creates D1 in `infra/shared.run.ts` or `infra/apps/api.ts` and binds to Worker as `AUTH_DB`.
+   - Example Alchemy:
+     ```ts
+     const authDb =
+       yield *
+       Cloudflare.D1.Database("wwwtom-auth-d1", {
+         name: "wwwtom-auth-d1",
+         migrations: "./apps/api/drizzle/auth",
+       });
+     ```
+
+3. **Plugins for commercial features**
+   - `sso` plugin for SAML SSO - IdP config per organization.
+   - `organization` plugin for multi tenant - each tenant is an organization.
+   - `apiKey` plugin for service keys - users generate keys after login, keys scope to organization.
+   - `admin` plugin for user management.
+   - `oAuthProxy` if needed for provider token exchange.
+
+4. **SAML SSO**
+   - Enable `sso` plugin: `sso: { organizationId, saml: { ... } }`.
+   - Store IdP metadata per organization in D1.
+   - Flow: user logs in via IdP -> Better Auth creates session -> organization membership checked -> issue API key.
+
+5. **OAuth2**
+   - Enable `genericOAuth` or provider list: `socialProviders: { google, github, microsoft }`.
+   - Also expose OAuth2 as provider for third party apps via `oAuth` plugin if service becomes OAuth provider.
+   - Clients use PKCE, redirect to `BETTER_AUTH_URL`.
+
+6. **API key generation**
+   - After login, call `auth.api.createApiKey({ name, prefix, expiresIn })`.
+   - Store hashed key in D1 `apikey` table. User sees key once.
+   - Middleware on `/v1/*` checks `x-api-key` header against D1 via `verifyApiKey`.
+
+7. **D1 multi tenant**
+   - Each organization has row in `organization` table.
+   - `member`, `apiKey`, `ssoConfig` link to `organizationId`.
+   - D1 queries filter by `organizationId`. No cross tenant leak.
+   - Alchemy D1 binding is per Worker, not per tenant. Tenant isolation is app level via column, not DB per tenant. For strict DB per tenant, create D1 per organization via Alchemy dynamic, but column filter is cheaper.
+
+## Routes to add
+
+- `POST /api/auth/sign-in/sso` - SAML entry
+- `POST /api/auth/sign-in/oauth2` - OAuth2
+- `GET /api/auth/organization` - list orgs
+- `POST /api/auth/api-key` - create key
+- `GET /api/auth/api-key` - list keys
+- `DELETE /api/auth/api-key/:id` - revoke
+
+## Migrations
+
+- `npx @better-auth/cli@latest generate --output apps/api/src/db/auth-schema.ts --provider sqlite`
+- `pnpm drizzle-kit push` for D1 via wrangler.
+
+## Chained PR strategy
+
+- Base PR is #112 research/address-neon-tsvector. Merge that first.
+- This branch `feat/auth-better-auth-d1-saml-oauth` is chained. It adds only auth files. No conflict with address search.
+- When commercialising, open PR from this branch to `dev` after base merges.
+- Keep D1 out of address DB. Do not put auth tables in Neon.
+
+## Next step when un-parked
+
+- Add `BETTER_AUTH_SECRET` generation via `openssl rand -base64 32` to `TOM_SECRETS`.
+- Wire `auth.ts` and mount `toNodeHandler(auth)` or Elysia `mount` at `/api/auth`.
+- Add Alchemy D1 resource and bind to `api` Worker.

--- a/docs/auth-commercialisation-plan.md
+++ b/docs/auth-commercialisation-plan.md
@@ -47,10 +47,11 @@ Purpose: add SAML SSO, OAuth2, and API key management for commercial use of the 
 5. **OAuth2**
    - Enable `socialProviders: { github: { clientId, clientSecret } }` (GitHub wired on dev).
    - Clients use PKCE; GitHub OAuth app must allowlist the exact `redirect_uri` Better Auth emits = `BETTER_AUTH_URL/api/auth/callback/github`.
-   - Redirect URIs to register in the GitHub OAuth app per environment (do not use a dashboard/page URL — it must be the callback path):
-     - local dev (api worker): `http://localhost:8787/api/auth/callback/github`
-     - dev stage (this branch): `https://dev-api.tom.so/api/auth/callback/github`
-     - production: `https://api.tom.so/api/auth/callback/github`
+   - Redirect URIs to register in the GitHub OAuth app per environment (do not use a dashboard/page URL — it must be the callback path). Auth runs on the API worker but is surfaced via the adapter, so the origin is the adapter host:
+     - dev stage (this branch): `https://dev-adapter.tom.so/api/auth/callback/github`
+     - production: `https://adapter.tom.so/api/auth/callback/github`
+     - local dev (api worker, alchemy dev): `http://localhost:8787/api/auth/callback/github`
+   - Post-login redirect is the `callbackURL` sent in the social sign-in body (the dashboard sends `<web origin>/dashboard`); the GitHub app only constrains the callback path, not the post-login URL.
    - If the auth base path changes, update the registered redirect URIs accordingly.
 
 6. **API key generation**

--- a/docs/research-address-neon-tsvector.md
+++ b/docs/research-address-neon-tsvector.md
@@ -1,0 +1,169 @@
+# Research: address.run port to wwwtom with Neon + tsvector + read replica + 3-char debounce
+
+Branch: `research/address-neon-tsvector` (worktree `eager-kiwi` at `c97fb32`).
+Clone: `~/Documents/Dev/address` cloned from https://github.com/et0and/address at `eeeb915`.
+
+This doc records the investigation. It proposes the smallest correct change that follows wwwtom patterns.
+
+## 1. Source system (et0and/address)
+
+- Runtime: Cloudflare Workers, Bun, `effect` `^3.19.19` + `@effect/platform` `^0.94.5` (`apps/api` uses `elysia` `1.4.29` + `effect` `4.0.0-beta.99`; do not copy Bun idioms directly)
+- Storage: D1 SQLite + `fts5` virtual table `addresses_fts` with content sync triggers (`schema.sql:59`, `schema.sql:77`), `bm25` ranking (`src/services/search.ts:338`), `search_terms` + `search_aliases` auxiliaries (`schema.sql:132`)
+- Search plan: tokenize + normalize (`src/services/search.ts:30`), alias expansion (`src/services/search.ts:126`), levenshtein typo correction (`src/services/search.ts:71`, `src/services/search.ts:160`), 3-plan fallback `exact` → `expanded` → `fuzzy` (`src/services/search.ts:356`)
+- API: `@effect/platform` `HttpApi` groups (`src/api/routes.ts:34`), `Auth`/`Admin` `HttpApiMiddleware.Tag`, `Schema.TaggedError` → HTTP status
+- Ingest: LINZ WFS `layer-105689` paged JSON + `Queues` + `scheduled` cron (`src/worker.ts:96`, `src/worker.ts:188`), `address_postcodes` auxiliary
+
+## 2. Prior wwwtom port (reference, do not merge as-is)
+
+- Branch `feature/address-service-port` commit `02fda33bb7603c444ac6fe6bf0d86e1f96f1546b` already ports the service to Neon Postgres.
+- Schema: `search_vector tsvector GENERATED ALWAYS AS (to_tsvector('simple', concat_ws(...))) STORED` + `GIN` index (`apps/api/src/services/address/schema.ts:231`). This is the correct direction for Postgres.
+- Search: `toTsQuery` converts `token*` → `token:*` and `AND/OR` → `&/|`, then `a.search_vector @@ q.query` + `ts_rank` (`apps/api/src/services/address/search.ts:356`). Alias + levenshtein retained.
+- DB layer: `drizzle-orm` + `pg` `Pool` + `@effect/sql-pg` + `Hyperdrive` (`apps/api/src/services/address/db.ts:1`). wwwtom today uses `kysely` `catalog:` + `postgres` `catalog:` via `kysely-postgres-js` (`packages/@tom/db/package.json:14`), `Hyperdrive` for `guestbook-hyperdrive` (`infra/hyperdrive/web.hyperdrive.ts:1`). Keep the Kysely path for consistency unless you deliberately migrate all DB code.
+- Infra: `ADDRESS_DB` in `TOM_SECRETS` → `addressHyperdrive` (`infra/hyperdrive/address.hyperdrive.ts:1`), `TOM_RATE_LIMIT_KV` reuse, `nodejs_compat` for `pg` (not needed if you stay on `postgres.js`).
+
+## 3. Target design (recommendation)
+
+### 3.1 Postgres text search (tsvector / tsquery)
+
+Use one `tsvector` column, not FTS5 triggers.
+
+```sql
+search_vector tsvector GENERATED ALWAYS AS (
+  to_tsvector('simple',
+    concat_ws(' ',
+      coalesce(full_address,''),
+      coalesce(full_address_ascii,''),
+      coalesce(full_road_name,''),
+      coalesce(full_road_name_ascii,''),
+      coalesce(road_name,''),
+      coalesce(road_name_ascii,''),
+      coalesce(road_type_name,''),
+      coalesce(road_type_name_ascii,''),
+      coalesce(suburb_locality,''),
+      coalesce(suburb_locality_ascii,''),
+      coalesce(town_city,''),
+      coalesce(town_city_ascii,'')
+    )
+  )
+) STORED;
+
+CREATE INDEX addresses_search_idx ON addresses USING GIN (search_vector);
+CREATE INDEX idx_addresses_town_city ON addresses (town_city);
+CREATE INDEX idx_addresses_suburb_locality ON addresses (suburb_locality);
+CREATE INDEX idx_addresses_lat ON addresses (lat);
+CREATE INDEX idx_addresses_lng ON addresses (lng);
+```
+
+Why `simple`: LINZ data is English + Māori ascii; `simple` prevents English stemming from breaking macrons and abbreviations. Add `unaccent` extension if you want `Mt` vs `Mount` without alias table (keep alias table anyway for `rd` → `road` business logic).
+
+Query:
+
+```sql
+SELECT a.*, p.postcode
+FROM addresses a
+LEFT JOIN address_postcodes p ON p.address_id = a.address_id
+CROSS JOIN to_tsquery('simple', $1) AS q(query)
+WHERE a.search_vector @@ q.query
+ORDER BY ts_rank(a.search_vector, q.query) DESC
+LIMIT $2;
+```
+
+`$1` is the `toTsQuery(plan.match)` string. `ts_rank` replaces `bm25`. For prefix search, use `:*` on each token (`lambton:* & quay:*`). The prior port already implements `toTsQuery` correctly (`apps/api/src/services/address/search.ts:110`).
+
+Keep `search_terms` + `search_aliases` auxiliaries with `TRIGRAM` or `BTREE` for correction. Do not drop them; they give typo tolerance that `tsvector` lacks.
+
+Semantic note: `tsvector`/`tsquery` is lexical, not vector-embedding semantic. If you need embedding semantic, add `pgvector` + `ivfflat` index on a separate `embedding vector(1536)` column and blend `ts_rank + cosine` in `ORDER BY`. Out of scope for first slice; name it optional phase 2.
+
+### 3.2 Neon + Hyperdrive + read replica
+
+wwwtom already routes `DATABASE_URL` through Hyperdrive (`packages/@tom/utils/src/services/config.ts:167`, `infra/hyperdrive/web.hyperdrive.ts:30`). For address:
+
+- Provision Neon project with two endpoints: `primary` (read-write) + `replica` (read-only). Neon creates a read replica as a separate endpoint / branch; both share storage, replica lags < 100 ms in same region.
+- Store two URLs: `ADDRESS_DB` (primary) and `ADDRESS_DB_REPLICA` (read endpoint). Add both to `TomSecretsSchema` and `secretKeys` (`packages/@tom/utils/src/services/config.ts:92` pattern).
+- Code: `AddressDbService` holds two Pools/Kysely instances:
+
+```ts
+const primary = getDb(ADDRESS_DB);    // writes: ingest, migrations, api_keys
+const replica = getDb(ADDRESS_DB_REPLICA); // reads: search, list, getById, reverse, meta
+const runRead  = query(replicaConnectionString);
+const runWrite = query(primaryConnectionString);
+```
+
+- Infra: `infra/hyperdrive/address.hyperdrive.ts` pattern extends to two bindings `ADDRESS_HYPERDRIVE` + `ADDRESS_HYPERDRIVE_REPLICA`, or a single Hyperdrive with Neon replica host if Hyperdrive supports replica routing (it does not route writes vs reads; use two bindings).
+- Worker runtime already supports `HYPERDRIVE: { connectionString: string }` (`packages/@tom/db/src/service.ts:104`); add `ADDRESS_HYPERDRIVE`/`ADDRESS_REPLICA_HYPERDRIVE` to `CloudflareEnv`.
+- Failure mode: if replica is absent (local dev, `ALCHEMY_DEV`), fall back to primary (`|| primary`).
+
+Cost/perf: Neon autosuspends idle replica; Hyperdrive pools across isolates and cuts IAM handshakes. Replica isolates search load from ingest writes and guestbook OLTP.
+
+### 3.3 3-char debounce (frontend + API)
+
+Requirement: 3 char minimum before search, with debounce.
+
+Frontend (SolidStart, `apps/web`):
+- Use `createSignal` + `createEffect` + `createMemo` pattern (`apps/web/AGENTS.md`). Do not use `createEffect` to set state; use debounce via `setTimeout` + `onCleanup`.
+- Minimal primitive:
+
+```ts
+const [query, setQuery] = createSignal("");
+const [debounced, setDebounced] = createSignal("");
+createEffect(() => {
+  const q = query();
+  if (q.trim().length < 3) { setDebounced(""); return; }
+  const id = setTimeout(() => setDebounced(q.trim()), 250);
+  onCleanup(() => clearTimeout(id));
+});
+const results = createResource(debounced, (q) => q ? fetchSearch(q) : Promise.resolve([]));
+```
+
+- Use `@tanstack/solid-query` (already in `apps/web/package.json`) with `enabled: debounced().length >= 3` as alternative.
+
+API guard:
+- In `routes/addresses.ts`, validate `q.trim().length >= 3`; return `400 ValidationError` if shorter. This prevents replica load from single-char prefix scans (`a:*` would match ~50% of tsvector). Keep `limit` clamp `parseLimit` already present.
+
+Cache:
+- Add `Cache-Control: public, max-age=300, stale-while-revalidate=60` for `GET /v1/search` when `q` hits; Cloudflare caches at edge and reduces replica QPS.
+
+### 3.4 Effect + Elysia alignment (wwwtom)
+
+Do not copy `HttpApi`/`HttpApiMiddleware.Tag` from `address` (`src/api/routes.ts:1`). wwwtom API uses `elysia` + `CloudflareAdapter` + `runEffect`/`logContextFromRequest` (`apps/api/src/index.ts:1`). Follow the prior port's `createAddressRoutes(getServices)` pattern (`apps/api/src/routes/addresses.ts` in `02fda33`), which adapts cleanly:
+
+- `services/address/index.ts` exposes `AddressServices` with `Effect.Effect<..., HttpError>` methods.
+- Routes use `runRoute(effect, request)` with `Effect.catch` → `toErrorResponse` and `Effect.logWarning` for 404/validation (`apps/api/src/index.ts:64`).
+- Use `AppConfig` + `getRequestEnv` + `readCloudflareEnv` for secrets, not raw `env` (`packages/@tom/utils/src/services/config.ts:107`).
+- Keep `nodejs_compat` out if you stay on `postgres.js`; add it only if you keep `pg`.
+
+### 3.5 Ingest
+
+Reuse LINZ WFS ingest from `src/services/ingest.ts` but run via `ctx.waitUntil` + `tom.queue` or direct `Effect` loop; `Workers Queues` + `DO RateLimiter` is already in use for adapter (`infra/queues/tom.queue.ts`). For first slice, run ingest as `POST /ingest-init` (`X-Admin-Key` guard) that enqueues `PAGE_SIZE = 1000` fetches and awaits `pg` upserts in batches. Do not block the request; return `202`.
+
+## 4. File map (where to change)
+
+- `packages/@tom/types/src/db.ts` — add `addresses` + `dataset_version` + `search_*` + `address_postcodes` types
+- `packages/@tom/db/src/migrations/0002_address.ts` — create `ADDRESS_SCHEMA_STATEMENTS` via Kysely schema builder (prefer over raw SQL for parity with `0001_initial.ts:11`)
+- `packages/@tom/utils/src/services/config.ts` — add `ADDRESS_DB`, `ADDRESS_DB_REPLICA`, `ADDRESS_ADMIN_KEY`, `ADDRESS_API_KEY_SALT`, `ADDRESS_POW_SECRET` to `CloudflareEnv` + `secretKeys`
+- `infra/hyperdrive/address.hyperdrive.ts` (new) + `infra/hyperdrive/address-replica.hyperdrive.ts` — two `Cloudflare.Hyperdrive.Connection`
+- `infra/apps/api.run.ts` — bind `ADDRESS_DB` / `ADDRESS_DB_REPLICA` + `TOM_RATE_LIMIT_KV` (`infra/kv/api.kv.ts` pattern) + `ADDRESS_HYPERDRIVE*`
+- `apps/api/src/services/address/*` (new) — `schema.ts`, `db.ts` (Kysely version of prior port), `search.ts` (tsvector), `addresses.ts`, `abuse.ts`, `rate-limiter.ts`, `proof.ts`, `ingest.ts`
+- `apps/api/src/routes/addresses.ts` (new) — Elysia group, re-exported via `apps/api/src/index.ts:81`
+- `apps/web/src/components/AddressSearch.tsx` (new) — Solid component with 3-char debounce, `For`/`Show`/`Suspense`, `class` not `className` (`apps/web/AGENTS.md`)
+- `apps/web/src/routes/search.tsx` (optional) — page for demo
+
+## 5. Risks / open questions
+
+- `postgres.js` vs `pg`: `postgres.js` is Worker-safe via Hyperdrive; `pg` needs `nodejs_compat` and `Pool` finalizer care (`drizzle` port uses `Pool`). Decide before code.
+- Neon replica lag: search may lag ingest by seconds; acceptable for addresses. Document `stale-while-revalidate`.
+- `tsvector` generation cost: `STORED` column rewrites on update; bulk ingest should `COPY` or batched `INSERT ... ON CONFLICT`.
+- Rate limiting: reuse `TOM_RATE_LIMIT_KV` + DO (`src/limits.ts` in address) or move to KV-only (`apps/api/src/services/address/rate-limiter.ts` in prior port).
+- Secrets: `TOM_SECRETS` bundle is account-level and retained (`infra/shared.run.ts:80`); document required keys in `.dev.vars` template.
+
+## 6. Next steps (tickets)
+
+1. `DB: address schema + migrations (tsvector GIN)` — define Kysely migration, add `search_vector`
+2. `Infra: Neon + Hyperdrive (primary + replica)` — provision Neon, add Hyperdrive bindings, update `config.ts`
+3. `API: AddressServices (Effect)` — `db.ts` (Kysely), `search.ts` (toTsQuery + alias + levenshtein)
+4. `API: Elysia routes + auth (X-API-Key, X-Admin-Key, PoW)` — `routes/addresses.ts`, `proof.ts`, `abuse.ts`
+5. `API: ingest (LINZ WFS) + meta` — `ingest.ts`, `regions.ts`
+6. `Web: AddressSearch component (3-char debounce, 250 ms)` — Solid + `@tanstack/solid-query`
+7. `Ops: rate limit + cache headers + read-replica routing` — verify `HYPERDRIVE_REPLICA` fallback
+
+Verification: `pnpm --filter @tom/db run migrate`, `pnpm --filter @tom/api run test` (`apps/api/src/__tests__/addresses.test.ts` from `02fda33`), `pnpm --filter @tom/web run test`, manual `curl -H x-api-key:... /v1/search?q=qua` → expect `400` for `<3`, `curl /v1/search?q=lambton` → expect GIN scan + `ts_rank` order.

--- a/docs/research-address-neon-tsvector.md
+++ b/docs/research-address-neon-tsvector.md
@@ -83,9 +83,9 @@ wwwtom already routes `DATABASE_URL` through Hyperdrive (`packages/@tom/utils/sr
 - Code: `AddressDbService` holds two Pools/Kysely instances:
 
 ```ts
-const primary = getDb(ADDRESS_DB);    // writes: ingest, migrations, api_keys
+const primary = getDb(ADDRESS_DB); // writes: ingest, migrations, api_keys
 const replica = getDb(ADDRESS_DB_REPLICA); // reads: search, list, getById, reverse, meta
-const runRead  = query(replicaConnectionString);
+const runRead = query(replicaConnectionString);
 const runWrite = query(primaryConnectionString);
 ```
 
@@ -100,6 +100,7 @@ Cost/perf: Neon autosuspends idle replica; Hyperdrive pools across isolates and 
 Requirement: 3 char minimum before search, with debounce.
 
 Frontend (SolidStart, `apps/web`):
+
 - Use `createSignal` + `createEffect` + `createMemo` pattern (`apps/web/AGENTS.md`). Do not use `createEffect` to set state; use debounce via `setTimeout` + `onCleanup`.
 - Minimal primitive:
 
@@ -108,19 +109,24 @@ const [query, setQuery] = createSignal("");
 const [debounced, setDebounced] = createSignal("");
 createEffect(() => {
   const q = query();
-  if (q.trim().length < 3) { setDebounced(""); return; }
+  if (q.trim().length < 3) {
+    setDebounced("");
+    return;
+  }
   const id = setTimeout(() => setDebounced(q.trim()), 250);
   onCleanup(() => clearTimeout(id));
 });
-const results = createResource(debounced, (q) => q ? fetchSearch(q) : Promise.resolve([]));
+const results = createResource(debounced, (q) => (q ? fetchSearch(q) : Promise.resolve([])));
 ```
 
 - Use `@tanstack/solid-query` (already in `apps/web/package.json`) with `enabled: debounced().length >= 3` as alternative.
 
 API guard:
+
 - In `routes/addresses.ts`, validate `q.trim().length >= 3`; return `400 ValidationError` if shorter. This prevents replica load from single-char prefix scans (`a:*` would match ~50% of tsvector). Keep `limit` clamp `parseLimit` already present.
 
 Cache:
+
 - Add `Cache-Control: public, max-age=300, stale-while-revalidate=60` for `GET /v1/search` when `q` hits; Cloudflare caches at edge and reduces replica QPS.
 
 ### 3.4 Effect + Elysia alignment (wwwtom)

--- a/infra/apps/api.run.ts
+++ b/infra/apps/api.run.ts
@@ -5,6 +5,8 @@ import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
 import { stageHost, tomSecrets } from "../shared.run.ts";
 import { tomQueue } from "../queues/tom.queue.ts";
+import { addressHyperdrive, addressReplicaHyperdrive } from "../hyperdrive/address.hyperdrive.ts";
+import { webKv } from "../kv/web.kv.ts";
 import { TomSecretsSchema } from "@tom/schemas/secrets";
 
 const rootDir = `${import.meta.dirname}/../..`;
@@ -33,6 +35,10 @@ export const api = Effect.gen(function* () {
       ? yield* Cloudflare.SecretsStore.Secret.ref("AXIOM_TOKEN", { stack: "wwwtom" })
       : undefined;
 
+  const addressReplicaEnv = yield* addressReplicaHyperdrive.pipe(
+    Effect.map((replica) => (replica ? { ADDRESS_HYPERDRIVE_REPLICA: replica } : {})),
+  );
+
   return yield* Cloudflare.Worker("wwwtom-api", {
     main: `${rootDir}/apps/api/src/index.ts`,
     compatibility: { date: "2025-12-10" },
@@ -56,6 +62,9 @@ export const api = Effect.gen(function* () {
       ...(isAlchemyDev ? undefined : { TOM_SECRETS: tomSecrets }),
       ...(axiomToken && { AXIOM_TOKEN: axiomToken }),
       WORK_QUEUE: tomQueue,
+      TOM_RATE_LIMIT_KV: webKv,
+      ADDRESS_HYPERDRIVE: addressHyperdrive,
+      ...addressReplicaEnv,
     },
   });
 });

--- a/infra/apps/api.run.ts
+++ b/infra/apps/api.run.ts
@@ -39,6 +39,14 @@ export const api = Effect.gen(function* () {
     Effect.map((replica) => (replica ? { ADDRESS_HYPERDRIVE_REPLICA: replica } : {})),
   );
 
+  // Better Auth D1 database for multi-tenant auth (users, orgs, api keys,
+  // usage). Migrations in apps/api/src/db/migrations apply on deploy.
+  const authDb = yield* Cloudflare.D1.Database("wwwtom-auth-d1", {
+    name: stage === "production" ? "wwwtom-auth-d1" : `wwwtom-auth-d1-${stage}`,
+    primaryLocationHint: "oc",
+    migrationsDir: `${rootDir}/apps/api/src/db/migrations`,
+  });
+
   return yield* Cloudflare.Worker("wwwtom-api", {
     main: `${rootDir}/apps/api/src/index.ts`,
     compatibility: { date: "2025-12-10" },
@@ -65,6 +73,7 @@ export const api = Effect.gen(function* () {
       TOM_RATE_LIMIT_KV: webKv,
       ADDRESS_HYPERDRIVE: addressHyperdrive,
       ...addressReplicaEnv,
+      AUTH_DB: authDb,
     },
   });
 });

--- a/infra/apps/web.run.ts
+++ b/infra/apps/web.run.ts
@@ -16,6 +16,7 @@ export const web = Effect.gen(function* () {
   const stage = yield* Stage;
   const isAlchemyDev = yield* ALCHEMY_DEV;
   const adapterHost = stageHost(stage, "adapter");
+  const apiHost = stageHost(stage, "api");
 
   // The Axiom ingest token is minted by the shared stack (production only);
   // reference it there instead of re-registering, which would fight over
@@ -43,7 +44,9 @@ export const web = Effect.gen(function* () {
       WORK_QUEUE: tomQueue,
       ADAPTER_URL: isAlchemyDev ? "http://localhost:8788" : `https://${adapterHost}`,
       // Inlined into the client bundle at build time (Alchemy VITE_ prefix).
-      ...(isAlchemyDev ? undefined : { VITE_ADAPTER_URL: `https://${adapterHost}` }),
+      ...(isAlchemyDev
+        ? undefined
+        : { VITE_ADAPTER_URL: `https://${adapterHost}`, VITE_API_URL: `https://${apiHost}` }),
     },
   });
 });

--- a/infra/hyperdrive/address.hyperdrive.ts
+++ b/infra/hyperdrive/address.hyperdrive.ts
@@ -1,0 +1,66 @@
+import * as Cloudflare from "alchemy/Cloudflare";
+import { Effect, Redacted } from "effect";
+import { InfrastructureConfigError } from "@tom/types/errors";
+import { Stage } from "alchemy/Stage";
+import { readSecretBundle } from "../shared.run.ts";
+
+const parseDatabaseUrl = (
+  url: string,
+  variable: string,
+): Effect.Effect<Cloudflare.Hyperdrive.PublicOrigin, InfrastructureConfigError> =>
+  Effect.try({
+    try: () => {
+      const parsed = new URL(url);
+      const scheme = parsed.protocol.replace(":", "");
+      if (scheme !== "postgres" && scheme !== "postgresql") {
+        throw new Error(`${variable} has unsupported scheme: ${scheme}`);
+      }
+
+      return {
+        scheme,
+        host: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : 5432,
+        database: parsed.pathname.replace(/^\//, ""),
+        user: decodeURIComponent(parsed.username),
+        password: Redacted.make(decodeURIComponent(parsed.password)),
+      };
+    },
+    catch: (cause) =>
+      new InfrastructureConfigError({
+        variable,
+        message: `${variable} must be a PostgreSQL connection URL`,
+        cause,
+      }),
+  });
+
+export const addressHyperdrive = Effect.gen(function* () {
+  const stage = yield* Stage;
+  const bundle = yield* readSecretBundle("TOM_SECRETS");
+  const addressDb = bundle.ADDRESS_DB;
+  if (!addressDb) {
+    return yield* new InfrastructureConfigError({
+      variable: "TOM_SECRETS",
+      message: "TOM_SECRETS must include ADDRESS_DB for the Hyperdrive origin",
+    });
+  }
+
+  return yield* Cloudflare.Hyperdrive.Connection("wwwtom-address-hyperdrive", {
+    ...(stage === "production" ? { name: "address-hyperdrive" } : undefined),
+    origin: yield* parseDatabaseUrl(addressDb, "ADDRESS_DB"),
+  });
+});
+
+export const addressReplicaHyperdrive = Effect.gen(function* () {
+  const stage = yield* Stage;
+  const bundle = yield* readSecretBundle("TOM_SECRETS");
+  const replica = bundle.ADDRESS_DB_REPLICA;
+  if (!replica) {
+    // Replica is optional; fall back to primary when absent (dev, single-region)
+    return undefined;
+  }
+
+  return yield* Cloudflare.Hyperdrive.Connection("wwwtom-address-replica-hyperdrive", {
+    ...(stage === "production" ? { name: "address-replica-hyperdrive" } : undefined),
+    origin: yield* parseDatabaseUrl(replica, "ADDRESS_DB_REPLICA"),
+  });
+});

--- a/infra/package.json
+++ b/infra/package.json
@@ -27,14 +27,14 @@
   "dependencies": {
     "@cloudflare/sandbox": "0.12.5",
     "@cloudflare/workers-types": "^4.20250408.0",
-    "@effect/platform-bun": "4.0.0-beta.105",
-    "@effect/platform-node": "4.0.0-beta.105",
+    "@effect/platform-bun": "4.0.0-rc.112",
+    "@effect/platform-node": "4.0.0-rc.112",
     "@tom/constants": "workspace:*",
     "@tom/schemas": "workspace:*",
     "@tom/types": "workspace:*",
     "@tom/utils": "workspace:*",
     "alchemy": "2.0.0-beta.72",
-    "effect": "4.0.0-beta.105",
+    "effect": "4.0.0-rc.112",
     "vite": "^8.1.5"
   },
   "devDependencies": {

--- a/packages/@tom/schemas/package.json
+++ b/packages/@tom/schemas/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./address": "./src/address.ts",
     "./arena": "./src/arena.ts",
     "./branded": "./src/branded.ts",
     "./error": "./src/error.ts",

--- a/packages/@tom/schemas/src/address.ts
+++ b/packages/@tom/schemas/src/address.ts
@@ -23,9 +23,9 @@ export const MetaSchema = Schema.Struct({
 });
 
 export const AddressSearchQuerySchema = Schema.Struct({
-  q: Schema.String,
+  q: Schema.Union([Schema.String, Schema.Array(Schema.String)]),
   limit: Schema.optional(Schema.String),
-  bbox: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.Union([Schema.String, Schema.Array(Schema.String)])),
 });
 
 export const AddressListQuerySchema = Schema.Struct({
@@ -34,7 +34,7 @@ export const AddressListQuerySchema = Schema.Struct({
   town_city: Schema.optional(Schema.String),
   suburb_locality: Schema.optional(Schema.String),
   road_name: Schema.optional(Schema.String),
-  bbox: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.Union([Schema.String, Schema.Array(Schema.String)])),
 });
 
 export const ReverseQuerySchema = Schema.Struct({

--- a/packages/@tom/schemas/src/address.ts
+++ b/packages/@tom/schemas/src/address.ts
@@ -1,0 +1,46 @@
+import { Schema } from "effect";
+
+export const AddressSchema = Schema.Struct({
+  addressId: Schema.Number,
+  fullAddress: Schema.String,
+  fullAddressNumber: Schema.String,
+  fullAddressRoad: Schema.NullOr(Schema.String),
+  suburb: Schema.String,
+  townCity: Schema.String,
+  territorialAuthority: Schema.String,
+  region: Schema.NullOr(Schema.String),
+  postcode: Schema.NullOr(Schema.String),
+  longitude: Schema.Number,
+  latitude: Schema.Number,
+});
+
+export const AddressListSchema = Schema.Array(AddressSchema);
+
+export const MetaSchema = Schema.Struct({
+  version: Schema.String,
+  totalAddresses: Schema.Number,
+  lastUpdated: Schema.String,
+});
+
+export const AddressSearchQuerySchema = Schema.Struct({
+  q: Schema.String,
+  limit: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.String),
+});
+
+export const AddressListQuerySchema = Schema.Struct({
+  limit: Schema.optional(Schema.String),
+  offset: Schema.optional(Schema.String),
+  town_city: Schema.optional(Schema.String),
+  suburb_locality: Schema.optional(Schema.String),
+  road_name: Schema.optional(Schema.String),
+  bbox: Schema.optional(Schema.String),
+});
+
+export const ReverseQuerySchema = Schema.Struct({
+  lat: Schema.String,
+  lng: Schema.String,
+  limit: Schema.optional(Schema.String),
+});
+
+export const ParamsSchema = Schema.Struct({ id: Schema.String });

--- a/packages/@tom/types/package.json
+++ b/packages/@tom/types/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./address": "./src/address.ts",
     "./customer": "./src/customer.ts",
     "./db": "./src/db.ts",
     "./errors": "./src/errors.ts",

--- a/packages/@tom/types/package.json
+++ b/packages/@tom/types/package.json
@@ -16,6 +16,7 @@
     "lint": "oxlint"
   },
   "dependencies": {
+    "@tom/schemas": "workspace:*",
     "effect": "catalog:",
     "kysely": "catalog:"
   },

--- a/packages/@tom/types/src/address.ts
+++ b/packages/@tom/types/src/address.ts
@@ -1,0 +1,30 @@
+export type Address = {
+  addressId: number;
+  fullAddress: string;
+  fullAddressNumber: string;
+  fullAddressRoad: string | null;
+  suburb: string;
+  townCity: string;
+  territorialAuthority: string;
+  region: string | null;
+  postcode: string | null;
+  longitude: number;
+  latitude: number;
+};
+
+export type AddressFilters = {
+  limit?: number;
+  offset?: number;
+  townCity?: string;
+  suburbLocality?: string;
+  roadName?: string;
+  bbox?: readonly [number, number, number, number];
+};
+
+export type Bbox = readonly [number, number, number, number];
+
+export type Meta = {
+  version: string;
+  totalAddresses: number;
+  lastUpdated: string;
+};

--- a/packages/@tom/types/src/address.ts
+++ b/packages/@tom/types/src/address.ts
@@ -1,16 +1,7 @@
-export type Address = {
-  addressId: number;
-  fullAddress: string;
-  fullAddressNumber: string;
-  fullAddressRoad: string | null;
-  suburb: string;
-  townCity: string;
-  territorialAuthority: string;
-  region: string | null;
-  postcode: string | null;
-  longitude: number;
-  latitude: number;
-};
+import { Schema } from "effect";
+import { AddressSchema, MetaSchema } from "@tom/schemas/address";
+
+export type Address = Schema.Schema.Type<typeof AddressSchema>;
 
 export type AddressFilters = {
   limit?: number;
@@ -23,8 +14,4 @@ export type AddressFilters = {
 
 export type Bbox = readonly [number, number, number, number];
 
-export type Meta = {
-  version: string;
-  totalAddresses: number;
-  lastUpdated: string;
-};
+export type Meta = Schema.Schema.Type<typeof MetaSchema>;

--- a/packages/@tom/utils/package.json
+++ b/packages/@tom/utils/package.json
@@ -25,6 +25,7 @@
     "obscenity": "catalog:"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "5.20260811.1",
     "@types/node": "^26.2.0",
     "typescript": "5.9.3",
     "vite": "^8.1.5",

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -47,6 +47,10 @@ export type CloudflareEnv = {
   PAYLOAD_URL?: string;
   DATABASE_URL?: string;
   HYPERDRIVE?: { connectionString: string };
+  ADDRESS_DB?: string;
+  ADDRESS_DB_REPLICA?: string;
+  ADDRESS_HYPERDRIVE?: { connectionString: string };
+  ADDRESS_HYPERDRIVE_REPLICA?: { connectionString: string };
   // Raw Cloudflare queue binding — app code should go through
   // TomQueueService (@tom/utils/services/queue) for schema-typed sends.
   WORK_QUEUE?: {
@@ -93,6 +97,8 @@ const secretKeys = [
   "ARENA_TOKEN",
   "PAYLOAD_URL",
   "DATABASE_URL",
+  "ADDRESS_DB",
+  "ADDRESS_DB_REPLICA",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_CHAT_ID",
   "SUCCESS_URL",

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -88,7 +88,14 @@ export type CloudflareEnv = {
   OTEL_TRACES_DATASET?: string;
   OTEL_LOGS_DATASET?: string;
   TOM_SECRETS?: { get(): Promise<string> };
+  // Better Auth: secret/url are read from the TOM_SECRETS bundle by
+  // readCloudflareEnv (secretKeys); AUTH_DB is the D1 binding.
+  BETTER_AUTH_SECRET?: string;
+  BETTER_AUTH_URL?: string;
+  AUTH_DB?: D1Database;
 };
+
+type D1Database = import("@cloudflare/workers-types").D1Database;
 
 // Keys seeded into the TOM_SECRETS bundle. AXIOM_TOKEN and the OTEL_*
 // overrides are deliberately absent: the ingest token is an IaC-minted
@@ -108,6 +115,8 @@ const secretKeys = [
   "INTERNAL_API_TOKEN",
   "GITHUB_TOKEN",
   "CONTROL_TOKEN",
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_URL",
 ] as const;
 
 export type ResolvedCloudflareEnv = CloudflareEnv & { AXIOM_TOKEN?: string };

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -51,6 +51,7 @@ export type CloudflareEnv = {
   ADDRESS_DB_REPLICA?: string;
   ADDRESS_HYPERDRIVE?: { connectionString: string };
   ADDRESS_HYPERDRIVE_REPLICA?: { connectionString: string };
+  LINZ_API_KEY?: string;
   // Raw Cloudflare queue binding — app code should go through
   // TomQueueService (@tom/utils/services/queue) for schema-typed sends.
   WORK_QUEUE?: {
@@ -99,6 +100,7 @@ const secretKeys = [
   "DATABASE_URL",
   "ADDRESS_DB",
   "ADDRESS_DB_REPLICA",
+  "LINZ_API_KEY",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_CHAT_ID",
   "SUCCESS_URL",

--- a/packages/@tom/utils/src/services/config.ts
+++ b/packages/@tom/utils/src/services/config.ts
@@ -92,6 +92,8 @@ export type CloudflareEnv = {
   // readCloudflareEnv (secretKeys); AUTH_DB is the D1 binding.
   BETTER_AUTH_SECRET?: string;
   BETTER_AUTH_URL?: string;
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
   AUTH_DB?: D1Database;
 };
 
@@ -117,6 +119,8 @@ const secretKeys = [
   "CONTROL_TOKEN",
   "BETTER_AUTH_SECRET",
   "BETTER_AUTH_URL",
+  "GITHUB_CLIENT_ID",
+  "GITHUB_CLIENT_SECRET",
 ] as const;
 
 export type ResolvedCloudflareEnv = CloudflareEnv & { AXIOM_TOKEN?: string };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@elysiajs/cors':
+        specifier: 'catalog:'
+        version: 1.4.2(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3))
       '@elysiajs/openapi':
         specifier: 'catalog:'
         version: 1.4.15(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
 
   apps/api:
     dependencies:
-      '@elysiajs/cors':
-        specifier: 'catalog:'
-        version: 1.4.2(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3))
       '@elysiajs/openapi':
         specifier: 'catalog:'
         version: 1.4.15(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,10 @@ catalogs:
       specifier: 4.1.10
       version: 4.1.10
 
+overrides:
+  '@better-auth/core': 1.7.2
+  '@better-auth/utils': 0.4.2
+
 importers:
 
   .:
@@ -198,10 +202,25 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/api:
     dependencies:
+      '@better-auth/api-key':
+        specifier: 1.7.2
+        version: 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(better-auth@1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
+      '@better-auth/core':
+        specifier: 1.7.2
+        version: 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/sso':
+        specifier: 1.7.2
+        version: 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))
+      '@better-auth/utils':
+        specifier: 0.4.2
+        version: 0.4.2
+      '@cloudflare/workers-types':
+        specifier: 5.20260811.1
+        version: 5.20260811.1
       '@elysiajs/openapi':
         specifier: 'catalog:'
         version: 1.4.15(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3))
@@ -223,6 +242,12 @@ importers:
       '@tom/utils':
         specifier: workspace:*
         version: link:../../packages/@tom/utils
+      better-auth:
+        specifier: 1.7.2
+        version: 1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.105
@@ -244,7 +269,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/cms:
     dependencies:
@@ -256,7 +281,7 @@ importers:
         version: 3.75.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@payloadcms/db-d1-sqlite':
         specifier: 'catalog:'
-        version: 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
+        version: 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
       '@payloadcms/next':
         specifier: 'catalog:'
         version: 3.75.0(@types/react@19.2.9)(graphql@16.12.0)(monaco-editor@0.55.1)(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
@@ -456,7 +481,7 @@ importers:
         version: 1.17.1(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(wrangler@4.76.0(@cloudflare/workers-types@4.20260702.1))
       '@payloadcms/db-d1-sqlite':
         specifier: 'catalog:'
-        version: 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
+        version: 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
       '@payloadcms/next':
         specifier: 'catalog:'
         version: 3.75.0(@types/react@19.2.9)(graphql@16.12.0)(monaco-editor@0.55.1)(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
@@ -529,7 +554,7 @@ importers:
         version: 16.1.7(eslint@9.39.2(jiti@2.7.0))(typescript@5.7.3)
       jsdom:
         specifier: 28.0.0
-        version: 28.0.0(@noble/hashes@1.8.0)
+        version: 28.0.0(@noble/hashes@2.4.0)
       postcss:
         specifier: 'catalog:'
         version: 8.5.8
@@ -550,7 +575,7 @@ importers:
         version: 6.0.5(typescript@5.7.3)(vite@8.1.5(@types/node@22.19.9)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@types/node@22.19.9)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.0.18(@types/node@22.19.9)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: 4.76.0
         version: 4.76.0(@cloudflare/workers-types@4.20260702.1)
@@ -680,7 +705,7 @@ importers:
         version: link:../packages/@tom/utils
       alchemy:
         specifier: 2.0.0-beta.72
-        version: 2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1)
+        version: 2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1)
       effect:
         specifier: 4.0.0-beta.105
         version: 4.0.0-beta.105
@@ -693,7 +718,7 @@ importers:
         version: 24.9.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@tom/arena:
     dependencies:
@@ -721,7 +746,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@tom/checkout:
     dependencies:
@@ -784,7 +809,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.20.3)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/@tom/email:
     dependencies:
@@ -893,6 +918,9 @@ importers:
         specifier: 'catalog:'
         version: 0.4.5
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 5.20260811.1
+        version: 5.20260811.1
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -904,7 +932,7 @@ importers:
         version: 8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -1025,6 +1053,10 @@ packages:
   '@ast-grep/napi@0.40.5':
     resolution: {integrity: sha512-hJA62OeBKUQT68DD2gDyhOqJxZxycqg8wLxbqjgqSzYttCMSDL9tiAQ9abgekBYNHudbJosm9sWOEbmCDfpX2A==}
     engines: {node: '>= 10'}
+
+  '@authenio/xml-encryption@2.0.2':
+    resolution: {integrity: sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg==}
+    engines: {node: '>=12'}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1357,6 +1389,102 @@ packages:
   '@badgateway/oauth2-client@2.4.2':
     resolution: {integrity: sha512-70Fmzlmn8EfCjjssls8N6E94quBUWnLhu4inPZU2pkwpc6ZvbErkLRvtkYl81KFCvVcuVC0X10QPZVNwjXo2KA==}
     engines: {node: '>= 14'}
+
+  '@better-auth/api-key@1.7.2':
+    resolution: {integrity: sha512-jih45wZaQ83lVYdChSnasxb8iax8p7AYetZ/XiImA9Yuag+cqmLBsaLPNvds5aZV18hLpmvzVkuzf7H/k1X88g==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      better-auth: ^1.7.2
+      better-call: 1.4.0
+
+  '@better-auth/core@1.7.2':
+    resolution: {integrity: sha512-j0nM4ygsWbF/fcYRoKtDn8gn8uLXkmC+075HqSqsJEAV828cJR9bvYBCUQ1zmxNyRBk6Iz/qXsA0Zm2oksiOTg==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.4.0
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.7.2':
+    resolution: {integrity: sha512-A5wE10PIv3aS5LGePecEHntQylKy6OOF17B4dqlE0DwJeqU/IOBSd7/LZhMop9cNJ3WFjKMpazVSf91yYM/NFg==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.7.2':
+    resolution: {integrity: sha512-LYdSRLOvZiF+6S0UThu+wE/Qxsq9P2jQs7ZKkY6BIBJqUjYyxVDmi8HFcantBvWWW1/BeQCSsD7YVDG4gICMIQ==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.7.2':
+    resolution: {integrity: sha512-0q1SXMzm5esH9L0xVuM6IxCk59E4G+3HySX4My9gvEwqtmUobykn+iuc/si3Y4xwUO7JODqQ5o+/pPcLDDMIrA==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.7.2':
+    resolution: {integrity: sha512-4879SmUWHUs0OYlvHoCFbycZ7i1bqytkcgAUdt9RLQMvZ5H3LRMTgax2YVlGZEXgwNjY/X7xAoXOecWLhlQWeA==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.7.2':
+    resolution: {integrity: sha512-mXTr/83WrNWLrvzIjtgDgdu9iXhOcSG1+qBQOAKlbGSFiOB+z4IMRneQ2wmMOiB8mKY9qGkClVUjKRFXqtHnFQ==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/sso@1.7.2':
+    resolution: {integrity: sha512-8tmkAGdcVu8Tr/+LPfSRgs/5a8YE1uU8OeaN5mAzsSdMWR4iwZdwQlJJmU8f9qZyIpNL/B6mIfDc5vaVUy1ECQ==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: ^1.7.2
+      better-call: 1.4.0
+
+  '@better-auth/telemetry@1.7.2':
+    resolution: {integrity: sha512-LcWu+O0zrxYDQj8E36vfkJwGPW4k9ZDA/rCo0zST6ihzL+juR7pBowoZIM9E6tK0Vit52mf6412bGT4XM4eTjQ==}
+    peerDependencies:
+      '@better-auth/core': 1.7.2
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -3294,6 +3422,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.4.0':
+    resolution: {integrity: sha512-AnjFn0Jv92laAkvMrghlFZq4qQCIN/4DxFV/eooqtC2YTjB7kBeLMS2T9KJX4Dn+ZVXLOwK0lSgqDtx9gvxtiw==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -3302,8 +3434,15 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@2.4.0':
+    resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@node-minify/core@8.0.6':
     resolution: {integrity: sha512-/vxN46ieWDLU67CmgbArEvOb41zlYFOkOtr9QW9CnTrBLuTyGgkyNWC2y5+khvRw3Br58p2B5ZVSx/PxCTru6g==}
@@ -3432,6 +3571,10 @@ packages:
     peerDependencies:
       next: ~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5
       wrangler: ^4.65.0
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-parser/binding-android-arm-eabi@0.139.0':
     resolution: {integrity: sha512-22EsXTA3Vc7OvrF4bfT48PFln2UbxkVgrp/Tm32qLw76Dv7SmcInfClJe6yPYamnli6HiqasnESZ5ezN+X4ybg==}
@@ -5718,6 +5861,18 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@xmldom/is-dom-node@1.0.1':
+    resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
+    engines: {node: '>= 16'}
+
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
+    engines: {node: '>=10.0.0'}
+
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
+    engines: {node: '>=14.6'}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -5852,6 +6007,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -5916,6 +6074,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -6074,6 +6235,76 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  better-auth@1.7.2:
+    resolution: {integrity: sha512-gKapKBEvYIGcMxi74RjQ7EbFLiqyQt58vdoJmL1qAlWSkY1Bc2Vqshl524/3u1NxauiOU03M/Ebh762Brmac9A==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4 || >=1.0.0-beta.1'
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.4.0:
+    resolution: {integrity: sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -6843,6 +7074,98 @@ packages:
       sqlite3:
         optional: true
 
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -7326,6 +7649,10 @@ packages:
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.11.1:
+    resolution: {integrity: sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==}
+    hasBin: true
 
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
@@ -8124,6 +8451,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
+
   is-upper-case@1.1.2:
     resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
 
@@ -8198,6 +8528,9 @@ packages:
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -8334,6 +8667,10 @@ packages:
   kysely@0.28.9:
     resolution: {integrity: sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==}
     engines: {node: '>=20.0.0'}
+
+  kysely@0.29.5:
+    resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
+    engines: {node: '>=22.0.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -8872,6 +9209,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanostores@1.5.2:
+    resolution: {integrity: sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -8957,6 +9298,9 @@ packages:
 
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  node-rsa@1.1.1:
+    resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -9357,6 +9701,10 @@ packages:
 
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -9999,6 +10347,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  samlify@2.13.1:
+    resolution: {integrity: sha512-vdYr/zohDGBbfWNU4miEzc1jmWOtkLySPViapC6nfGkv9KxzLq4UlGkKyryzwLw4jVlZk88Rw93HaCRVpe+t+g==}
+
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
 
@@ -10074,6 +10425,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -10399,6 +10753,9 @@ packages:
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
+
   strtok3@8.1.0:
     resolution: {integrity: sha512-ExzDvHYPj6F6QkSNe/JxSlBxTh3OrI6wrAIz53ulxo1c4hBJ1bT9C/JrAthEKHWG9riVH3Xzg7B03Oxty6S2Lw==}
     engines: {node: '>=16'}
@@ -10605,15 +10962,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.0.30:
-    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.0.30:
-    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
     hasBin: true
 
   tmp@0.0.33:
@@ -11464,6 +11821,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-crypto@6.1.2:
+    resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
+    engines: {node: '>=16'}
+
+  xml-escape@1.1.0:
+    resolution: {integrity: sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -11472,11 +11836,27 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xpath@0.0.32:
+    resolution: {integrity: sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==}
+    engines: {node: '>=0.6.0'}
+
+  xpath@0.0.33:
+    resolution: {integrity: sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==}
+    engines: {node: '>=0.6.0'}
+
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
 
   xss@1.0.15:
     resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
@@ -11686,6 +12066,12 @@ snapshots:
       '@ast-grep/napi-win32-arm64-msvc': 0.40.5
       '@ast-grep/napi-win32-ia32-msvc': 0.40.5
       '@ast-grep/napi-win32-x64-msvc': 0.40.5
+
+  '@authenio/xml-encryption@2.0.2':
+    dependencies:
+      '@xmldom/xmldom': 0.8.15
+      escape-html: 1.0.3
+      xpath: 0.0.32
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -12541,6 +12927,97 @@ snapshots:
 
   '@badgateway/oauth2-client@2.4.2': {}
 
+  '@better-auth/api-key@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(better-auth@1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
+      better-call: 1.4.0(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.4.0(zod@4.4.3)
+      jose: 6.2.10
+      kysely: 0.28.9
+      nanostores: 1.5.2
+      zod: 4.4.3
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260811.1
+
+  '@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.4.0(zod@4.4.3)
+      jose: 6.2.10
+      kysely: 0.29.5
+      nanostores: 1.5.2
+      zod: 4.4.3
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260811.1
+
+  '@better-auth/drizzle-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
+
+  '@better-auth/kysely-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.5
+
+  '@better-auth/memory-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/sso@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))))(better-call@1.4.0(zod@4.4.3))':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@xmldom/xmldom': 0.9.12
+      better-auth: 1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
+      better-call: 1.4.0(zod@4.4.3)
+      fast-xml-parser: 5.11.1
+      jose: 6.2.10
+      samlify: 2.13.1
+      tldts: 7.4.11
+      zod: 4.4.3
+
+  '@better-auth/telemetry@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.4.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@cf-wasm/internals@0.0.3': {}
@@ -12843,7 +13320,7 @@ snapshots:
       '@smithy/util-base64': 4.4.2
       aws4fetch: 1.0.20
       effect: 4.0.0-beta.105
-      fast-xml-parser: 5.7.3
+      fast-xml-parser: 5.11.1
     transitivePeerDependencies:
       - aws-crt
 
@@ -12960,10 +13437,10 @@ snapshots:
     dependencies:
       effect: 4.0.0-beta.105
 
-  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       effect: 4.0.0-beta.105
-      vitest: 4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
     dependencies:
@@ -13538,9 +14015,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.15.0(@noble/hashes@2.4.0)':
     optionalDependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.4.0
 
   '@faceless-ui/modal@3.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -14246,13 +14723,19 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.4.0': {}
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
 
+  '@noble/hashes@2.4.0': {}
+
   '@nodable/entities@2.1.0': {}
+
+  '@nodable/entities@3.0.0': {}
 
   '@node-minify/core@8.0.6':
     dependencies:
@@ -14422,6 +14905,8 @@ snapshots:
       - aws-crt
       - encoding
       - supports-color
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.139.0':
     optional: true
@@ -14610,12 +15095,12 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@payloadcms/db-d1-sqlite@3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)':
+  '@payloadcms/db-d1-sqlite@3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)':
     dependencies:
-      '@payloadcms/drizzle': 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
+      '@payloadcms/drizzle': 3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)
       console-table-printer: 2.12.1
       drizzle-kit: 0.31.7
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(postgres@3.4.7)
       payload: 3.75.0(graphql@16.12.0)(typescript@5.7.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -14652,11 +15137,11 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@payloadcms/drizzle@3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)':
+  '@payloadcms/drizzle@3.75.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(payload@3.75.0(graphql@16.12.0)(typescript@5.7.3))(postgres@3.4.7)':
     dependencies:
       console-table-printer: 2.12.1
       dequal: 2.0.3
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(postgres@3.4.7)
       payload: 3.75.0(graphql@16.12.0)(typescript@5.7.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -16772,6 +17257,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xmldom/is-dom-node@1.0.1': {}
+
+  '@xmldom/xmldom@0.8.15': {}
+
+  '@xmldom/xmldom@0.9.12': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -16819,7 +17310,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1):
+  alchemy@2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1):
     dependencies:
       '@alchemy.run/cloudflare-runtime': 2.0.0-beta.72(@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-beta.105))(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(effect@4.0.0-beta.105)(rolldown@1.1.5)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
       '@alchemy.run/node-utils': 0.0.5
@@ -16833,7 +17324,7 @@ snapshots:
       '@distilled.cloud/planetscale': 1.0.0-rc.4(effect@4.0.0-beta.105)
       '@effect/sql-d1': 4.0.0-beta.107(effect@4.0.0-beta.105)
       '@effect/sql-sqlite-do': 4.0.0-beta.107(effect@4.0.0-beta.105)
-      '@effect/vitest': 4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
+      '@effect/vitest': 4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.4
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -16906,6 +17397,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  anynum@1.0.1: {}
 
   arg@5.0.2: {}
 
@@ -16999,6 +17492,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -17124,6 +17621,46 @@ snapshots:
   basic-ftp@5.3.1: {}
 
   before-after-hook@4.0.0: {}
+
+  better-auth@1.7.2(@cloudflare/workers-types@5.20260811.1)(drizzle-kit@0.31.7)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.7(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.12)(vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))):
+    dependencies:
+      '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2)
+      '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7))
+      '@better-auth/kysely-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260811.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.28.9)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.4.0
+      '@noble/hashes': 2.4.0
+      better-call: 1.4.0(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.10
+      kysely: 0.29.5
+      nanostores: 1.5.2
+      zod: 4.4.3
+    optionalDependencies:
+      drizzle-kit: 0.31.7
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
+      next: 16.1.7(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.77.4)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      solid-js: 1.9.12
+      vitest: 4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.4.0(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.9.1
+      set-cookie-parser: 3.1.2
+    optionalDependencies:
+      zod: 4.4.3
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -17618,10 +18155,10 @@ snapshots:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
 
-  data-urls@7.0.0(@noble/hashes@1.8.0):
+  data-urls@7.0.0(@noble/hashes@2.4.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -17794,9 +18331,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.29.5)(postgres@3.4.7):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260702.1
+      '@electric-sql/pglite': 0.5.5
+      '@libsql/client': 0.17.4
+      kysely: 0.29.5
+      postgres: 3.4.7
+
+  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7):
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260811.1
       '@electric-sql/pglite': 0.5.5
       '@libsql/client': 0.17.4
       kysely: 0.28.9
@@ -18770,8 +19315,17 @@ snapshots:
 
   fast-xml-builder@1.2.0:
     dependencies:
-      path-expression-matcher: 1.5.0
+      path-expression-matcher: 1.6.2
       xml-naming: 0.1.0
+
+  fast-xml-parser@5.11.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
 
   fast-xml-parser@5.7.3:
     dependencies:
@@ -19292,9 +19846,9 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.4.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -19650,6 +20204,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-unsafe@2.0.2: {}
+
   is-upper-case@1.1.2:
     dependencies:
       upper-case: 1.1.3
@@ -19713,6 +20269,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@5.9.6: {}
+
+  jose@6.2.10: {}
 
   joycon@3.1.1: {}
 
@@ -19785,15 +20343,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@28.0.0(@noble/hashes@1.8.0):
+  jsdom@28.0.0(@noble/hashes@2.4.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.4.0)
       cssstyle: 5.3.7
-      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      data-urls: 7.0.0(@noble/hashes@2.4.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.4.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -19805,7 +20363,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.4.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -19890,6 +20448,8 @@ snapshots:
       postgres: 3.4.7
 
   kysely@0.28.9: {}
+
+  kysely@0.29.5: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -20574,6 +21134,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanostores@1.5.2: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -20664,6 +21226,10 @@ snapshots:
       resolve: 1.22.12
 
   node-releases@2.0.44: {}
+
+  node-rsa@1.1.1:
+    dependencies:
+      asn1: 0.2.6
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -21045,6 +21611,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.5.0: {}
+
+  path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -21801,6 +22369,16 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  samlify@2.13.1:
+    dependencies:
+      '@authenio/xml-encryption': 2.0.2
+      '@xmldom/xmldom': 0.8.15
+      node-rsa: 1.1.1
+      xml: 1.0.1
+      xml-crypto: 6.1.2
+      xml-escape: 1.1.0
+      xpath: 0.0.34
+
   sanitize-filename@1.6.3:
     dependencies:
       truncate-utf8-bytes: 1.0.2
@@ -21921,6 +22499,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -22319,6 +22899,10 @@ snapshots:
 
   strnum@2.3.0: {}
 
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
+
   strtok3@8.1.0:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -22553,15 +23137,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.0.30: {}
+  tldts-core@7.4.11: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.0.30:
+  tldts@7.4.11:
     dependencies:
-      tldts-core: 7.0.30
+      tldts-core: 7.4.11
 
   tmp@0.0.33:
     dependencies:
@@ -22595,7 +23179,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.30
+      tldts: 7.4.11
 
   tr46@0.0.3: {}
 
@@ -23220,7 +23804,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -23248,7 +23832,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 26.2.0
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
+      jsdom: 28.0.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23263,7 +23847,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@22.19.9)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@4.0.18(@types/node@22.19.9)(jiti@2.7.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.3(@types/node@22.19.9)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
@@ -23287,7 +23871,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.9
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
+      jsdom: 28.0.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23329,7 +23913,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
@@ -23353,11 +23937,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
+      jsdom: 28.0.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.20.3)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.20.3)(yaml@2.9.0))
@@ -23381,11 +23965,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
+      jsdom: 28.0.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.2.0)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
@@ -23409,7 +23993,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
-      jsdom: 28.0.0(@noble/hashes@1.8.0)
+      jsdom: 28.0.0(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - msw
 
@@ -23454,9 +24038,9 @@ snapshots:
       tr46: 6.0.0
       webidl-conversions: 8.0.1
 
-  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+  whatwg-url@16.0.1(@noble/hashes@2.4.0):
     dependencies:
-      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.4.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -23601,13 +24185,29 @@ snapshots:
 
   ws@8.21.1: {}
 
+  xml-crypto@6.1.2:
+    dependencies:
+      '@xmldom/is-dom-node': 1.0.1
+      '@xmldom/xmldom': 0.8.15
+      xpath: 0.0.33
+
+  xml-escape@1.1.0: {}
+
   xml-name-validator@5.0.0: {}
 
   xml-naming@0.1.0: {}
 
+  xml-naming@0.3.0: {}
+
   xml@1.0.1: {}
 
   xmlchars@2.2.0: {}
+
+  xpath@0.0.32: {}
+
+  xpath@0.0.33: {}
+
+  xpath@0.0.34: {}
 
   xss@1.0.15:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,6 +839,9 @@ importers:
 
   packages/@tom/types:
     dependencies:
+      '@tom/schemas':
+        specifier: workspace:*
+        version: link:../schemas
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.105

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,15 @@ importers:
       elysia:
         specifier: 'catalog:'
         version: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
+      kysely:
+        specifier: 'catalog:'
+        version: 0.28.9
+      kysely-postgres-js:
+        specifier: 3.0.0
+        version: 3.0.0(kysely@0.28.9)(postgres@3.4.7)
+      postgres:
+        specifier: 'catalog:'
+        version: 3.4.7
       workers-og:
         specifier: 0.0.27
         version: 0.0.27
@@ -7138,6 +7147,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: 16.4.7
       version: 16.4.7
     effect:
-      specifier: 4.0.0-beta.105
-      version: 4.0.0-beta.105
+      specifier: 4.0.0-rc.112
+      version: 4.0.0-rc.112
     elysia:
       specifier: 1.4.29
       version: 1.4.29
@@ -189,7 +189,7 @@ importers:
         version: link:../../packages/@tom/utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       elysia:
         specifier: 'catalog:'
         version: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
@@ -250,7 +250,7 @@ importers:
         version: 0.45.2(@cloudflare/workers-types@5.20260811.1)(@electric-sql/pglite@0.5.5)(@libsql/client@0.17.4)(kysely@0.28.9)(postgres@3.4.7)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       elysia:
         specifier: 'catalog:'
         version: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
@@ -462,7 +462,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       elysia:
         specifier: 'catalog:'
         version: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@19.3.0)(openapi-types@12.1.3)(typescript@6.0.3)
@@ -626,7 +626,7 @@ importers:
         version: 2.0.5
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       number-to-words:
         specifier: 1.2.4
         version: 1.2.4
@@ -686,11 +686,11 @@ importers:
         specifier: ^4.20250408.0
         version: 4.20260702.1
       '@effect/platform-bun':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
       '@effect/platform-node':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1)
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@tom/constants':
         specifier: workspace:*
         version: link:../packages/@tom/constants
@@ -705,10 +705,10 @@ importers:
         version: link:../packages/@tom/utils
       alchemy:
         specifier: 2.0.0-beta.72
-        version: 2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1)
+        version: 2.0.0-beta.72(@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1))(@types/react@19.2.9)(effect@4.0.0-rc.112)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.3)
       effect:
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
@@ -739,7 +739,7 @@ importers:
         version: link:../utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -781,7 +781,7 @@ importers:
         version: link:../utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       kysely:
         specifier: 'catalog:'
         version: 0.28.9
@@ -843,7 +843,7 @@ importers:
         version: link:../utils
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -856,7 +856,7 @@ importers:
         version: 0.0.4
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -869,7 +869,7 @@ importers:
         version: link:../schemas
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       kysely:
         specifier: 'catalog:'
         version: 0.28.9
@@ -913,7 +913,7 @@ importers:
         version: link:../types
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.105
+        version: 4.0.0-rc.112
       obscenity:
         specifier: 'catalog:'
         version: 0.4.5
@@ -1819,23 +1819,23 @@ packages:
     resolution: {integrity: sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw==}
     hasBin: true
 
-  '@effect/platform-bun@4.0.0-beta.105':
-    resolution: {integrity: sha512-5eCuMLxfkLbVK5If5zFybyKduQvhYofy0oPsbTH8UiIrYqyx5QqK9G9PZ1SfBsbqHfykwLEpMCdzQczFGERw2w==}
+  '@effect/platform-bun@4.0.0-rc.112':
+    resolution: {integrity: sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg==}
     peerDependencies:
-      effect: ^4.0.0-beta.105
+      effect: ^4.0.0-rc.112
 
-  '@effect/platform-node-shared@4.0.0-beta.107':
-    resolution: {integrity: sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA==}
+  '@effect/platform-node-shared@4.0.0-rc.112':
+    resolution: {integrity: sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.107
+      effect: ^4.0.0-rc.112
 
-  '@effect/platform-node@4.0.0-beta.105':
-    resolution: {integrity: sha512-gOHtgE9PqCT8aiiM0W7ZSbu4M2/jPGfJOKWuyBCxofNV5Np36fFY55FSa1MtyG+vjOjlD5btNY2i6i/SPtRqTA==}
+  '@effect/platform-node@4.0.0-rc.112':
+    resolution: {integrity: sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.105
-      ioredis: '>=5.7.0 <6.0.0'
+      effect: ^4.0.0-rc.112
+      redis: '>=5.0.0 <7.0.0'
 
   '@effect/sql-d1@4.0.0-beta.107':
     resolution: {integrity: sha512-GN0RMZRQ+Kc6t4hiIbGBFMdYj2UssX27w0n1oyV+s9OZcWOdD42C2vDxUwnnKLstPDdeOMBAFX7dMekOiF2rUQ==}
@@ -3102,9 +3102,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@ioredis/commands@1.5.1':
-    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -4568,6 +4565,42 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@redis/bloom@6.2.1':
+    resolution: {integrity: sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/client@6.2.1':
+    resolution: {integrity: sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.2.1':
+    resolution: {integrity: sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/search@6.2.1':
+    resolution: {integrity: sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/time-series@6.2.1':
+    resolution: {integrity: sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
 
   '@resvg/resvg-wasm@2.4.0':
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
@@ -6894,10 +6927,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -7183,8 +7212,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.105:
-    resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
+  effect@4.0.0-rc.112:
+    resolution: {integrity: sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==}
 
   electron-to-chromium@1.5.356:
     resolution: {integrity: sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==}
@@ -8260,10 +8289,6 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ioredis@5.10.1:
-    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
-    engines: {node: '>=12.22.0'}
-
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -8651,9 +8676,6 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  kubernetes-types@1.30.0:
-    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
-
   kysely-postgres-js@3.0.0:
     resolution: {integrity: sha512-o2t/xNSYJQDW6rVGGFPXKmZ0BEz2dGn66c2B+cO/k9ZNcU2qPWPycQPQ+B+P2MBXbKYq0xV9BZmFIvkUrmFWAQ==}
     engines: {bun: '>=1.2', node: '>=20'}
@@ -8818,18 +8840,12 @@ packages:
   lodash.capitalize@4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
 
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
-
-  lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -9191,8 +9207,8 @@ packages:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
+  msgpackr@2.1.0:
+    resolution: {integrity: sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==}
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -10180,13 +10196,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
-  redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
+  redis@6.2.1:
+    resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
+    engines: {node: '>= 20.0.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -10626,9 +10638,6 @@ packages:
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
@@ -11190,8 +11199,8 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.7.0:
-    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -11328,10 +11337,6 @@ packages:
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   uuid@9.0.0:
@@ -11821,6 +11826,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-crypto@6.1.2:
     resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
     engines: {node: '>=16'}
@@ -11964,21 +11981,21 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/cloudflare-runtime@2.0.0-beta.72(@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-beta.105))(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(effect@4.0.0-beta.105)(rolldown@1.1.5)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))':
+  '@alchemy.run/cloudflare-runtime@2.0.0-beta.72(@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-rc.112))(@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1))(effect@4.0.0-rc.112)(rolldown@1.1.5)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260704.1)
-      '@distilled.cloud/cloudflare': 1.0.0-rc.4(effect@4.0.0-beta.105)
+      '@distilled.cloud/cloudflare': 1.0.0-rc.4(effect@4.0.0-rc.112)
       '@puppeteer/browsers': 2.13.2
       capnp-es: 0.0.14(typescript@5.9.3)
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
       magic-string: 0.30.21
       sharp: 0.34.5
       unenv: 2.0.0-rc.24
       workerd: 1.20260704.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.105(effect@4.0.0-beta.105)
-      '@effect/platform-node': 4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@effect/platform-node': 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       rolldown: 1.1.5
       vite: 8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -13308,45 +13325,45 @@ snapshots:
 
   '@date-fns/tz@1.2.0': {}
 
-  '@distilled.cloud/aws@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/aws@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1047.0
       '@aws-sdk/types': 3.973.8
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
       '@smithy/shared-ini-file-loader': 4.6.10
       '@smithy/types': 4.16.1
       '@smithy/util-base64': 4.4.2
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
       fast-xml-parser: 5.11.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@distilled.cloud/axiom@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/axiom@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
 
-  '@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
 
-  '@distilled.cloud/core@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/core@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
 
-  '@distilled.cloud/neon@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/neon@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
 
-  '@distilled.cloud/planetscale@1.0.0-rc.4(effect@4.0.0-beta.105)':
+  '@distilled.cloud/planetscale@1.0.0-rc.4(effect@4.0.0-rc.112)':
     dependencies:
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
     dependencies:
@@ -13400,46 +13417,46 @@ snapshots:
 
   '@effect/language-service@0.86.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105)':
+  '@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.107(effect@4.0.0-beta.105)':
+  '@effect/platform-node-shared@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.105
-      ws: 8.21.1
+      effect: 4.0.0-rc.112
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.105)
-      effect: 4.0.0-beta.105
-      ioredis: 5.10.1
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.112
       mime: 4.1.0
-      undici: 8.7.0
+      redis: 6.2.1
+      undici: 8.10.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.107(effect@4.0.0-beta.105)':
+  '@effect/sql-d1@4.0.0-beta.107(effect@4.0.0-rc.112)':
     dependencies:
       '@cloudflare/workers-types': 5.20260811.1
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
 
-  '@effect/sql-sqlite-do@4.0.0-beta.107(effect@4.0.0-beta.105)':
+  '@effect/sql-sqlite-do@4.0.0-beta.107(effect@4.0.0-rc.112)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
 
-  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
       vitest: 4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
 
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
@@ -14302,8 +14319,6 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@26.2.0)':
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@ioredis/commands@1.5.1': {}
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -15861,6 +15876,26 @@ snapshots:
     dependencies:
       react: 19.2.1
 
+  '@redis/bloom@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/client@6.2.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/search@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
   '@resvg/resvg-wasm@2.4.0': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
@@ -17310,21 +17345,21 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.72(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(@types/react@19.2.9)(effect@4.0.0-beta.105)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.1):
+  alchemy@2.0.0-beta.72(@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1))(@types/react@19.2.9)(effect@4.0.0-rc.112)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.3):
     dependencies:
-      '@alchemy.run/cloudflare-runtime': 2.0.0-beta.72(@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-beta.105))(@effect/platform-bun@4.0.0-beta.105(effect@4.0.0-beta.105))(@effect/platform-node@4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1))(effect@4.0.0-beta.105)(rolldown@1.1.5)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
+      '@alchemy.run/cloudflare-runtime': 2.0.0-beta.72(@distilled.cloud/cloudflare@1.0.0-rc.4(effect@4.0.0-rc.112))(@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1))(effect@4.0.0-rc.112)(rolldown@1.1.5)(typescript@5.9.3)(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0))
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1047.0
       '@clack/prompts': 1.7.0
-      '@distilled.cloud/aws': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@distilled.cloud/axiom': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@distilled.cloud/cloudflare': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@distilled.cloud/neon': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@distilled.cloud/planetscale': 1.0.0-rc.4(effect@4.0.0-beta.105)
-      '@effect/sql-d1': 4.0.0-beta.107(effect@4.0.0-beta.105)
-      '@effect/sql-sqlite-do': 4.0.0-beta.107(effect@4.0.0-beta.105)
-      '@effect/vitest': 4.0.0-beta.107(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/aws': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@distilled.cloud/axiom': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@distilled.cloud/cloudflare': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@distilled.cloud/core': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@distilled.cloud/neon': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@distilled.cloud/planetscale': 1.0.0-rc.4(effect@4.0.0-rc.112)
+      '@effect/sql-d1': 4.0.0-beta.107(effect@4.0.0-rc.112)
+      '@effect/sql-sqlite-do': 4.0.0-beta.107(effect@4.0.0-rc.112)
+      '@effect/vitest': 4.0.0-beta.107(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@24.9.1)(jsdom@28.0.0(@noble/hashes@2.4.0))(vite@8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.4
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -17335,7 +17370,7 @@ snapshots:
       '@types/aws-lambda': 8.10.162
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-rc.112
       fast-glob: 3.3.3
       fast-xml-parser: 5.7.3
       ink: 6.8.0(@types/react@19.2.9)(react@19.2.1)
@@ -17348,10 +17383,10 @@ snapshots:
       undici: 7.25.0
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.105(effect@4.0.0-beta.105)
-      '@effect/platform-node': 4.0.0-beta.105(effect@4.0.0-beta.105)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@effect/platform-node': 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       vite: 8.1.5(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.21.0)(yaml@2.9.0)
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - '@types/react'
       - aws-crt
@@ -18249,8 +18284,6 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  denque@2.1.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -18368,13 +18401,10 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.105:
+  effect@4.0.0-rc.112:
     dependencies:
-      '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
-      kubernetes-types: 1.30.0
-      msgpackr: 2.0.4
-      uuid: 14.0.1
+      msgpackr: 2.1.0
 
   electron-to-chromium@1.5.356: {}
 
@@ -20026,20 +20056,6 @@ snapshots:
       hasown: 2.0.3
       side-channel: 1.1.0
 
-  ioredis@5.10.1:
-    dependencies:
-      '@ioredis/commands': 1.5.1
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -20439,8 +20455,6 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  kubernetes-types@1.30.0: {}
-
   kysely-postgres-js@3.0.0(kysely@0.28.9)(postgres@3.4.7):
     dependencies:
       kysely: 0.28.9
@@ -20579,13 +20593,9 @@ snapshots:
 
   lodash.capitalize@4.2.1: {}
 
-  lodash.defaults@4.2.0: {}
-
   lodash.escaperegexp@4.1.2: {}
 
   lodash.get@4.4.2: {}
-
-  lodash.isarguments@3.1.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -21118,7 +21128,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.4:
+  msgpackr@2.1.0:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
@@ -22126,11 +22136,16 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
+  redis@6.2.1:
     dependencies:
-      redis-errors: 1.2.0
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1)
+      '@redis/client': 6.2.1
+      '@redis/json': 6.2.1(@redis/client@6.2.1)
+      '@redis/search': 6.2.1(@redis/client@6.2.1)
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -22749,8 +22764,6 @@ snapshots:
 
   stackframe@1.3.4: {}
 
-  standard-as-callback@2.1.0: {}
-
   state-local@1.0.7: {}
 
   statuses@2.0.2: {}
@@ -23362,7 +23375,7 @@ snapshots:
 
   undici@7.25.0: {}
 
-  undici@8.7.0: {}
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -23510,8 +23523,6 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@11.1.1: {}
-
-  uuid@14.0.1: {}
 
   uuid@9.0.0: {}
 
@@ -24184,6 +24195,8 @@ snapshots:
   ws@8.20.1: {}
 
   ws@8.21.1: {}
+
+  ws@8.21.3: {}
 
   xml-crypto@6.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ onlyBuiltDependencies:
   - "unrs-resolver"
   - "workerd"
 catalog:
-  effect: 4.0.0-beta.105
+  effect: 4.0.0-rc.112
   kysely: 0.28.9
   postgres: 3.4.7
   solid-js: 1.9.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,3 +58,6 @@ minimumReleaseAgeExclude:
   - "@distilled.cloud/neon@1.0.0-rc.4"
   - "@distilled.cloud/planetscale@1.0.0-rc.4"
   - alchemy@2.0.0-beta.72
+overrides:
+  "@better-auth/core": 1.7.2
+  "@better-auth/utils": 0.4.2


### PR DESCRIPTION
Implements `et0and/address` port using wwwtom patterns with Neon Postgres.

## What's in

- **Postgres tsvector**: `search_vector tsvector GENERATED ALWAYS AS (to_tsvector('simple', concat_ws(...))) STORED` + `USING GIN (search_vector)` (`apps/api/src/services/address/schema.ts:29`). Prefix `tsquery` via `toTsQuery` (`token*` → `token:*`, `AND/OR` → `&/|`) and `ts_rank` ordering.
- **Read replica**: `AddressDbService` holds `primary`/`replica` `postgres.js` pools (`apps/api/src/services/address/db.ts:14`). Reads (`search`, `list`, `getById`, `reverse`, `meta`) hit `replica`, writes (`ensureSchema`, `insertApiKey`, `rebuildSearchTerms`) hit `primary`. Infra provisions `ADDRESS_HYPERDRIVE` + `ADDRESS_HYPERDRIVE_REPLICA` from `ADDRESS_DB`/`ADDRESS_DB_REPLICA` (`infra/hyperdrive/address.hyperdrive.ts:14`, `infra/apps/api.run.ts:12`).
- **SQL extracted**: All inline `sql.unsafe` moved to `apps/api/src/services/address/queries.ts:1` (`SQL` constants + `buildRebuildTermsQuery` allowlist). No inline SQL remains in `db.ts`/`search.ts`/`addresses.ts`.
- **Effect Idioms**: `normalizeText` now `pipe(value, String.normalize("NFKD"), String.replace(...), String.toLowerCase, ...)` (`search.ts:22`) and `tokenize` via `String.split`/`Arr.filter`. Query parsing via `Schema.Struct` + `Schema.decodeUnknownSync` at route boundary (`routes/addresses.ts:58`). No `as unknown as` chained assertions. Shared `Address`/`Meta` inferred from `AddressSchema` in `@tom/schemas/address` (`packages/@tom/schemas/src/address.ts:1`), `Address` type in `@tom/types/address` via `Schema.Schema.Type`.
- **API**: Elysia `addressRoutes` (`apps/api/src/routes/addresses.ts:42`): `GET /v1/search` (3-char guard, `Cache-Control: public, max-age=300`, `tsvector` search), `/v1/addresses/:id`, `/v1/addresses`, `/v1/reverse`, `/v1/meta`. `exactOptionalPropertyTypes` handled without `undefined` spreads.
- **Adapter → API via Eden**: `apps/adapter/src/integrations/address/index.ts:1` exposes `GET /address/search` + `/address/meta` that proxy to `api.v1.search.get` / `api.v1.meta.get` via `callApi` + `treaty<ApiApp>` + `runAdapter` + `HttpError` tagged errors (`Schema.TaggedError`). No `as`/`Record<string,unknown>`/`typeof` casts, fully typed.
- **Web example page `address.tsx`**: `apps/web/src/routes/address.tsx:1` is the canonical example — `createSignal`/`createEffect`/`onCleanup` 250ms debounce, `createMemo` 3-char guard, `useQuery` with `callAdapter().address.search.get({ query: { q, limit } })` via Eden Treaty and `unwrapAdapter` (`HttpError` tagged), `Show`/`For`/`Suspense`, `Meta` via `callAdapter().address.meta.get`. `apps/web/src/components/AddressSearch.tsx:1` (direct `fetch` to `api`) kept for comparison but now uses `HttpError` + `AddressListSchema` decode.
- **Web preview**: `https://dev-web.tom.so/address` (adapter→api) and `https://dev-web.tom.so/search` (direct). `VITE_API_URL` inlined via `infra/apps/web.run.ts:18`.

## Secrets / Hyperdrive

**Yes — Neon Postgres connection strings live in `TOM_SECRETS`** alongside `DATABASE_URL`.

- `packages/@tom/utils/src/services/config.ts:96` adds `ADDRESS_DB`/`ADDRESS_DB_REPLICA` to `secretKeys`/`CloudflareEnv`.
- `infra/shared.run.ts:108` `TOM_SECRETS` is account-level Secrets Store bundle (`wwwtom-secrets` → `TOM_SECRETS`), seeded from `TOM_SECRETS` env JSON.
- `infra/hyperdrive/address.hyperdrive.ts:34` reads from bundle and creates `ADDRESS_HYPERDRIVE`/`REPLICA`; `infra/apps/api.run.ts:12` binds them; `apps/api` resolves `env.ADDRESS_HYPERDRIVE?.connectionString ?? env.ADDRESS_DB` (`services/address/index.ts:12`).
- Main DB and address DB are separate Neon projects; replica is Neon read-only endpoint.

**Provisioned for dev:** `ADDRESS_DB`=`ep-damp-mode-a7jxfnhb-pooler` and `ADDRESS_DB_REPLICA`=`ep-icy-scene-a7bgjgmh-pooler` added to `infra/.dev.vars` and `TOM_SECRETS` GitHub secret, `ALCHEMY_STAGE=dev` deploy of `shared` (TOM_SECRETS update) + `api` (Hyperdrives + worker) + `web` (VITE_API_URL) succeeded — `https://dev-api.tom.so` / `https://dev-web.tom.so`.

Research doc: `docs/research-address-neon-tsvector.md`
Cloned `et0and/address` to `~/Documents/Dev/address`; prior port `feature/address-service-port` (02fda33) as reference.

## Verification

- `pnpm --filter @tom/api|adapter|web typecheck` / `lint` clean (antislop/effect rules, no `as`/`Record<string,unknown>`/`typeof`)
- `pnpm --filter @tom/api test` — 23 passed
- Preview: push to `research/address-neon-tsvector` triggers `preview.yml` → `https://dev-web.tom.so/address` (and `/search`)