### PR TITLE
feat(queue): wire guestbook sign alerts through the tom work queue

### DIFF
--- a/apps/adapter/src/config/effect.ts
+++ b/apps/adapter/src/config/effect.ts
@@ -1,5 +1,5 @@
-import { Effect, Layer } from "effect";
-import { AppConfig, makeAppConfigLayer } from "@tom/utils/services/config";
+import { Effect, Layer, Schema } from "effect";
+import { type AppConfig, makeAppConfigLayer } from "@tom/utils/services/config";
 import type { CloudflareEnv } from "@tom/utils/services/config";
 import { withLogging } from "@tom/utils/services/logging";
 import type { LogContext } from "@tom/utils/services/logging";
@@ -39,16 +39,10 @@ export const createDbLayer = (env: CloudflareEnv) =>
  * Error thrown by integration runners when the underlying Effect fails.
  * The global onError hook maps it to a JSON response with the right status.
  */
-export class AdapterError extends Error {
-  readonly _tag = "AdapterError";
-  constructor(
-    readonly status: number,
-    message: string,
-  ) {
-    super(message);
-    this.name = "AdapterError";
-  }
-}
+export class AdapterError extends Schema.TaggedError<AdapterError>()("AdapterError", {
+  status: Schema.Number,
+  message: Schema.String,
+}) {}
 
 /**
  * Run an effect (already provided with its layer) and reject with an AdapterError

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -89,7 +89,7 @@ export const app = new Elysia({
   })
   .onError(({ code, error, set, request }) => {
     set.headers["content-type"] = "application/json";
-    if (error instanceof AdapterError) {
+    if (Schema.is(AdapterError)(error)) {
       return toErrorResponse(error.status, error.message);
     }
     if (code === "NOT_FOUND") {

--- a/apps/adapter/src/integrations/arena/index.ts
+++ b/apps/adapter/src/integrations/arena/index.ts
@@ -3,6 +3,7 @@ import { Effect, Schema } from "effect";
 import { ArenaService } from "@tom/arena/service";
 import type { ArenaApi } from "@tom/arena/client";
 import type { PaginationAttributes } from "@tom/schemas/arena";
+import { HttpStatus } from "@tom/constants/http";
 import { HttpError } from "@tom/types/errors";
 import { simulatorEnv } from "../../simulator";
 import { retryPolicy } from "@tom/utils/retry";
@@ -63,10 +64,14 @@ const runArena = <T>(
       Effect.mapError((error) =>
         error instanceof HttpError
           ? error
-          : new HttpError({ message: error.message, status: 500, cause: error }),
+          : new HttpError({
+              message: error.message,
+              status: HttpStatus.InternalServerError,
+              cause: error,
+            }),
       ),
     ),
-    (error) => new AdapterError(error.status, error.message),
+    (error) => new AdapterError({ status: error.status, message: error.message }),
     context,
   );
 

--- a/apps/adapter/src/integrations/guestbook/index.ts
+++ b/apps/adapter/src/integrations/guestbook/index.ts
@@ -2,13 +2,15 @@ import { Elysia } from "elysia";
 import { Effect, Option, Schema } from "effect";
 import { DatabaseService, type GuestbookEntry } from "@tom/db/service";
 import { checkProfanity } from "@tom/utils/profanity";
+import { makeTomQueueLayer, TomQueueService } from "@tom/utils/services/queue";
+import { HttpStatus } from "@tom/constants/http";
 import { readCloudflareEnv } from "@tom/utils/services/config";
 import { getRequestEnv, logContextFromRequest } from "@tom/utils/services/worker";
 import type { LogContext } from "@tom/utils/services/logging";
 import {
   MissingFieldError,
   ProfanityError,
-  AuthenticationError,
+  type AuthenticationError,
   type GuestbookValidationError,
   type OAuthSessionError,
   HttpError,
@@ -36,29 +38,62 @@ type GuestbookError =
   | OAuthSessionError
   | HttpError;
 
-const guestbookStatus = (error: GuestbookError): number => {
-  if (error instanceof HttpError) return error.status;
-  if (error instanceof AuthenticationError) return 401;
-  return 400;
-};
+const guestbookStatus = (error: HttpError): number => error.status;
 
 const runGuestbook = <T>(
   env: CloudflareEnv,
-  effect: Effect.Effect<T, GuestbookError, DatabaseService>,
+  effect: Effect.Effect<T, GuestbookError, DatabaseService | TomQueueService>,
   context: LogContext,
 ): Promise<T> =>
   runAdapter(
     Effect.tryPromise(() => readCloudflareEnv(env)).pipe(
-      Effect.flatMap((resolved) => effect.pipe(Effect.provide(createDbLayer(resolved)))),
+      Effect.flatMap((resolved) =>
+        effect.pipe(
+          Effect.provide(createDbLayer(resolved)),
+          // No-op binding wrapper for routes that never send, and enables
+          // the sign route's best-effort enqueue without blocking the reply.
+          Effect.provide(makeTomQueueLayer(resolved)),
+        ),
+      ),
+      // HttpError carries the response status; pass it through, wrap every
+      // other failure (env resolution, database, flow) as a 500.
       Effect.mapError((error) =>
-        error instanceof HttpError
+        error._tag === "HttpError"
           ? error
-          : new HttpError({ message: error.message, status: 500, cause: error }),
+          : new HttpError({
+              message: error.message,
+              status: HttpStatus.InternalServerError,
+              cause: error,
+            }),
       ),
     ),
-    (error) => new AdapterError(guestbookStatus(error), error.message ?? "Bad request"),
+    (error) =>
+      new AdapterError({ status: guestbookStatus(error), message: error.message ?? "Bad request" }),
     context,
   );
+
+/**
+ * Enqueue a `guestbook-sign` job after the entry exists in the DB. The sign
+ * response never depends on the queue: a failed send is logged and the
+ * user's signature still stands.
+ */
+const notifyGuestbookSign = (entry: GuestbookEntry): Effect.Effect<void, never, TomQueueService> =>
+  Effect.gen(function* () {
+    const queue = yield* TomQueueService;
+    yield* queue
+      .send({
+        kind: "guestbook-sign",
+        entryId: entry.id,
+        fediverseUsername: entry.fediverse_username,
+        displayName: entry.display_name ?? "",
+        message: entry.message,
+      })
+      .pipe(
+        Effect.catchTag("QueueError", (error) =>
+          Effect.logWarning("guestbook:sign:enqueue-failed", { error: error.message }),
+        ),
+      );
+  });
 
 /**
  * In simulator mode (x-use-simulator + SIMULATOR_URL) entries come from the
@@ -67,7 +102,7 @@ const runGuestbook = <T>(
  */
 const simulatorEntries = (
   request: Request,
-): Effect.Effect<readonly GuestbookEntry[], GuestbookError, never> | undefined => {
+): Effect.Effect<readonly GuestbookEntry[], HttpError, never> | undefined => {
   const env = getRequestEnv(request);
   const simulatorUrl = env.SIMULATOR_URL;
   if (!isSimulatorRequest(request) || !simulatorUrl) return undefined;
@@ -85,12 +120,16 @@ const simulatorEntries = (
     if (!response.ok) {
       return yield* new HttpError({
         message: "Guestbook simulator error",
-        status: 502,
+        status: HttpStatus.BadGateway,
       });
     }
     const body = yield* Effect.tryPromise({
       try: () => response.json() as Promise<{ results: readonly GuestbookEntry[] }>,
-      catch: () => new HttpError({ message: "Guestbook simulator parse error", status: 502 }),
+      catch: () =>
+        new HttpError({
+          message: "Guestbook simulator parse error",
+          status: HttpStatus.BadGateway,
+        }),
     });
     yield* Effect.logInfo("guestbook:entries:simulator:success");
     return body.results;
@@ -121,7 +160,11 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
         if (effect) {
           return runAdapter(
             effect,
-            (error) => new AdapterError(guestbookStatus(error), error.message ?? "Bad request"),
+            (error) =>
+              new AdapterError({
+                status: guestbookStatus(error),
+                message: error.message ?? "Bad request",
+              }),
             context,
           );
         }
@@ -290,7 +333,8 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
             });
           }
 
-          yield* auth.signGuestbook({ user, message: body.message });
+          const entry = yield* auth.signGuestbook({ user, message: body.message });
+          yield* notifyGuestbookSign(entry);
           yield* Effect.logInfo("guestbook:sign:success");
           return { success: true };
         }),

--- a/apps/adapter/src/integrations/payload/index.ts
+++ b/apps/adapter/src/integrations/payload/index.ts
@@ -7,6 +7,7 @@ import {
   type PayloadPost,
   type PayloadResponse,
 } from "@tom/schemas/payload";
+import { HttpStatus } from "@tom/constants/http";
 import { readCloudflareEnv } from "@tom/utils/services/config";
 import { getRequestEnv, logContextFromRequest } from "@tom/utils/services/worker";
 import type { LogContext } from "@tom/utils/services/logging";
@@ -50,7 +51,7 @@ const runPayload = <T>(
         effect.pipe(Effect.provide(createPayloadLayer(simulatorEnv(resolved, request)))),
       ),
     ),
-    (error) => new AdapterError(500, error.message),
+    (error) => new AdapterError({ status: HttpStatus.InternalServerError, message: error.message }),
     context,
   );
 

--- a/apps/adapter/src/integrations/polar/index.ts
+++ b/apps/adapter/src/integrations/polar/index.ts
@@ -180,7 +180,11 @@ const createPolarCustomer = (
 const runPolar = <T>(effect: Effect.Effect<T, PolarApiError>, context: LogContext): Promise<T> =>
   runAdapter(
     effect,
-    (error) => new AdapterError(error.status || HttpStatus.InternalServerError, error.message),
+    (error) =>
+      new AdapterError({
+        status: error.status || HttpStatus.InternalServerError,
+        message: error.message,
+      }),
     context,
   );
 

--- a/apps/api/src/__tests__/queue-consumer.test.ts
+++ b/apps/api/src/__tests__/queue-consumer.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { Effect, Layer } from "effect";
+import { TelegramService } from "@tom/utils/telegram";
+import { buildGuestbookSignAlert, processMessage } from "../services/queue-consumer";
+
+const testTelegramLayer = (sendAlert: (message: string) => void) =>
+  Layer.succeed(TelegramService, {
+    sendAlert: (message: string) =>
+      Effect.sync(() => {
+        sendAlert(message);
+      }),
+    sendError: () => Effect.void,
+  });
+
+const guestbookSignMessage = {
+  kind: "guestbook-sign",
+  entryId: 7,
+  fediverseUsername: "tom@mastodon.social",
+  displayName: "Tom",
+  message: "hi!",
+} as const;
+
+describe("processMessage", () => {
+  it("sends a telegram alert for a guestbook-sign message", async () => {
+    const sendAlert = vi.fn();
+
+    await Effect.runPromise(
+      Effect.provide(processMessage(guestbookSignMessage), testTelegramLayer(sendAlert)),
+    );
+
+    expect(sendAlert).toHaveBeenCalledOnce();
+    expect(sendAlert).toHaveBeenCalledWith(expect.stringContaining("hi!"));
+  });
+
+  it("acks an unhandled kind without sending", async () => {
+    const sendAlert = vi.fn();
+
+    await Effect.runPromise(
+      Effect.provide(
+        processMessage({ kind: "render-og", url: new URL("https://tom.so") }),
+        testTelegramLayer(sendAlert),
+      ),
+    );
+
+    expect(sendAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildGuestbookSignAlert", () => {
+  it("renders the signer and message", () => {
+    const text = buildGuestbookSignAlert(guestbookSignMessage);
+    expect(text).toContain("*New guestbook signature*");
+    expect(text).toContain("@tom@mastodon.social (Tom)");
+    expect(text).toContain("hi!");
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import { requireInternalTokenBeforeHandle } from "./internal";
 import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { ogRoutes } from "./routes/og";
 import { polarRoutes } from "./routes/polar";
+import { queueHandler, type MessageBatch } from "./services/queue-consumer";
 
 export const app = new Elysia({
   adapter: CloudflareAdapter,
@@ -89,6 +90,7 @@ export type ApiApp = typeof app;
 
 const worker = {
   fetch: (request: Request, env: CloudflareEnv) => app.fetch(attachRequestEnv(request, env)),
+  queue: (batch: MessageBatch, env: CloudflareEnv) => queueHandler(batch, env),
 };
 
 export default worker;

--- a/apps/api/src/routes/polar.ts
+++ b/apps/api/src/routes/polar.ts
@@ -103,7 +103,7 @@ export const polarRoutes = new Elysia({ name: "polar" })
                   Effect.fail(
                     new PolarApiError({
                       message: "Polar returned an invalid checkout URL",
-                      status: 502,
+                      status: HttpStatus.BadGateway,
                       operation: "checkout",
                     }),
                   ),

--- a/apps/api/src/services/queue-consumer.ts
+++ b/apps/api/src/services/queue-consumer.ts
@@ -1,0 +1,92 @@
+import { Effect, Layer, Schema } from "effect";
+import { TomWorkMessage } from "@tom/schemas/queue";
+import type { TelegramError } from "@tom/types/errors";
+import { makeAppConfigLayer, readCloudflareEnv } from "@tom/utils/services/config";
+import type { CloudflareEnv } from "@tom/utils/services/config";
+import {
+  logLevelFromEnv,
+  otelConfigFromResolvedEnv,
+  withLogging,
+} from "@tom/utils/services/logging";
+import type { LogContext } from "@tom/utils/services/logging";
+import { TelegramService } from "@tom/utils/telegram";
+
+export type GuestbookSignMessage = Extract<TomWorkMessage, { kind: "guestbook-sign" }>;
+
+// Structural subset of the queue event the runtime delivers; the Worker
+// entry needs no full @cloudflare/workers-types dependency.
+type QueueMessage = { readonly id: string; readonly body: unknown };
+export type MessageBatch = { readonly messages: readonly QueueMessage[] };
+
+/**
+ * Markdown alert for the site owner, sent off the sign request path so the
+ * response never waits on Telegram.
+ */
+export const buildGuestbookSignAlert = (message: GuestbookSignMessage): string =>
+  [
+    "*New guestbook signature*",
+    "",
+    `*From:* @${message.fediverseUsername} (${message.displayName})`,
+    `*Message:* ${message.message}`,
+  ].join("\n");
+
+const handleGuestbookSign = Effect.fn("api.queue.guestbook-sign")((message: GuestbookSignMessage) =>
+  Effect.gen(function* () {
+    const telegram = yield* TelegramService;
+    yield* telegram.sendAlert(buildGuestbookSignAlert(message));
+  }),
+);
+
+/**
+ * Dispatch one decoded queue message. Handler errors propagate so Cloudflare
+ * Queues retries the batch and exhausted messages land in the DLQ.
+ */
+export const processMessage = (
+  message: TomWorkMessage,
+): Effect.Effect<void, TelegramError, TelegramService> =>
+  Effect.gen(function* () {
+    yield* Effect.logInfo("api:queue:process", { kind: message.kind });
+    if (message.kind === "guestbook-sign") {
+      yield* handleGuestbookSign(message);
+    } else {
+      // publish-post / render-og are not produced yet; ack with a warning
+      // rather than poisoning the queue.
+      yield* Effect.logWarning("api:queue:unhandled-kind", { kind: message.kind });
+    }
+  });
+
+const telegramLayer = (env: CloudflareEnv) => {
+  const configLayer = makeAppConfigLayer({
+    TELEGRAM_BOT_TOKEN: env.TELEGRAM_BOT_TOKEN,
+    TELEGRAM_CHAT_ID: env.TELEGRAM_CHAT_ID,
+  });
+  return Layer.provide(TelegramService.Default, configLayer);
+};
+
+/**
+ * The tom work queue consumer, hosted by the api worker (the script serves
+ * HTTP and drains the queue; both handlers coexist). Each body arrives as
+ * unknown JSON — decode at the boundary with TomWorkMessage, then let
+ * processMessage fail loudly on any handler error so Cloudflare retries the
+ * batch and exhausted messages land in the DLQ (tom-work-queue-dlq).
+ */
+export const queueHandler = async (batch: MessageBatch, env: CloudflareEnv): Promise<void> => {
+  const resolved = await readCloudflareEnv(env);
+  const otel = otelConfigFromResolvedEnv(resolved);
+  const context: LogContext = {
+    serviceName: "tom-api",
+    logLevel: logLevelFromEnv(resolved),
+    ...(otel && { otel }),
+  };
+  await Effect.runPromise(
+    withLogging(
+      Effect.gen(function* () {
+        for (const message of batch.messages) {
+          const job = yield* Schema.decodeUnknownEffect(TomWorkMessage)(message.body);
+          yield* processMessage(job);
+        }
+      }).pipe(Effect.provide(telegramLayer(resolved))),
+      context,
+    ),
+  );
+};

--- a/apps/web/src/libs/adapter.ts
+++ b/apps/web/src/libs/adapter.ts
@@ -3,6 +3,7 @@ import type { AdapterApp } from "@tom/adapter";
 import { getRequestEvent, isServer } from "@solidjs/web";
 import { Effect, Option, Schema } from "effect";
 import { HttpError } from "@tom/types/errors";
+import { HttpStatus } from "@tom/constants/http";
 import { withLogging } from "@tom/utils/services/logging";
 import type { LogContext } from "@tom/utils/services/logging";
 
@@ -87,7 +88,13 @@ export const adapterRequest = <T>(
   request: () => Promise<EdenResult<T>>,
 ): Effect.Effect<T, HttpError> =>
   Effect.tryPromise(() => request()).pipe(
-    Effect.mapError(() => new HttpError({ message: "Adapter request failed", status: 500 })),
+    Effect.mapError(
+      () =>
+        new HttpError({
+          message: "Adapter request failed",
+          status: HttpStatus.InternalServerError,
+        }),
+    ),
     Effect.flatMap((result) =>
       result.error
         ? Effect.fail(
@@ -101,7 +108,12 @@ export const adapterRequest = <T>(
     Effect.timeoutOrElse({
       duration: ADAPTER_TIMEOUT_MS,
       orElse: () =>
-        Effect.fail(new HttpError({ message: "Adapter request timed out", status: 504 })),
+        Effect.fail(
+          new HttpError({
+            message: "Adapter request timed out",
+            status: HttpStatus.GatewayTimeout,
+          }),
+        ),
     }),
   );
 

--- a/infra/apps/api.run.ts
+++ b/infra/apps/api.run.ts
@@ -4,7 +4,7 @@ import { Effect, Option, Schema } from "effect";
 import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
 import { stageHost, tomSecrets } from "../shared.run.ts";
-import { tomQueue } from "../queues/tom.queue.ts";
+import { tomQueue, tomQueueDlq } from "../queues/tom.queue.ts";
 import { TomSecretsSchema } from "@tom/schemas/secrets";
 
 const rootDir = `${import.meta.dirname}/../..`;
@@ -33,7 +33,10 @@ export const api = Effect.gen(function* () {
       ? yield* Cloudflare.SecretsStore.Secret.ref("AXIOM_TOKEN", { stack: "wwwtom" })
       : undefined;
 
-  return yield* Cloudflare.Worker("wwwtom-api", {
+  const queue = yield* tomQueue;
+  const dlq = yield* tomQueueDlq;
+
+  const worker = yield* Cloudflare.Worker("wwwtom-api", {
     main: `${rootDir}/apps/api/src/index.ts`,
     compatibility: { date: "2025-12-10" },
     dev: {
@@ -58,6 +61,18 @@ export const api = Effect.gen(function* () {
       WORK_QUEUE: tomQueue,
     },
   });
+
+  // The api worker hosts the single worker consumer (at most one per queue):
+  // it drains tom-work-queue via the `queue` handler in apps/api/src/index.ts;
+  // exhausted messages route to the DLQ.
+  yield* Cloudflare.Queues.Consumer("tom-work-consumer", {
+    queueId: queue.queueId,
+    scriptName: worker.workerName,
+    deadLetterQueue: dlq.queueName,
+    settings: { batchSize: 10, maxRetries: 3, maxWaitTimeMs: 5000 },
+  });
+
+  return worker;
 });
 
 export default Stack(

--- a/infra/queues/tom.queue.ts
+++ b/infra/queues/tom.queue.ts
@@ -4,8 +4,8 @@ import { Stage } from "alchemy/Stage";
 
 /**
  * The single generic tom work queue. Any app worker (web, api, adapter) binds
- * it as `WORK_QUEUE` in its env and enqueues work at runtime; a dedicated
- * consumer worker drains it (at most one worker consumer per queue).
+ * it as `WORK_QUEUE` in its env and enqueues work at runtime; the api worker
+ * hosts the single worker consumer (at most one per queue) that drains it.
  *
  * Production adopts the plain `tom-work-queue`; other stages get a
  * deterministic per-stage name so every app stack in a stage binds the same
@@ -38,13 +38,11 @@ import { Stage } from "alchemy/Stage";
  * Message bodies are `TomWorkMessage` (@tom/schemas/queue) — a tagged union
  * keyed on `kind`; `sendBatch` exists for several at once.
  *
- * @example Drain the queue from a consumer worker
+ * @example Drain the queue from the api worker (consumer)
  * ```ts
- * // infra/apps/worker.run.ts — register the consumer against a worker whose
- * // entry exports a `queue` handler.
- * const worker = yield* Cloudflare.Worker("wwwtom-worker", {
- *   main: `${rootDir}/apps/worker/src/index.ts`,
- * });
+ * // infra/apps/api.run.ts — the api worker's entry (apps/api/src/index.ts)
+ * // exports both `fetch` and `queue`; register the consumer against it.
+ * const queue = yield* tomQueue;
  * const dlq = yield* tomQueueDlq;
  * yield* Cloudflare.Queues.Consumer("tom-work-consumer", {
  *   queueId: queue.queueId,
@@ -54,26 +52,23 @@ import { Stage } from "alchemy/Stage";
  * });
  * ```
  * ```ts
- * // apps/worker/src/index.ts — bodies arrive as unknown JSON; parse at the
- * // boundary with the TomWorkMessage schema, then switch on `kind`.
+ * // apps/api/src/services/queue-consumer.ts — bodies arrive as unknown JSON;
+ * // parse at the boundary with the TomWorkMessage schema, then switch on kind.
  * import { Schema } from "effect";
  * import { TomWorkMessage } from "@tom/schemas/queue";
  *
- * export default {
- *   queue: async (batch) => {
- *     for (const message of batch.messages) {
- *       const job = Schema.decodeUnknownSync(TomWorkMessage)(message.body);
- *       switch (job.kind) {
- *         case "publish-post":
- *           await publishPost(job.postId);
- *           break;
- *         case "render-og":
- *           await renderOg(job.url);
- *           break;
- *       }
- *     }
- *   },
- * };
+ * const job = Schema.decodeUnknownSync(TomWorkMessage)(message.body);
+ * switch (job.kind) {
+ *   case "guestbook-sign":
+ *     await sendOwnerAlert(job);
+ *     break;
+ *   case "publish-post":
+ *     await publishPost(job.postId);
+ *     break;
+ *   case "render-og":
+ *     await renderOg(job.url);
+ *     break;
+ * }
  * ```
  * `maxRetries` + `retryDelay` give delivery guarantees; messages that still
  * fail land in the dead letter queue (see {@link tomQueueDlq}).

--- a/packages/@tom/arena/__tests__/client.test.ts
+++ b/packages/@tom/arena/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
+import { HttpError } from "@tom/types/errors";
 import { ArenaClient, paginationQueryString, type Fetch, type DateProvider } from "../src/client";
 
 type MockFetch = ReturnType<typeof vi.fn<Fetch>>;
@@ -276,7 +277,7 @@ describe("ArenaClient", () => {
   });
 
   describe("error handling", () => {
-    it("returns HttpError on network failure", async () => {
+    it("returns an HttpError with status 502 on network failure", async () => {
       const networkErrorFetch = vi.fn(async () => {
         throw new Error("Network down");
       });
@@ -286,17 +287,22 @@ describe("ArenaClient", () => {
 
       expect(result._tag).toBe("Failure");
       if (result._tag !== "Failure") throw new Error("Expected Failure");
-      const cause = result.cause;
-      expect(cause).toBeDefined();
-      expect(cause.reasons[0]?._tag).toBe("Fail");
+      const httpError = result.cause.reasons.find(Cause.isFailReason)?.error;
+      expect(httpError).toBeInstanceOf(HttpError);
+      if (!(httpError instanceof HttpError)) throw new Error("Expected HttpError");
+      // A network failure has no upstream status; 502 is the truthful one.
+      expect(httpError.status).toBe(502);
     });
 
-    it("returns HttpError on non-ok response", async () => {
+    it("returns an HttpError carrying the upstream status on non-ok response", async () => {
       const errorResponse = {
         ok: false,
         status: 404,
         statusText: "Not Found",
         headers: new Headers({ "content-type": "text/plain" }),
+        // The SDK normalizes non-ok bodies via response.text(); without it
+        // a TypeError would escape and land in the 500 catch-all.
+        text: async () => "",
         json: async () => ({}),
       } as Response;
       const errorFetch = vi.fn(async () => errorResponse);
@@ -306,9 +312,10 @@ describe("ArenaClient", () => {
 
       expect(result._tag).toBe("Failure");
       if (result._tag !== "Failure") throw new Error("Expected Failure");
-      const cause = result.cause;
-      expect(cause).toBeDefined();
-      expect(cause.reasons[0]?._tag).toBe("Fail");
+      const httpError = result.cause.reasons.find(Cause.isFailReason)?.error;
+      expect(httpError).toBeInstanceOf(HttpError);
+      if (!(httpError instanceof HttpError)) throw new Error("Expected HttpError");
+      expect(httpError.status).toBe(404);
     });
   });
 

--- a/packages/@tom/arena/src/client.ts
+++ b/packages/@tom/arena/src/client.ts
@@ -140,7 +140,9 @@ function mapArenaError(cause: unknown): HttpError {
     return new HttpError({ message: cause.message, status: cause.status });
   }
   if (cause instanceof ArenaNetworkError) {
-    return new HttpError({ message: cause.message, status: 0 });
+    // No HTTP response arrived; 502 is the truthful status for an upstream
+    // the adapter could not reach (never use 0 as a sentinel).
+    return new HttpError({ message: cause.message, status: HttpStatus.BadGateway });
   }
   return new HttpError({
     message: "Arena request failed",
@@ -505,7 +507,11 @@ export class ArenaClient implements ArenaApi {
             headers,
             body: null,
           }),
-        catch: () => new HttpError({ message: "Network request failed", status: 0 }),
+        catch: () =>
+          new HttpError({
+            message: "Network request failed",
+            status: HttpStatus.BadGateway,
+          }),
       });
 
       if (!response.ok) {

--- a/packages/@tom/constants/src/http.ts
+++ b/packages/@tom/constants/src/http.ts
@@ -21,3 +21,11 @@ export const HttpStatus = {
 } as const;
 
 export type HttpStatus = (typeof HttpStatus)[keyof typeof HttpStatus];
+
+/**
+ * True for a real HTTP error status (integer 4xx/5xx). The error-response
+ * boundary uses this so no sentinel (0), redirect class, or 2xx can reach
+ * the wire as an error status.
+ */
+export const isErrorStatus = (status: number): boolean =>
+  Number.isInteger(status) && status >= HttpStatus.BadRequest && status < 600;

--- a/packages/@tom/schemas/src/queue.ts
+++ b/packages/@tom/schemas/src/queue.ts
@@ -10,6 +10,15 @@ import { Schema } from "effect";
  * `unknown` body with it (`Schema.decodeUnknownSync(TomWorkMessage)(body)`).
  */
 export const TomWorkMessage = Schema.Union([
+  // Live: the adapter enqueues this after a guestbook entry is created; the
+  // queue consumer worker (apps/worker) turns it into a site-owner alert.
+  Schema.Struct({
+    kind: Schema.Literal("guestbook-sign"),
+    entryId: Schema.Number,
+    fediverseUsername: Schema.String,
+    displayName: Schema.String,
+    message: Schema.String,
+  }),
   Schema.Struct({
     kind: Schema.Literal("publish-post"),
     postId: Schema.Number,

--- a/packages/@tom/utils/__tests__/error-response.test.ts
+++ b/packages/@tom/utils/__tests__/error-response.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { toErrorResponse } from "../src/services/worker";
+
+describe("toErrorResponse", () => {
+  it("keeps a valid error status", async () => {
+    const response = toErrorResponse(502, "upstream down");
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "upstream down" });
+  });
+
+  it("falls back to 500 for a 0 sentinel", () => {
+    expect(toErrorResponse(0, "boom").status).toBe(500);
+  });
+
+  it("falls back to 500 for a redirect-class status", () => {
+    expect(toErrorResponse(302, "boom").status).toBe(500);
+  });
+
+  it("falls back to 500 for a non-error status", () => {
+    expect(toErrorResponse(200, "boom").status).toBe(500);
+  });
+});

--- a/packages/@tom/utils/__tests__/queue.test.ts
+++ b/packages/@tom/utils/__tests__/queue.test.ts
@@ -25,6 +25,20 @@ describe("TomWorkMessage", () => {
     expect(message.kind).toBe("render-og");
   });
 
+  it("decodes a guestbook-sign message", () => {
+    const message = Schema.decodeUnknownSync(TomWorkMessage)({
+      kind: "guestbook-sign",
+      entryId: 7,
+      fediverseUsername: "tom@mastodon.social",
+      displayName: "Tom",
+      message: "hi!",
+    });
+    if (message.kind !== "guestbook-sign") {
+      throw new Error("expected guestbook-sign");
+    }
+    expect(message.entryId).toBe(7);
+  });
+
   it("rejects an unknown kind", () => {
     expect(() => Schema.decodeUnknownSync(TomWorkMessage)({ kind: "nope" })).toThrow();
   });

--- a/packages/@tom/utils/src/services/worker.ts
+++ b/packages/@tom/utils/src/services/worker.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Schema } from "effect";
 import { errorResponseSchema } from "@tom/schemas/error";
-import { HttpStatus } from "@tom/constants/http";
+import { HttpStatus, isErrorStatus } from "@tom/constants/http";
 import { WorkerEnvMissingError } from "@tom/types/errors";
 import { TelegramService } from "../telegram";
 import { withLogging } from "./logging";
@@ -94,11 +94,19 @@ export const logApiFailure = (message: string, status: number, cause?: unknown) 
     ? Effect.logWarning(message, cause === undefined ? { status } : { status, cause })
     : Effect.logError(message, cause === undefined ? { status } : { status, cause });
 
+/**
+ * An error response status must be a real 4xx/5xx code; anything else (a
+ * 0 sentinel, a redirect class, a non-integer) would produce an invalid
+ * HTTP response, so fall back to 500 at the boundary.
+ */
+const toErrorStatus = (status: number): number =>
+  isErrorStatus(status) ? status : HttpStatus.InternalServerError;
+
 export const toErrorResponse = (status: number, error: string, cause?: string): Response =>
   new Response(
     JSON.stringify(Schema.encodeSync(errorResponseSchema)(cause ? { error, cause } : { error })),
     {
-      status,
+      status: toErrorStatus(status),
       headers: { "Content-Type": "application/json" },
     },
   );


### PR DESCRIPTION
Wire the previously unused `tom-work-queue` end to end through the guestbook sign flow.

### Changes

- **Producer (adapter):** `guestbook/sign` enqueues a schema-typed `guestbook-sign` job after the DB entry is created. Best-effort: a failed send is logged and never fails the sign response.
- **Consumer (api worker):** the api worker now exports both the Elysia `fetch` handler and a `queue` handler (`apps/api/src/services/queue-consumer.ts`). `infra/apps/api.run.ts` registers it as the single Cloudflare worker consumer on `tom-work-queue`, with the DLQ wired (`batchSize 10, maxRetries 3`).
- **Schema:** new `guestbook-sign` member of `TomWorkMessage` (`@tom/schemas/queue`).
- **Error-status hardening** (follows review feedback on `instanceof`-based dispatch of tagged errors):
  - `AdapterError` is now a `Schema.TaggedError` (was a hand-rolled `_tag` on `Error`); the Elysia boundary dispatches via `Schema.is`
  - `HttpError`/`AdapterError` normalization dispatches on `_tag`
  - arena client no longer emits a `status: 0` sentinel for network failures — 502 instead; `toErrorResponse` drops any invalid status to 500 at the response boundary; `HttpStatus.isErrorStatus` in `@tom/constants/http` is the single predicate
  - raw numeric statuses in error construction now use the `HttpStatus` vocabulary
- **Tests:** consumer dispatch (api), boundary guard (utils), strengthened arena network/upstream status assertions, `guestbook-sign` schema decode.

### Notes

- Deploy chain unchanged (`shared → api → adapter → web`); the consumer is created by the api stack.
- Delivery is at-least-once: a retried batch can duplicate the Telegram alert — acceptable for a one-person notification.
- Handler errors fail the batch so Cloudflare retries, then the DLQ captures exhausted messages.

### Checklist

- [x] I've left instructions in this PR for reviewers (where necessary).
- [x] I've created appropriate, meaningful tests if necessary.
- [x] I've added documentation and/or comments where we are introducing new patterns that aren't already established.
- [x] My changes have (passing) tests.
- [x] I'm confident this PR resolves the issue it is linked to in GitHub.