### PR TITLE
fix(e2e): retry staging suite through Cloudflare bot-protection blocks

### DIFF
--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -174,6 +174,19 @@ and on `workflow_dispatch`. Every push to `dev` deploys the staging stage
 via the Deploy workflow (production deploys are manual), so the nightly
 validates the latest staged stack.
 
+### Cloudflare bot protection on CI runs
+
+The suite is served through the Cloudflare edge (same `tom.so` zone), and
+GitHub-hosted runners come from datacenter IPs that Cloudflare bot
+protection intermittently fast-blocks (403 on API fetches) or answers with
+its Managed Challenge interstitial. Two layers make the suite resilient:
+config-level `retries` (`playwright.staging.config.ts`) re-run a failed
+test fresh, and the specific helpers in `src/helpers.ts`
+(`fetchWithBackoff` / `gotoWithBackoff`) retry transient
+transfer statuses with exponential backoff mirroring Effect's
+`Schedule.exponential`. Other statuses (404s, 422s, real app errors)
+pass through untouched so regressions surface immediately.
+
 ## Conventions for tests in this suite
 
 - Assert fixture data (titles, prices, messages) — never request counts,

--- a/apps/e2e/playwright.staging.config.ts
+++ b/apps/e2e/playwright.staging.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
   testDir: "./tests-staging",
   fullyParallel: true,
   forbidOnly: true,
-  retries: 0,
+  // GitHub-hosted runners come from datacenter IPs that Cloudflare bot
+  // protection intermittently challenges or fast-blocks; retries give each
+  // test a fresh context once the transient block clears. The three
+  // endpoint tests and the route-headings loop additionally back off
+  // in-spec (helpers.ts) so a blocked request is retried with delay.
+  retries: process.env.CI === "true" || process.env.CI === "1" ? 2 : 0,
   timeout: 30_000,
   expect: { timeout: 10_000 },
   reporter: [["list"], ["html", { open: "never" }]],

--- a/apps/e2e/src/helpers.ts
+++ b/apps/e2e/src/helpers.ts
@@ -1,10 +1,83 @@
-import { expect, type Page } from "@playwright/test";
+import {
+  expect,
+  type APIRequestContext,
+  type APIResponse,
+  type Page,
+  type Response,
+} from "@playwright/test";
 
 /**
  * Event plumbing that isn't a Playwright primitive — this file deliberately
  * contains no goto/expect wrappers; specs use page.goto, expect and locators
- * directly.
+ * directly. The two backoff helpers below are the exception: they exist only
+ * because the staging suite runs from GitHub-hosted runner IPs, which
+ * Cloudflare bot protection intermittently fast-blocks (see spec header).
  */
+
+/**
+ * Exponential backoff policy, mirroring Effect's Schedule.exponential: the
+ * first retry waits baseDelayMs and every subsequent retry doubles it.
+ */
+export interface BackoffOptions {
+  /** Total attempts including the first. Defaults to 4. */
+  attempts?: number;
+  /** Delay before the first retry, in ms. Doubles per retry. Defaults to 2s. */
+  baseDelayMs?: number;
+}
+
+/**
+ * Statuses Cloudflare's managed protections use when it fast-blocks or
+ * rate-limits a runner IP. Any other status is a real app answer and is
+ * returned on the first attempt so regressions surface immediately.
+ */
+const TRANSIENT_STATUSES = new Set([403, 429, 502, 503, 504]);
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True while the page is showing the Cloudflare Managed Challenge interstitial. */
+const isCloudflareChallenge = async (page: Page): Promise<boolean> =>
+  page.url().includes("__cf_chl") ||
+  (await page.getByText("Performing security verification").isVisible());
+
+/**
+ * GET with exponential backoff. Retries only on transient Cloudflare
+ * statuses; the first GET that answers with anything else is returned as-is.
+ */
+export const fetchWithBackoff = async (
+  request: APIRequestContext,
+  url: string,
+  options: BackoffOptions = {},
+): Promise<APIResponse> => {
+  const { attempts = 4, baseDelayMs = 2_000 } = options;
+  let response: APIResponse | undefined;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    response = await request.get(url);
+    if (response.ok() || !TRANSIENT_STATUSES.has(response.status())) return response;
+    if (attempt < attempts - 1) await sleep(baseDelayMs * 2 ** attempt);
+  }
+  return response as APIResponse;
+};
+
+/**
+ * Navigate with exponential backoff. If Cloudflare answers the browser with
+ * its Managed Challenge interstitial, wait and try again — the verification
+ * state on the runner IP often clears within one or two backoff windows.
+ * Returns the final navigation's response, challenge page or not.
+ */
+export const gotoWithBackoff = async (
+  page: Page,
+  url: string,
+  options: BackoffOptions = {},
+): Promise<Response | null> => {
+  const { attempts = 4, baseDelayMs = 2_000 } = options;
+  let response: Response | null = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    response = await page.goto(url);
+    if (!(await isCloudflareChallenge(page))) return response;
+    if (attempt < attempts - 1) await sleep(baseDelayMs * 2 ** attempt);
+  }
+  return response;
+};
 
 /** Return an assertion fn that fails if the page committed page/console errors. */
 export const expectNoPageErrors = (page: Page) => {

--- a/apps/e2e/tests-staging/site.smoke.spec.ts
+++ b/apps/e2e/tests-staging/site.smoke.spec.ts
@@ -1,10 +1,16 @@
 import { test, expect, type Page } from "@playwright/test";
-import { expectNoPageErrors } from "../src/helpers";
+import { expectNoPageErrors, fetchWithBackoff, gotoWithBackoff } from "../src/helpers";
 
 /**
  * Content-agnostic smoke tests against the deployed staging site. These
  * assert structure and behavior only — no fixture titles or IDs, so they
  * pass against whatever real data the staging stage holds.
+ *
+ * CI runs the suite from GitHub-hosted runner IPs, which Cloudflare bot
+ * protection intermittently fast-blocks (403) or answers with its Managed
+ * Challenge interstitial. The fetch/goto helpers below back off and retry
+ * on those transient responses; config-level retries (staging config) cover
+ * the remaining tests.
  */
 
 const expectNoErrors = async (page: Page): Promise<void> => {
@@ -28,13 +34,16 @@ test.describe("staging site chrome", () => {
   });
 
   test("static routes render their headings", async ({ page }) => {
+    // Backoff retries against the challenge interstitial can add ~14s per
+    // challenged route, so this loop gets a budget beyond the 30s default.
+    test.setTimeout(60_000);
     for (const [path, heading] of [
       ["/about", "About"],
       ["/accessibility", "Accessibility"],
       ["/thanks", "Thank you!"],
       ["/worktable", "Worktable"],
     ] as const) {
-      await page.goto(path);
+      await gotoWithBackoff(page, path);
       await expect(page.getByRole("heading", { name: heading, level: 1 })).toBeVisible();
       await expectNoErrors(page);
     }
@@ -57,7 +66,7 @@ test.describe("staging public endpoints", () => {
   });
 
   test("the RSS feed is valid XML with posts from the stage's CMS", async ({ request }) => {
-    const response = await request.get("/feed.xml");
+    const response = await fetchWithBackoff(request, "/feed.xml");
     expect(response.status()).toBe(200);
     expect(response.headers()["content-type"]).toContain("application/rss+xml");
     const body = await response.text();
@@ -67,7 +76,7 @@ test.describe("staging public endpoints", () => {
   });
 
   test("the sitemap lists live URLs", async ({ request }) => {
-    const response = await request.get("/sitemap.xml");
+    const response = await fetchWithBackoff(request, "/sitemap.xml");
     expect(response.status()).toBe(200);
     const body = await response.text();
     expect(body).toContain('<?xml version="1.0"');
@@ -89,7 +98,8 @@ test.describe("staging public endpoints", () => {
     // asserting the stage's direct endpoint keeps this check independent
     // of the production deploy state.
     const adapter = process.env.E2E_STAGING_ADAPTER_URL ?? "https://staging-adapter.tom.so";
-    const response = await request.get(
+    const response = await fetchWithBackoff(
+      request,
       `${adapter}/og?title=Home&summary=Tom%20Hackshaw%20is%20a%20design%20engineer%20from%20Aotearoa%2C%20New%20Zealand`,
     );
     expect(response.status(), "stage og image must generate").toBe(200);


### PR DESCRIPTION
Both nightly E2E (staging) runs have been red on the same four tests since the suite landed: `/feed.xml`, `/sitemap.xml` and the adapter `/og` return 403, and `/worktable` is served Cloudflare's Managed Challenge interstitial ("Performing security verification"). The failing artifacts show the requests are blocked at the Cloudflare edge, not by app code — every endpoint answers 200 for normal visitors, and the app routes cannot produce 403 (verified inline in `apps/adapter/src/integrations/og/index.ts`).

The suite runs from GitHub-hosted runner IPs (Azure datacenter ranges), which Cloudflare bot protection intermittently fast-blocks and challenges on the `tom.so` zone.

### Changes

- `apps/e2e/src/helpers.ts`: `fetchWithBackoff` / `gotoWithBackoff` — exponential-backoff retries (mirroring Effect's `Schedule.exponential`) for the three endpoint assertions and the route-headings loop. Only transient statuses (403/429/502/503/504) and the challenge interstitial are retried; real app errors pass through on the first attempt.
- `apps/e2e/playwright.staging.config.ts`: `retries: 2` under CI so every test gets a fresh context once a transient block clears (matches the fixture-suite config pattern).
- `apps/e2e/tests-staging/site.smoke.spec.ts`: wired the affected tests through the helpers; the route-headings loop gets a 60s timeout budget for backoff windows.
- `apps/e2e/README.md`: documented the two resilience layers.

Note on the Effect root cause: `Effect.retry` inside the workers cannot help here — the block is enforced by Cloudflare *before* any Worker runs, so the retry belongs in the Playwright layer.

### Verification

- `pnpm --filter @tom/e2e typecheck`, oxfmt, oxlint: clean.
- Full staging suite passes locally against the live staging stage: 11/11.
- Retry paths proven with a local server: transient 403 retries to 200; a 404 returns on the first attempt with no retry.

### Checklist

- [x] I've left instructions in this PR for reviewers (where necessary).
- [x] I've created appropriate, meaningful tests if necessary.
- [x] I've added documentation and/or comments where we are introducing new patterns that aren't already established.
- [x] My changes have (passing) tests.
- [x] I'm confident this PR resolves the issue it is linked to in GitHub.