### PR TITLE
feat(api,adapter): adopt RFC 9457 problem details for error responses

### DIFF
--- a/apps/adapter/src/__tests__/error-handling.test.ts
+++ b/apps/adapter/src/__tests__/error-handling.test.ts
@@ -14,10 +14,15 @@ afterEach(() => {
 });
 
 describe("adapter error handling", () => {
-  it("returns 404 JSON for unknown routes", async () => {
+  it("returns RFC 9457 problem details for unknown routes", async () => {
     const response = await app.fetch(requestWithEnv("http://localhost/nope", testEnv()));
     expect(response.status).toBe(404);
-    expect(await response.json()).toEqual({ error: "Not found" });
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/not-found",
+      status: 404,
+      title: "Not found",
+      instance: "http://localhost/nope",
+    });
   });
 
   it("forwards an unparseable page param and falls back to the empty page", async () => {
@@ -45,10 +50,15 @@ describe("adapter error handling", () => {
     );
   });
 
-  it("returns 500 JSON when an integration has no access token configured", async () => {
+  it("returns 500 problem details when an integration has no access token configured", async () => {
     const response = await app.fetch(requestWithEnv("http://localhost/polar/products", testEnv()));
     expect(response.status).toBe(500);
     const body = await response.json();
-    expect(body.error).toBe("Network error");
+    expect(body).toEqual({
+      type: "about:blank",
+      status: 500,
+      title: "Network error",
+      instance: "http://localhost/polar/products",
+    });
   });
 });

--- a/apps/adapter/src/__tests__/guestbook-errors.test.ts
+++ b/apps/adapter/src/__tests__/guestbook-errors.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { requestWithEnv, testEnv } from "../test/helpers";
+
+const env = testEnv();
+
+const userCookie = encodeURIComponent(
+  JSON.stringify({
+    username: "tom",
+    instance: "mastodon.social",
+    display_name: "Tom",
+    avatar_url: "https://mastodon.social/avatar.png",
+    access_token: "token",
+  }),
+);
+
+const signedInRequest = (url: string, init: RequestInit = {}) =>
+  requestWithEnv(url, env, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `guestbook_user=${userCookie}`,
+      ...init.headers,
+    },
+  });
+
+const postJson = (url: string, body: Record<string, string>) =>
+  signedInRequest(url, { method: "POST", body: JSON.stringify(body) });
+
+describe("guestbook flow error mapping", () => {
+  it("maps a profanity failure to a 400 validation problem", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/sign", { message: "fuck" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Your message contains profanity. Please keep it clean!",
+      instance: "http://localhost/guestbook/sign",
+    });
+  });
+
+  it("maps a missing sign message to a 400 validation problem naming the field", async () => {
+    const response = await app.fetch(postJson("http://localhost/guestbook/sign", { message: "" }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Missing required field: message",
+      instance: "http://localhost/guestbook/sign",
+    });
+  });
+
+  it("maps an invalid fediverse handle to a 400 validation problem", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/auth/initiate", { handle: "not-a-handle" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Invalid fediverse handle format. Use: user@instance.social (without the leading @)",
+      instance: "http://localhost/guestbook/auth/initiate",
+    });
+  });
+
+  it("maps a missing handle to a 400 validation problem", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/auth/initiate", { handle: "" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Missing field: handle",
+      instance: "http://localhost/guestbook/auth/initiate",
+    });
+  });
+
+  it("rejects a sign without a signed-in user as 401 unauthorized", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/guestbook/sign", env, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello" }),
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/unauthorized",
+      status: 401,
+      title: "Not authenticated",
+      instance: "http://localhost/guestbook/sign",
+    });
+  });
+});

--- a/apps/adapter/src/__tests__/polar.test.ts
+++ b/apps/adapter/src/__tests__/polar.test.ts
@@ -31,11 +31,16 @@ describe("polar integration", () => {
       expect(await response.json()).toEqual(products);
     });
 
-    it("maps Polar errors to a JSON error response", async () => {
+    it("maps Polar errors to RFC 9457 problem details", async () => {
       fetchMock.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
       const response = await app.fetch(requestWithEnv("http://localhost/polar/products", polarEnv));
       expect(response.status).toBe(401);
-      expect(await response.json()).toEqual({ error: "Failed to fetch products" });
+      expect(await response.json()).toEqual({
+        type: "https://errors.tom.so/unauthorized",
+        status: 401,
+        title: "Failed to fetch products",
+        instance: "http://localhost/polar/products",
+      });
     });
   });
 
@@ -54,13 +59,18 @@ describe("polar integration", () => {
       expect(await response.json()).toEqual(product);
     });
 
-    it("maps Polar errors to a JSON error response", async () => {
+    it("maps Polar errors to RFC 9457 problem details", async () => {
       fetchMock.mockResolvedValue(jsonResponse({ error: "not found" }, 404));
       const response = await app.fetch(
         requestWithEnv("http://localhost/polar/products/missing", polarEnv),
       );
       expect(response.status).toBe(404);
-      expect(await response.json()).toEqual({ error: "Failed to fetch product" });
+      expect(await response.json()).toEqual({
+        type: "https://errors.tom.so/not-found",
+        status: 404,
+        title: "Failed to fetch product",
+        instance: "http://localhost/polar/products/missing",
+      });
     });
   });
 
@@ -99,7 +109,10 @@ describe("polar integration", () => {
         }),
       );
       expect(response.status).toBe(400);
-      expect(await response.json()).toEqual({ error: "Validation error" });
+      const body = await response.json();
+      expect(body.type).toBe("https://errors.tom.so/validation");
+      expect(body.title).toBe("Validation error");
+      expect(body.errors?.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -1,4 +1,10 @@
-import { Elysia } from "elysia";
+import {
+  Elysia,
+  ValidationError,
+  type InternalServerError,
+  type NotFoundError,
+  type ParseError,
+} from "elysia";
 import { CloudflareAdapter } from "elysia/adapter/cloudflare-worker";
 import { cors } from "@elysiajs/cors";
 import { Effect, Option, Schema } from "effect";
@@ -8,9 +14,11 @@ import {
   attachRequestEnv,
   getRequestEnv,
   sendErrorAlert,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
 import type { CloudflareEnv } from "@tom/utils/services/config";
+import { HttpStatus } from "@tom/constants/http";
+import { ProblemType } from "@tom/constants/problem";
 import { AdapterError } from "./config/effect";
 import { arenaIntegration } from "./integrations/arena";
 import { payloadIntegration } from "./integrations/payload";
@@ -87,21 +95,32 @@ export const app = new Elysia({
       ...(otel && { otel }),
     });
   })
-  .onError(({ code, error, set, request }) => {
-    set.headers["content-type"] = "application/json";
+  .onError(({ code, error, request }) => {
     if (Schema.is(AdapterError)(error)) {
-      return toErrorResponse(error.status, error.message);
+      const type = problemTypeForStatus(error.status);
+      return toProblemResponse(error.status, error.message, {
+        ...(type && { type }),
+        instance: request.url,
+      });
     }
     if (code === "NOT_FOUND") {
       Effect.runFork(Effect.logWarning("Not found", { path: request.url }));
-      return toErrorResponse(404, "Not found");
+      return toProblemResponse(HttpStatus.NotFound, "Not found", {
+        type: ProblemType.NotFound,
+        instance: request.url,
+      });
     }
     if (code === "VALIDATION") {
       Effect.runFork(Effect.logWarning("Validation error", { path: request.url }));
-      return toErrorResponse(400, "Validation error");
+      const errors = toValidationProblems(error);
+      return toProblemResponse(HttpStatus.BadRequest, "Validation error", {
+        type: ProblemType.Validation,
+        instance: request.url,
+        ...(errors && { errors }),
+      });
     }
     sendErrorAlert(getRequestEnv(request), "Unhandled adapter error", error);
-    return toErrorResponse(500, "Internal server error");
+    return toProblemResponse(HttpStatus.InternalServerError, "Internal server error");
   })
   .use(arenaIntegration)
   .use(payloadIntegration)
@@ -113,6 +132,37 @@ export const app = new Elysia({
   .compile();
 
 export type AdapterApp = typeof app;
+
+/**
+ * Field-level problems from an Elysia validation failure, as the RFC 9457
+ * `errors` extension (JSON-pointer paths, rfc9457 §3.2).
+ */
+const toValidationProblems = (
+  error: Error | ValidationError | ParseError | NotFoundError | InternalServerError,
+): readonly { readonly detail: string; readonly pointer: string }[] | undefined =>
+  error instanceof ValidationError && error.all.length > 0
+    ? error.all.map(({ path, message }) => ({ detail: message, pointer: toPointer(path) }))
+    : undefined;
+
+/** Dot-joined Elysia error paths become RFC 6901 JSON pointers. */
+const toPointer = (path: string): string =>
+  path === "root" ? "#" : `#/${path.split(".").join("/")}`;
+
+/** RFC 9457 problem type for a wrapped AdapterError's status, when known. */
+const problemTypeForStatus = (status: number): string | undefined => {
+  switch (status) {
+    case HttpStatus.BadRequest:
+      return ProblemType.Validation;
+    case HttpStatus.Unauthorized:
+      return ProblemType.Unauthorized;
+    case HttpStatus.Forbidden:
+      return ProblemType.Forbidden;
+    case HttpStatus.NotFound:
+      return ProblemType.NotFound;
+    default:
+      return undefined;
+  }
+};
 
 const worker = {
   fetch: (request: Request, env: CloudflareEnv) => app.fetch(attachRequestEnv(request, env)),

--- a/apps/adapter/src/integrations/guestbook/index.ts
+++ b/apps/adapter/src/integrations/guestbook/index.ts
@@ -5,7 +5,12 @@ import { checkProfanity } from "@tom/utils/profanity";
 import { makeTomQueueLayer, TomQueueService } from "@tom/utils/services/queue";
 import { HttpStatus } from "@tom/constants/http";
 import { readCloudflareEnv } from "@tom/utils/services/config";
-import { getRequestEnv, logContextFromRequest } from "@tom/utils/services/worker";
+import {
+  getRequestEnv,
+  logContextFromRequest,
+  toProblemResponse,
+} from "@tom/utils/services/worker";
+import { ProblemType } from "@tom/constants/problem";
 import type { LogContext } from "@tom/utils/services/logging";
 import {
   MissingFieldError,
@@ -21,7 +26,7 @@ import { isSimulatorRequest } from "../../simulator";
 import {
   authUrlResponseSchema,
   callbackQuerySchema,
-  errorResponseSchema,
+  problemDetailsSchema,
   guestbookSessionCookieSchema,
   guestbookUserCookieSchema,
   handleBodySchema,
@@ -38,7 +43,40 @@ type GuestbookError =
   | OAuthSessionError
   | HttpError;
 
-const guestbookStatus = (error: HttpError): number => error.status;
+/** A failure from the guestbook flow channel (HttpError or a flow error). */
+type GuestbookFlowError = { readonly _tag: string };
+
+/**
+ * HTTP status for a guestbook failure. HttpError carries its own status;
+ * client-flow failures map to 4xx; anything else (env, database, unknown)
+ * stays a 500.
+ */
+const guestbookStatus = (error: GuestbookFlowError): number => {
+  switch (error._tag) {
+    case "HttpError":
+      return (error as HttpError).status;
+    case "AuthenticationError":
+      return HttpStatus.Unauthorized;
+    case "MissingFieldError":
+    case "ProfanityError":
+    case "GuestbookValidationError":
+    case "OAuthSessionError":
+      return HttpStatus.BadRequest;
+    default:
+      return HttpStatus.InternalServerError;
+  }
+};
+
+/** User-facing message for a guestbook failure; field-only errors get one. */
+const guestbookMessage = (
+  error: GuestbookFlowError & {
+    readonly message?: string;
+    readonly field?: string;
+  },
+): string =>
+  error._tag === "MissingFieldError"
+    ? `Missing required field: ${error.field}`
+    : (error.message ?? "Bad request");
 
 const runGuestbook = <T>(
   env: CloudflareEnv,
@@ -55,14 +93,15 @@ const runGuestbook = <T>(
           Effect.provide(makeTomQueueLayer(resolved)),
         ),
       ),
-      // HttpError carries the response status; pass it through, wrap every
-      // other failure (env resolution, database, flow) as a 500.
+      // HttpError carries the response status; client-flow failures map to
+      // their 4xx status with a user-facing message; anything else (env
+      // resolution, database, unknown flow failures) stays a 500.
       Effect.mapError((error) =>
         error._tag === "HttpError"
           ? error
           : new HttpError({
-              message: error.message,
-              status: HttpStatus.InternalServerError,
+              message: guestbookMessage(error),
+              status: guestbookStatus(error),
               cause: error,
             }),
       ),
@@ -203,11 +242,13 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
   )
   .post(
     "/guestbook/auth/initiate",
-    ({ body, cookie, request, set }) => {
+    ({ body, cookie, request }) => {
       const env = getRequestEnv(request);
       if (!body.handle) {
-        set.status = 400;
-        return { error: "Missing field: handle" };
+        return toProblemResponse(HttpStatus.BadRequest, "Missing field: handle", {
+          type: ProblemType.Validation,
+          instance: request.url,
+        });
       }
 
       const adapterUrl = env.ADAPTER_URL ?? "http://localhost:8788";
@@ -244,9 +285,9 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
       cookie: guestbookSessionCookieSchema,
       response: {
         200: authUrlResponseSchema,
-        400: errorResponseSchema,
-        401: errorResponseSchema,
-        500: errorResponseSchema,
+        400: problemDetailsSchema,
+        401: problemDetailsSchema,
+        500: problemDetailsSchema,
       },
       detail: { description: "Start Fediverse OAuth for the guestbook", tags: ["guestbook"] },
     },
@@ -302,7 +343,7 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
   )
   .post(
     "/guestbook/sign",
-    ({ body, cookie, request, set }) => {
+    ({ body, cookie, request }) => {
       const env = getRequestEnv(request);
       const userJson = Option.getOrElse(
         Schema.decodeUnknownOption(Schema.String)(cookie.guestbook_user.value),
@@ -313,8 +354,10 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
         () => null,
       );
       if (!user) {
-        set.status = 401;
-        return { error: "Not authenticated" };
+        return toProblemResponse(HttpStatus.Unauthorized, "Not authenticated", {
+          type: ProblemType.Unauthorized,
+          instance: request.url,
+        });
       }
 
       return runGuestbook(
@@ -346,9 +389,9 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
       cookie: guestbookUserCookieSchema,
       response: {
         200: successResponseSchema,
-        400: errorResponseSchema,
-        401: errorResponseSchema,
-        500: errorResponseSchema,
+        400: problemDetailsSchema,
+        401: problemDetailsSchema,
+        500: problemDetailsSchema,
       },
       detail: { description: "Sign the guestbook (requires the user cookie)", tags: ["guestbook"] },
     },

--- a/apps/adapter/src/integrations/image/index.ts
+++ b/apps/adapter/src/integrations/image/index.ts
@@ -6,8 +6,9 @@ import {
   logApiFailure,
   logContextFromRequest,
   runEffect,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
+import { ProblemType } from "@tom/constants/problem";
 
 const ALLOWED_DOMAINS = ["cdn.tom.so"];
 
@@ -25,7 +26,7 @@ const imageQuerySchema = Schema.toStandardSchemaV1(ImageQuerySchema);
 const toImageError = (message: string, cause?: unknown): ImageError => {
   const fields = cause === undefined ? {} : { cause };
   return new ImageError({
-    response: toErrorResponse(HttpStatus.InternalServerError, message),
+    response: toProblemResponse(HttpStatus.InternalServerError, message),
     ...fields,
   });
 };
@@ -45,7 +46,9 @@ export const imageIntegration = new Elysia({ name: "image" }).get(
             onNone: () =>
               Effect.fail(
                 new ImageError({
-                  response: toErrorResponse(HttpStatus.BadRequest, "Invalid URL"),
+                  response: toProblemResponse(HttpStatus.BadRequest, "Invalid URL", {
+                    type: ProblemType.Validation,
+                  }),
                 }),
               ),
             onSome: (url) => Effect.succeed(url),
@@ -54,7 +57,9 @@ export const imageIntegration = new Elysia({ name: "image" }).get(
 
         if (!ALLOWED_DOMAINS.includes(parsed.hostname)) {
           return yield* new ImageError({
-            response: toErrorResponse(HttpStatus.Forbidden, "Domain not allowed"),
+            response: toProblemResponse(HttpStatus.Forbidden, "Domain not allowed", {
+              type: ProblemType.Forbidden,
+            }),
           });
         }
 

--- a/apps/adapter/src/integrations/og/index.ts
+++ b/apps/adapter/src/integrations/og/index.ts
@@ -9,8 +9,9 @@ import {
   getRequestEnv,
   logContextFromRequest,
   runEffect,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
+import { ProblemType } from "@tom/constants/problem";
 
 /**
  * OG text is free text and legitimately contains commas ("Aotearoa, New
@@ -86,7 +87,9 @@ export const ogIntegration = new Elysia({ name: "og" }).get(
       Effect.catch(
         Effect.fn("ogErrorHandler")(function* (error: ImageGenerationError) {
           yield* Effect.logError("OG image proxy error", error);
-          return toErrorResponse(HttpStatus.InternalServerError, error.message);
+          return toProblemResponse(HttpStatus.InternalServerError, error.message, {
+            type: ProblemType.Upstream,
+          });
         }),
       ),
     );

--- a/apps/adapter/src/integrations/polar/index.ts
+++ b/apps/adapter/src/integrations/polar/index.ts
@@ -11,7 +11,7 @@ import {
   logApiFailure,
   logContextFromRequest,
   runEffect,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
 import { readCloudflareEnv, type CloudflareEnv } from "@tom/utils/services/config";
 import type { LogContext } from "@tom/utils/services/logging";
@@ -208,7 +208,7 @@ const proxyToApi = (
           const location = upstream.headers.get("location");
           if (location) return Response.redirect(location, upstream.status);
         }
-        return toErrorResponse(HttpStatus.InternalServerError, errorMessage);
+        return toProblemResponse(HttpStatus.InternalServerError, errorMessage);
       }),
     ),
     context,

--- a/apps/adapter/src/schemas.ts
+++ b/apps/adapter/src/schemas.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { errorResponseSchema as sharedErrorResponseSchema } from "@tom/schemas/error";
+import { problemDetailsSchema as sharedProblemDetailsSchema } from "@tom/schemas/error";
 
 export const PaginationQuerySchema = Schema.Struct({
   page: Schema.optional(Schema.NumberFromString),
@@ -73,4 +73,4 @@ export const successResponseSchema = Schema.toStandardSchemaV1(
   Schema.Struct({ success: Schema.Boolean }),
 );
 
-export const errorResponseSchema = Schema.toStandardSchemaV1(sharedErrorResponseSchema);
+export const problemDetailsSchema = Schema.toStandardSchemaV1(sharedProblemDetailsSchema);

--- a/apps/api/src/__tests__/internal-auth.test.ts
+++ b/apps/api/src/__tests__/internal-auth.test.ts
@@ -9,7 +9,11 @@ describe("internal token auth", () => {
       requestWithEnv("http://localhost/checkout?products=prod_1", testEnv()),
     );
     expect(response.status).toBe(401);
-    expect(await response.json()).toEqual({ error: "Unauthorized" });
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/unauthorized",
+      status: 401,
+      title: "Unauthorized",
+    });
   });
 
   it("rejects /checkout with a wrong token", async () => {
@@ -19,6 +23,7 @@ describe("internal token auth", () => {
       }),
     );
     expect(response.status).toBe(401);
+    expect((await response.json()).type).toBe("https://errors.tom.so/unauthorized");
   });
 
   it("leaves /og public for social crawlers", async () => {

--- a/apps/api/src/__tests__/not-found.test.ts
+++ b/apps/api/src/__tests__/not-found.test.ts
@@ -3,9 +3,15 @@ import { app } from "../index";
 import { requestWithEnv, testEnv } from "../test/helpers";
 
 describe("api error handling", () => {
-  it("returns 404 JSON for unknown routes", async () => {
+  it("returns RFC 9457 problem details for unknown routes", async () => {
     const response = await app.fetch(requestWithEnv("http://localhost/nope", testEnv()));
     expect(response.status).toBe(404);
-    expect(await response.json()).toEqual({ error: "Not found" });
+    expect(response.headers.get("content-type")).toBe("application/problem+json");
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/not-found",
+      status: 404,
+      title: "Not found",
+      instance: "http://localhost/nope",
+    });
   });
 });

--- a/apps/api/src/__tests__/polar.test.ts
+++ b/apps/api/src/__tests__/polar.test.ts
@@ -86,7 +86,13 @@ describe("polar routes", () => {
     it("returns 400 when products are missing", async () => {
       const response = await app.fetch(internalRequest("http://localhost/checkout", env));
       expect(response.status).toBe(400);
-      expect(await response.json()).toEqual({ error: "Validation error" });
+      expect(await response.json()).toEqual({
+        type: "https://errors.tom.so/validation",
+        status: 400,
+        title: "Validation error",
+        instance: "http://localhost/checkout",
+        errors: [{ pointer: "#/products", detail: "Missing key" }],
+      });
     });
 
     it("returns Polar's 4xx status when the product doesn't exist", async () => {
@@ -96,7 +102,11 @@ describe("polar routes", () => {
       );
       expect(response.status).toBe(404);
       const body = await response.json();
-      expect(body).toEqual({ error: "Failed to create checkout" });
+      expect(body).toEqual({
+        type: "about:blank",
+        status: 404,
+        title: "Failed to create checkout",
+      });
     });
 
     it("returns 500 JSON when Polar fails with a server error", async () => {
@@ -106,7 +116,11 @@ describe("polar routes", () => {
       );
       expect(response.status).toBe(500);
       const body = await response.json();
-      expect(body).toEqual({ error: "Failed to create checkout" });
+      expect(body).toEqual({
+        type: "about:blank",
+        status: 500,
+        title: "Failed to create checkout",
+      });
     });
 
     it("returns 500 JSON when Polar is unreachable", async () => {
@@ -116,7 +130,11 @@ describe("polar routes", () => {
       );
       expect(response.status).toBe(500);
       const body = await response.json();
-      expect(body).toEqual({ error: "Network error" });
+      expect(body).toEqual({
+        type: "about:blank",
+        status: 500,
+        title: "Network error",
+      });
     });
   });
 
@@ -145,7 +163,13 @@ describe("polar routes", () => {
     it("returns 400 when customerId is missing", async () => {
       const response = await app.fetch(internalRequest("http://localhost/portal", env));
       expect(response.status).toBe(400);
-      expect(await response.json()).toEqual({ error: "Validation error" });
+      expect(await response.json()).toEqual({
+        type: "https://errors.tom.so/validation",
+        status: 400,
+        title: "Validation error",
+        instance: "http://localhost/portal",
+        errors: [{ pointer: "#/customerId", detail: "Missing key" }],
+      });
     });
 
     it("returns 500 JSON when Polar fails", async () => {
@@ -155,7 +179,11 @@ describe("polar routes", () => {
       );
       expect(response.status).toBe(500);
       const body = await response.json();
-      expect(body).toEqual({ error: "Failed to create customer session" });
+      expect(body).toEqual({
+        type: "about:blank",
+        status: 500,
+        title: "Failed to create customer session",
+      });
     });
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,10 @@
-import { Elysia } from "elysia";
+import {
+  Elysia,
+  ValidationError,
+  type InternalServerError,
+  type NotFoundError,
+  type ParseError,
+} from "elysia";
 import { CloudflareAdapter } from "elysia/adapter/cloudflare-worker";
 import { openapi } from "@elysiajs/openapi";
 import { Effect } from "effect";
@@ -8,15 +14,32 @@ import {
   attachRequestEnv,
   getRequestEnv,
   sendErrorAlert,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
 import type { CloudflareEnv } from "@tom/utils/services/config";
+import { HttpStatus } from "@tom/constants/http";
+import { ProblemType } from "@tom/constants/problem";
 import { healthRoutes } from "./routes/health";
 import { requireInternalTokenBeforeHandle } from "./internal";
 import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { ogRoutes } from "./routes/og";
 import { polarRoutes } from "./routes/polar";
 import { queueHandler, type MessageBatch } from "./services/queue-consumer";
+
+/**
+ * Field-level problems from an Elysia validation failure, as the RFC 9457
+ * `errors` extension (JSON-pointer paths, rfc9457 §3.2).
+ */
+const toValidationProblems = (
+  error: Error | ValidationError | ParseError | NotFoundError | InternalServerError,
+): readonly { readonly detail: string; readonly pointer: string }[] | undefined =>
+  error instanceof ValidationError && error.all.length > 0
+    ? error.all.map(({ path, message }) => ({ detail: message, pointer: toPointer(path) }))
+    : undefined;
+
+/** Dot-joined Elysia error paths become RFC 6901 JSON pointers. */
+const toPointer = (path: string): string =>
+  path === "root" ? "#" : `#/${path.split(".").join("/")}`;
 
 export const app = new Elysia({
   adapter: CloudflareAdapter,
@@ -62,22 +85,29 @@ export const app = new Elysia({
       ...(otel && { otel }),
     });
   })
-  .onError(({ code, error, set, request }) => {
-    set.headers["content-type"] = "application/json";
+  .onError(({ code, error, request }) => {
     if (code === "NOT_FOUND") {
       Effect.runFork(Effect.logWarning("Not found", { path: request.url }));
-      return toErrorResponse(404, "Not found");
+      return toProblemResponse(HttpStatus.NotFound, "Not found", {
+        type: ProblemType.NotFound,
+        instance: request.url,
+      });
     }
     if (code === "VALIDATION") {
       Effect.runFork(Effect.logWarning("Validation error", { path: request.url }));
-      return toErrorResponse(400, "Validation error");
+      const errors = toValidationProblems(error);
+      return toProblemResponse(HttpStatus.BadRequest, "Validation error", {
+        type: ProblemType.Validation,
+        instance: request.url,
+        ...(errors && { errors }),
+      });
     }
     Effect.runFork(
       Effect.sync(() => {
         void sendErrorAlert(getRequestEnv(request), "Unhandled API error", error);
       }),
     );
-    return toErrorResponse(500, "Internal server error");
+    return toProblemResponse(HttpStatus.InternalServerError, "Internal server error");
   })
   .use(healthRoutes)
   // OG image generation is a public route: social crawlers (Twitter, Slack,

--- a/apps/api/src/internal.ts
+++ b/apps/api/src/internal.ts
@@ -1,8 +1,9 @@
 import { Effect } from "effect";
 import { HttpStatus } from "@tom/constants/http";
+import { ProblemType } from "@tom/constants/problem";
 import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { readCloudflareEnv } from "@tom/utils/services/config";
-import { getRequestEnv, toErrorResponse } from "@tom/utils/services/worker";
+import { getRequestEnv, toProblemResponse } from "@tom/utils/services/worker";
 
 /** Constant-time comparison so token timing can't leak the shared secret. */
 const timingSafeEqual = (a: string, b: string): boolean => {
@@ -30,6 +31,9 @@ export const requireInternalTokenBeforeHandle = async ({ request }: { request: R
         hasToken: provided !== null,
       }),
     );
-    return toErrorResponse(HttpStatus.Unauthorized, "Unauthorized");
+    return toProblemResponse(HttpStatus.Unauthorized, "Unauthorized", {
+      type: ProblemType.Unauthorized,
+    });
   }
+  return;
 };

--- a/apps/api/src/routes/og.ts
+++ b/apps/api/src/routes/og.ts
@@ -1,6 +1,6 @@
 import { Elysia } from "elysia";
 import { Effect, Schema } from "effect";
-import { errorResponseSchema } from "@tom/schemas/error";
+import { problemDetailsSchema } from "@tom/schemas/error";
 import { ValidationError } from "@tom/types/errors";
 import { logContextFromRequest, runEffect } from "@tom/utils/services/worker";
 import { toOpenApiSchema } from "../openapi";
@@ -67,15 +67,15 @@ const imageResponseSchema = Schema.String.pipe(
   Schema.annotate({ description: "Generated OG image (PNG)" }),
 );
 
-const badRequestSchema = errorResponseSchema.pipe(
+const badRequestSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Invalid query parameters" }),
 );
 
-const failedSchema = errorResponseSchema.pipe(
+const failedSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Image generation failed" }),
 );
 
-const badGatewaySchema = errorResponseSchema.pipe(
+const badGatewaySchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Font fetch failed" }),
 );
 

--- a/apps/api/src/routes/polar.ts
+++ b/apps/api/src/routes/polar.ts
@@ -1,7 +1,7 @@
 import { Elysia } from "elysia";
 import { Effect, Option, Schema } from "effect";
 import { HttpStatus } from "@tom/constants/http";
-import { errorResponseSchema } from "@tom/schemas/error";
+import { problemDetailsSchema } from "@tom/schemas/error";
 import { PolarApiError } from "@tom/types/errors";
 import {
   getRequestEnv,
@@ -53,19 +53,19 @@ const portalQuerySchema = toOpenApiSchema(PortalQuerySchema);
 const redirectSchema = (description: string) =>
   Schema.String.pipe(Schema.annotate({ description }));
 
-const missingCustomerSchema = errorResponseSchema.pipe(
+const missingCustomerSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Missing products and/or customerId parameter" }),
 );
 
-const missingPortalSchema = errorResponseSchema.pipe(
+const missingPortalSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Missing customerId parameter" }),
 );
 
-const checkoutFailedSchema = errorResponseSchema.pipe(
+const checkoutFailedSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Failed to create checkout" }),
 );
 
-const productNotFoundSchema = errorResponseSchema.pipe(
+const productNotFoundSchema = problemDetailsSchema.pipe(
   Schema.annotate({ description: "Product not found" }),
 );
 

--- a/apps/api/src/services/og.ts
+++ b/apps/api/src/services/og.ts
@@ -4,7 +4,8 @@ import { ogImageQueryParamsSchema } from "@tom/schemas/og";
 import { OgTemplates, type OgTemplateParams } from "@tom/ui/OgImage";
 import { FontFetchError, ValidationError, ImageGenerationError } from "@tom/types/errors";
 import { HttpStatus } from "@tom/constants/http";
-import { toErrorResponse } from "@tom/utils/services/worker";
+import { ProblemType } from "@tom/constants/problem";
+import { toProblemResponse } from "@tom/utils/services/worker";
 
 const FONT_URL = "https://cdn.tom.so/LibreCaslonCondensed-Regular.ttf";
 
@@ -101,13 +102,17 @@ export const handleOgError = (
   error: FontFetchError | ValidationError | ImageGenerationError,
 ): Response => {
   if (error instanceof FontFetchError) {
-    return toErrorResponse(HttpStatus.BadGateway, error.message, error.cause);
+    return toProblemResponse(HttpStatus.BadGateway, error.message, {
+      type: ProblemType.Upstream,
+      detail: error.cause,
+    });
   }
   if (error instanceof ValidationError) {
-    return toErrorResponse(
-      HttpStatus.BadRequest,
-      `Validation error: ${error.field} - ${error.issue}`,
-    );
+    return toProblemResponse(HttpStatus.BadRequest, "Validation error", {
+      type: ProblemType.Validation,
+      detail: `${error.field} - ${error.issue}`,
+      errors: [{ pointer: `#/${error.field}`, detail: error.issue }],
+    });
   }
-  return toErrorResponse(HttpStatus.InternalServerError, error.message);
+  return toProblemResponse(HttpStatus.InternalServerError, error.message);
 };

--- a/apps/api/src/services/polar.ts
+++ b/apps/api/src/services/polar.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { PolarApiError } from "@tom/types/errors";
 import { HttpStatus } from "@tom/constants/http";
-import { logApiFailure, toErrorResponse } from "@tom/utils/services/worker";
+import { logApiFailure, toProblemResponse } from "@tom/utils/services/worker";
 
 const authHeaders = (accessToken: string | undefined) => ({
   Authorization: `Bearer ${accessToken}`,
@@ -101,7 +101,7 @@ export const createPolarCustomerSession = (
   }).pipe(Effect.withSpan("polar.customerSession"));
 
 export const handlePolarError = (error: PolarApiError): Response =>
-  toErrorResponse(
+  toProblemResponse(
     error.status >= HttpStatus.BadRequest && error.status < HttpStatus.InternalServerError
       ? error.status
       : HttpStatus.InternalServerError,

--- a/apps/web/src/libs/__tests__/adapter.test.ts
+++ b/apps/web/src/libs/__tests__/adapter.test.ts
@@ -31,7 +31,17 @@ describe("unwrapAdapter", () => {
   it("throws an HttpError with the adapter message and status", () => {
     let error: unknown;
     try {
-      unwrapAdapter({ data: null, error: { status: 404, value: { error: "Not found" } } });
+      unwrapAdapter({
+        data: null,
+        error: {
+          status: 404,
+          value: {
+            type: "https://errors.tom.so/not-found",
+            status: 404,
+            title: "Not found",
+          },
+        },
+      });
     } catch (caught) {
       error = caught;
     }
@@ -39,16 +49,44 @@ describe("unwrapAdapter", () => {
     expect(error).toMatchObject({ message: "Not found", status: 404 });
   });
 
-  it("falls back to a generic message when the error body has no message", () => {
+  it("prefers detail over title for the user-facing message", () => {
+    let error: unknown;
+    try {
+      unwrapAdapter({
+        data: null,
+        error: {
+          status: 400,
+          value: {
+            type: "https://errors.tom.so/validation",
+            status: 400,
+            title: "Validation error",
+            detail: "title - too long",
+          },
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({ message: "title - too long", status: 400 });
+  });
+
+  it("falls back to a generic message when the error body is not problem details", () => {
     expect(() =>
-      unwrapAdapter({ data: null, error: { status: 400, value: { detail: "nope" } } }),
+      unwrapAdapter({ data: null, error: { status: 400, value: { error: "legacy" } } }),
     ).toThrow("Adapter request failed");
   });
 
   it("falls back to status 500 when the error status is missing", () => {
     let error: unknown;
     try {
-      unwrapAdapter({ data: null, error: { status: null, value: { error: "boom" } } });
+      unwrapAdapter({
+        data: null,
+        error: {
+          status: null,
+          value: { type: "about:blank", status: 500, title: "boom" },
+        },
+      });
     } catch (caught) {
       error = caught;
     }
@@ -58,7 +96,10 @@ describe("unwrapAdapter", () => {
 
   it("throws an HttpError instance", () => {
     try {
-      unwrapAdapter({ data: null, error: { status: 500, value: { error: "boom" } } });
+      unwrapAdapter({
+        data: null,
+        error: { status: 500, value: { type: "about:blank", status: 500, title: "boom" } },
+      });
       expect.unreachable();
     } catch (error) {
       expect(error).toBeInstanceOf(HttpError);

--- a/apps/web/src/libs/adapter.ts
+++ b/apps/web/src/libs/adapter.ts
@@ -53,12 +53,20 @@ type EdenResult<T> = {
   error: { status: unknown; value: unknown } | null;
 };
 
-/** The adapter's error responses are `{ error: string }`; parse at the boundary. */
-const AdapterErrorBody = Schema.Struct({ error: Schema.String });
+/** The adapter's error responses are RFC 9457 problem details; parse at the boundary. */
+const ProblemDetailsBody = Schema.Struct({
+  type: Schema.String,
+  status: Schema.Number,
+  title: Schema.String,
+  detail: Schema.optional(Schema.String),
+});
 
 const errorMessage = (error: NonNullable<EdenResult<unknown>["error"]>): string =>
   Option.getOrElse(
-    Option.map(Schema.decodeUnknownOption(AdapterErrorBody)(error.value), (body) => body.error),
+    Option.map(
+      Schema.decodeUnknownOption(ProblemDetailsBody)(error.value),
+      (body) => body.detail ?? body.title,
+    ),
     () => "Adapter request failed",
   );
 

--- a/apps/web/src/server/__tests__/adapter.test.ts
+++ b/apps/web/src/server/__tests__/adapter.test.ts
@@ -56,7 +56,16 @@ describe("server functions", () => {
     });
 
     it("throws an HttpError carrying the adapter status and message", async () => {
-      fetchMock.mockResolvedValue(jsonResponse({ error: "Not found" }, 404));
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          {
+            type: "https://errors.tom.so/not-found",
+            status: 404,
+            title: "Not found",
+          },
+          404,
+        ),
+      );
       try {
         await fetchPostBySlug("missing");
         expect.unreachable();

--- a/infra/apps/adapter.run.ts
+++ b/infra/apps/adapter.run.ts
@@ -3,6 +3,7 @@ import { ALCHEMY_DEV } from "alchemy";
 import { Effect, Option, Schema } from "effect";
 import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
+import { retain } from "alchemy/RemovalPolicy";
 import { stageHost, stageWebHost, tomSecrets } from "../shared.run.ts";
 import { webHyperdrive } from "../hyperdrive/web.hyperdrive.ts";
 import { tomQueue } from "../queues/tom.queue.ts";
@@ -54,7 +55,7 @@ export const adapter = Effect.gen(function* () {
     env: {
       NODE_ENV: "production",
       ...devSecrets,
-      WORK_QUEUE: tomQueue,
+      WORK_QUEUE: tomQueue.pipe(retain()),
       ...(isAlchemyDev
         ? undefined
         : {

--- a/infra/apps/api.run.ts
+++ b/infra/apps/api.run.ts
@@ -3,6 +3,7 @@ import { ALCHEMY_DEV } from "alchemy";
 import { Effect, Option, Schema } from "effect";
 import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
+import { retain } from "alchemy/RemovalPolicy";
 import { stageHost, tomSecrets } from "../shared.run.ts";
 import { tomQueue, tomQueueDlq } from "../queues/tom.queue.ts";
 import { TomSecretsSchema } from "@tom/schemas/secrets";
@@ -33,8 +34,11 @@ export const api = Effect.gen(function* () {
       ? yield* Cloudflare.SecretsStore.Secret.ref("AXIOM_TOKEN", { stack: "wwwtom" })
       : undefined;
 
-  const queue = yield* tomQueue;
-  const dlq = yield* tomQueueDlq;
+  // The shared stack owns the queue lifecycle; this copy stays retained so a
+  // preview destroy never deletes the queue while sibling workers still bind
+  // it (see infra/queues/tom.queue.ts).
+  const queue = yield* tomQueue.pipe(retain());
+  const dlq = yield* tomQueueDlq.pipe(retain());
 
   const worker = yield* Cloudflare.Worker("wwwtom-api", {
     main: `${rootDir}/apps/api/src/index.ts`,
@@ -58,7 +62,7 @@ export const api = Effect.gen(function* () {
       ...devSecrets,
       ...(isAlchemyDev ? undefined : { TOM_SECRETS: tomSecrets }),
       ...(axiomToken && { AXIOM_TOKEN: axiomToken }),
-      WORK_QUEUE: tomQueue,
+      WORK_QUEUE: queue,
     },
   });
 

--- a/infra/apps/web.run.ts
+++ b/infra/apps/web.run.ts
@@ -4,6 +4,7 @@ import { ALCHEMY_DEV } from "alchemy";
 import { Effect, Layer } from "effect";
 import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
+import { retain } from "alchemy/RemovalPolicy";
 import { webHyperdrive } from "../hyperdrive/web.hyperdrive.ts";
 import { webKv } from "../kv/web.kv.ts";
 import { tomQueue } from "../queues/tom.queue.ts";
@@ -40,7 +41,7 @@ export const web = Effect.gen(function* () {
       ...(axiomToken && { AXIOM_TOKEN: axiomToken }),
       TOM_RATE_LIMIT_KV: webKv,
       HYPERDRIVE: webHyperdrive,
-      WORK_QUEUE: tomQueue,
+      WORK_QUEUE: tomQueue.pipe(retain()),
       ADAPTER_URL: isAlchemyDev ? "http://localhost:8788" : `https://${adapterHost}`,
       // Inlined into the client bundle at build time (Alchemy VITE_ prefix).
       ...(isAlchemyDev ? undefined : { VITE_ADAPTER_URL: `https://${adapterHost}` }),

--- a/infra/queues/tom.queue.ts
+++ b/infra/queues/tom.queue.ts
@@ -7,6 +7,14 @@ import { Stage } from "alchemy/Stage";
  * it as `WORK_QUEUE` in its env and enqueues work at runtime; the api worker
  * hosts the single worker consumer (at most one per queue) that drains it.
  *
+ * The shared stack (`infra/shared.run.ts`) owns the queue's lifecycle — it is
+ * destroyed last in every teardown, by which point every worker that binds it
+ * is already gone, so the queue can actually be deleted (Cloudflare refuses
+ * to delete a queue that a Worker still references, which aborted preview
+ * destroys mid-chain and leaked every sibling resource — Hyperdrives
+ * included). The app stacks keep their own copies marked `retain()`, so
+ * their destroys skip the delete and preview teardown stays convergent.
+ *
  * Production adopts the plain `tom-work-queue`; other stages get a
  * deterministic per-stage name so every app stack in a stage binds the same
  * queue (Alchemy's auto-naming would give each stack its own queue, since the

--- a/infra/runner/src/index.ts
+++ b/infra/runner/src/index.ts
@@ -1,6 +1,7 @@
 import { getSandbox, type Sandbox } from "@cloudflare/sandbox";
 import { Effect, Schema } from "effect";
 import { HttpStatus } from "@tom/constants/http";
+import { ProblemType } from "@tom/constants/problem";
 import { GitHubApiError, RunnerError } from "@tom/types/errors";
 import { logLevelFromEnv, otelConfigFromResolvedEnv } from "@tom/utils/services/logging";
 import { readCloudflareEnv, type CloudflareEnv } from "@tom/utils/services/config";
@@ -10,7 +11,7 @@ import {
   runEffect,
   sendErrorAlert,
   toErrorMessage,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
 
 // The container-backed DO class this Worker hosts. The stack binds it via
@@ -291,21 +292,31 @@ const handleRequest = (
     if (isCleanupRequest) {
       const cleanupToken = yield* createCleanupToken(cleanupSandboxId, secrets.CONTROL_TOKEN);
       const authorized = yield* authenticate(request, cleanupToken);
-      if (!authorized) return toErrorResponse(HttpStatus.Unauthorized, "Unauthorized");
+      if (!authorized) {
+        return toProblemResponse(HttpStatus.Unauthorized, "Unauthorized", {
+          type: ProblemType.Unauthorized,
+        });
+      }
 
       yield* destroyRunner(env, cleanupSandboxId);
       return new Response(null, { status: HttpStatus.NoContent });
     }
 
     if (url.pathname !== "/runners") {
-      return toErrorResponse(HttpStatus.NotFound, "Not found");
+      return toProblemResponse(HttpStatus.NotFound, "Not found", {
+        type: ProblemType.NotFound,
+      });
     }
     if (request.method !== "POST") {
-      return toErrorResponse(HttpStatus.MethodNotAllowed, "Method not allowed");
+      return toProblemResponse(HttpStatus.MethodNotAllowed, "Method not allowed");
     }
 
     const authorized = yield* authenticate(request, secrets.CONTROL_TOKEN);
-    if (!authorized) return toErrorResponse(HttpStatus.Unauthorized, "Unauthorized");
+    if (!authorized) {
+      return toProblemResponse(HttpStatus.Unauthorized, "Unauthorized", {
+        type: ProblemType.Unauthorized,
+      });
+    }
 
     return yield* startRunner(env, secrets, url.origin).pipe(
       Effect.map((runner) => Response.json(runner, { status: HttpStatus.Accepted })),
@@ -315,11 +326,10 @@ const handleRequest = (
             error: toErrorMessage(error),
             repository: env.GITHUB_REPOSITORY,
           });
-          return toErrorResponse(
-            HttpStatus.BadGateway,
-            "Failed to start runner",
-            toErrorMessage(error),
-          );
+          return toProblemResponse(HttpStatus.BadGateway, "Failed to start runner", {
+            type: ProblemType.Upstream,
+            detail: toErrorMessage(error),
+          });
         }),
       ),
     );
@@ -337,7 +347,7 @@ const handleRequestWithAlerts = (
         yield* Effect.sync(() => {
           sendErrorAlert(env, "Unhandled runner error", cause);
         });
-        return toErrorResponse(HttpStatus.InternalServerError, "Internal server error");
+        return toProblemResponse(HttpStatus.InternalServerError, "Internal server error");
       }),
     ),
   );

--- a/infra/shared.run.ts
+++ b/infra/shared.run.ts
@@ -9,6 +9,7 @@ import { InfrastructureConfigError } from "@tom/types/errors";
 import { TomSecretsSchema } from "@tom/schemas/secrets";
 import { Stack } from "alchemy/Stack";
 import { Stage } from "alchemy/Stage";
+import { tomQueue, tomQueueDlq } from "./queues/tom.queue.ts";
 
 export const readSecretBundle = (
   name: string,
@@ -128,7 +129,12 @@ export default Stack(
   },
   Effect.gen(function* () {
     const stage = yield* Stage;
-    const [store, secrets] = yield* Effect.all([secretsStore, tomSecrets]);
+    const [store, secrets, queue, dlq] = yield* Effect.all([
+      secretsStore,
+      tomSecrets,
+      tomQueue,
+      tomQueueDlq,
+    ]);
 
     // The Axiom resources are org-level and can only have one owner, so only
     // production registers them; other stages would fight over ownership on
@@ -139,6 +145,8 @@ export default Stack(
     return {
       secretsStore: store.storeName,
       tomSecrets: secrets.secretName,
+      tomQueue: queue.queueName,
+      tomQueueDlq: dlq.queueName,
       ...(axiom && {
         axiom: {
           traces: axiom.traces.name,

--- a/infra/turbo/src/index.ts
+++ b/infra/turbo/src/index.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect";
 import { HttpStatus } from "@tom/constants/http";
+import { ProblemType } from "@tom/constants/problem";
 import { TurboCacheError } from "@tom/types/errors";
 import { logLevelFromEnv, otelConfigFromResolvedEnv } from "@tom/utils/services/logging";
 import { readCloudflareEnv, type CloudflareEnv } from "@tom/utils/services/config";
@@ -9,7 +10,7 @@ import {
   runEffect,
   sendErrorAlert,
   toErrorMessage,
-  toErrorResponse,
+  toProblemResponse,
 } from "@tom/utils/services/worker";
 
 /**
@@ -242,7 +243,7 @@ const putArtifact = ({
   Effect.gen(function* () {
     const contentLength = request.headers.get("Content-Length");
     if (contentLength !== null && Number.parseInt(contentLength, 10) > MAX_ARTIFACT_BYTES) {
-      return toErrorResponse(
+      return toProblemResponse(
         HttpStatus.PayloadTooLarge,
         "Artifact exceeds the 25 MiB Cloudflare KV value limit",
       );
@@ -253,7 +254,7 @@ const putArtifact = ({
       catch: (cause) => new TurboCacheError({ message: "Failed to read artifact body", cause }),
     });
     if (body.byteLength > MAX_ARTIFACT_BYTES) {
-      return toErrorResponse(
+      return toProblemResponse(
         HttpStatus.PayloadTooLarge,
         "Artifact exceeds the 25 MiB Cloudflare KV value limit",
       );
@@ -277,7 +278,9 @@ const putArtifact = ({
         );
       if (!tagMatches) {
         yield* Effect.logWarning("cache artifact rejected: signature mismatch", { hash });
-        return toErrorResponse(HttpStatus.Unauthorized, "Invalid artifact tag");
+        return toProblemResponse(HttpStatus.Unauthorized, "Invalid artifact tag", {
+          type: ProblemType.Unauthorized,
+        });
       }
       yield* storeArtifact(kv, hash, body, {
         ...metadataFromHeaders(request.headers),
@@ -294,7 +297,9 @@ const getArtifact = (hash: string, kv: TurboCacheKv): Effect.Effect<Response, Tu
     const entry = yield* loadArtifact(kv, hash);
     if (entry === null) {
       yield* Effect.logDebug("cache artifact miss", { hash });
-      return toErrorResponse(HttpStatus.NotFound, "Artifact not found");
+      return toProblemResponse(HttpStatus.NotFound, "Artifact not found", {
+        type: ProblemType.NotFound,
+      });
     }
     yield* Effect.logDebug("cache artifact hit", { hash });
     return new Response(entry.body, {
@@ -306,7 +311,10 @@ const getArtifact = (hash: string, kv: TurboCacheKv): Effect.Effect<Response, Tu
 const headArtifact = (hash: string, kv: TurboCacheKv): Effect.Effect<Response, TurboCacheError> =>
   Effect.gen(function* () {
     const entry = yield* loadArtifact(kv, hash);
-    if (entry === null) return toErrorResponse(HttpStatus.NotFound, "Artifact not found");
+    if (entry === null)
+      return toProblemResponse(HttpStatus.NotFound, "Artifact not found", {
+        type: ProblemType.NotFound,
+      });
     return new Response(null, {
       status: HttpStatus.Ok,
       headers: artifactHeaders(entry.metadata ?? {}, entry.body.byteLength),
@@ -326,7 +334,11 @@ const handleRequest = (
     });
 
     const authorized = yield* authenticate(request, secrets.TURBO_CACHE_TOKEN);
-    if (!authorized) return toErrorResponse(HttpStatus.Unauthorized, "Unauthorized");
+    if (!authorized) {
+      return toProblemResponse(HttpStatus.Unauthorized, "Unauthorized", {
+        type: ProblemType.Unauthorized,
+      });
+    }
 
     if (request.method === "GET" && url.pathname === "/v8/artifacts/status") {
       return Response.json({ status: "enabled" });
@@ -337,7 +349,9 @@ const handleRequest = (
 
     const artifactMatch = url.pathname.match(ARTIFACT_ROUTE_PATTERN);
     if (artifactMatch === null || artifactMatch[1] === undefined) {
-      return toErrorResponse(HttpStatus.NotFound, "Not found");
+      return toProblemResponse(HttpStatus.NotFound, "Not found", {
+        type: ProblemType.NotFound,
+      });
     }
     const hash = artifactMatch[1];
 
@@ -352,7 +366,7 @@ const handleRequest = (
     if (request.method === "GET") return yield* getArtifact(hash, env.TURBO_CACHE_KV);
     if (request.method === "HEAD") return yield* headArtifact(hash, env.TURBO_CACHE_KV);
 
-    return toErrorResponse(HttpStatus.MethodNotAllowed, "Method not allowed");
+    return toProblemResponse(HttpStatus.MethodNotAllowed, "Method not allowed");
   });
 
 const handleRequestWithAlerts = (
@@ -369,7 +383,7 @@ const handleRequestWithAlerts = (
         yield* Effect.sync(() => {
           sendErrorAlert(env, "Unhandled turbo error", cause);
         });
-        return toErrorResponse(HttpStatus.InternalServerError, "Internal server error");
+        return toProblemResponse(HttpStatus.InternalServerError, "Internal server error");
       }),
     ),
   );

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     "./http": "./src/http.ts",
-    "./headers": "./src/headers.ts"
+    "./headers": "./src/headers.ts",
+    "./problem": "./src/problem.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/constants/src/problem.ts
+++ b/packages/constants/src/problem.ts
@@ -1,0 +1,18 @@
+/** RFC 9457 problem details media type (see rfc9457 §3). */
+export const PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+
+/**
+ * Problem type URIs under tom.so control (rfc9457 §3.1.1). `about:blank` is
+ * the RFC's generic fallback for problems without a dedicated type and is the
+ * builder's default.
+ */
+export const ProblemType = {
+  AboutBlank: "about:blank",
+  Validation: "https://errors.tom.so/validation",
+  Unauthorized: "https://errors.tom.so/unauthorized",
+  Forbidden: "https://errors.tom.so/forbidden",
+  NotFound: "https://errors.tom.so/not-found",
+  Upstream: "https://errors.tom.so/upstream",
+} as const;
+
+export type ProblemType = (typeof ProblemType)[keyof typeof ProblemType];

--- a/packages/schemas/src/error.ts
+++ b/packages/schemas/src/error.ts
@@ -1,10 +1,25 @@
 import { Schema } from "effect";
 
-const ErrorResponseSchema = Schema.Struct({
-  error: Schema.String,
-  cause: Schema.optional(Schema.String),
+/** A single field-level problem, per the RFC 9457 validation extension. */
+const ProblemErrorSchema = Schema.Struct({
+  detail: Schema.String,
+  pointer: Schema.optional(Schema.String),
 });
 
-export const errorResponseSchema = ErrorResponseSchema;
+/**
+ * RFC 9457 problem details object, serialized as
+ * `application/problem+json` (rfc9457 §3). `type` is a URI identifying the
+ * problem; `errors` carries field-level validation problems as an extension.
+ */
+const ProblemDetailsSchema = Schema.Struct({
+  type: Schema.String,
+  status: Schema.Number,
+  title: Schema.String,
+  detail: Schema.optional(Schema.String),
+  instance: Schema.optional(Schema.String),
+  errors: Schema.optional(Schema.Array(ProblemErrorSchema)),
+});
 
-export type ErrorResponse = Schema.Schema.Type<typeof ErrorResponseSchema>;
+export const problemDetailsSchema = ProblemDetailsSchema;
+
+export type ProblemDetails = Schema.Schema.Type<typeof ProblemDetailsSchema>;

--- a/packages/utils/__tests__/error-response.test.ts
+++ b/packages/utils/__tests__/error-response.test.ts
@@ -1,22 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { toErrorResponse } from "../src/services/worker";
+import { toProblemResponse } from "../src/services/worker";
 
-describe("toErrorResponse", () => {
-  it("keeps a valid error status", async () => {
-    const response = toErrorResponse(502, "upstream down");
+describe("toProblemResponse", () => {
+  it("keeps a valid error status and defaults the type to about:blank", async () => {
+    const response = toProblemResponse(502, "upstream down");
     expect(response.status).toBe(502);
-    expect(await response.json()).toEqual({ error: "upstream down" });
+    expect(response.headers.get("content-type")).toBe("application/problem+json");
+    expect(await response.json()).toEqual({
+      type: "about:blank",
+      status: 502,
+      title: "upstream down",
+    });
+  });
+
+  it("carries problem details, instance, and validation errors", async () => {
+    const response = toProblemResponse(400, "Validation error", {
+      type: "https://errors.tom.so/validation",
+      detail: "title - too long",
+      instance: "http://localhost/og",
+      errors: [{ pointer: "#/title", detail: "too long" }],
+    });
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Validation error",
+      detail: "title - too long",
+      instance: "http://localhost/og",
+      errors: [{ pointer: "#/title", detail: "too long" }],
+    });
   });
 
   it("falls back to 500 for a 0 sentinel", () => {
-    expect(toErrorResponse(0, "boom").status).toBe(500);
+    expect(toProblemResponse(0, "boom").status).toBe(500);
   });
 
   it("falls back to 500 for a redirect-class status", () => {
-    expect(toErrorResponse(302, "boom").status).toBe(500);
+    expect(toProblemResponse(302, "boom").status).toBe(500);
   });
 
   it("falls back to 500 for a non-error status", () => {
-    expect(toErrorResponse(200, "boom").status).toBe(500);
+    expect(toProblemResponse(200, "boom").status).toBe(500);
   });
 });

--- a/packages/utils/src/services/worker.ts
+++ b/packages/utils/src/services/worker.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Schema } from "effect";
-import { errorResponseSchema } from "@tom/schemas/error";
+import { problemDetailsSchema, type ProblemDetails } from "@tom/schemas/error";
 import { HttpStatus, isErrorStatus } from "@tom/constants/http";
+import { PROBLEM_JSON_MEDIA_TYPE, ProblemType } from "@tom/constants/problem";
 import { WorkerEnvMissingError } from "@tom/types/errors";
 import { TelegramService } from "../telegram";
 import { withLogging } from "./logging";
@@ -102,14 +103,37 @@ export const logApiFailure = (message: string, status: number, cause?: unknown) 
 const toErrorStatus = (status: number): number =>
   isErrorStatus(status) ? status : HttpStatus.InternalServerError;
 
-export const toErrorResponse = (status: number, error: string, cause?: string): Response =>
+/**
+ * RFC 9457 problem-details response (rfc9457 §3). `type` defaults to
+ * `about:blank`, the RFC's generic fallback; pass a ProblemType constant for
+ * known problems. Field-level validation problems ride in the `errors`
+ * extension with JSON-pointer paths.
+ */
+export const toProblemResponse = (
+  status: number,
+  title: string,
+  options: ProblemDetailsOptions = {},
+): Response =>
   new Response(
-    JSON.stringify(Schema.encodeSync(errorResponseSchema)(cause ? { error, cause } : { error })),
+    JSON.stringify(
+      Schema.encodeSync(problemDetailsSchema)({
+        type: options.type ?? ProblemType.AboutBlank,
+        status: toErrorStatus(status),
+        title,
+        ...(options.detail !== undefined && { detail: options.detail }),
+        ...(options.instance !== undefined && { instance: options.instance }),
+        ...(options.errors !== undefined && { errors: options.errors }),
+      }),
+    ),
     {
       status: toErrorStatus(status),
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": PROBLEM_JSON_MEDIA_TYPE },
     },
   );
+
+type ProblemDetailsOptions = {
+  readonly [K in "type" | "detail" | "instance" | "errors"]?: ProblemDetails[K];
+};
 
 /** Human-readable message from an unknown failure (Error or string). */
 export const toErrorMessage = (cause: unknown): string =>


### PR DESCRIPTION
## Summary

Adopt [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) (Problem Details for HTTP APIs) on the Tom API and adapter, replacing the bespoke `{ error, cause? }` wire format, and parse the new shape in the web client.

## Changes

**Shared contract** (`packages/schemas`, `packages/constants`)
- `errorResponseSchema` is replaced by `problemDetailsSchema`: `type`, `status`, `title`, plus optional `detail`, `instance`, and an `errors` extension for field-level problems.
- New `@tom/constants/problem` exports the `application/problem+json` media type and problem-type URIs under `errors.tom.so` (validation, unauthorized, forbidden, not-found, upstream; `about:blank` default).

**tom-api / tom-adapter** (`packages/utils`)
- `toErrorResponse` is gone; `toProblemResponse` builds RFC 9457 bodies with `Content-Type: application/problem+json`.
- Elysia validation failures now carry field-level `errors` with JSON-pointer paths (e.g. `#/products`) instead of a flat "Validation error".
- Error responses include `instance` (the request URL) for support forensics.
- Route OpenAPI response schemas declare the problem shape.

**tom-web** (`apps/web`)
- The adapter client parses the problem-details body and surfaces `detail ?? title`; the old `{ error }` parse is removed.

**Guestbook flow errors** (`apps/adapter`)
- `MissingFieldError`, `ProfanityError`, `GuestbookValidationError`, `OAuthSessionError` now map to 400; `AuthenticationError` to 401 — instead of a blanket 500.
- `MissingFieldError` had an empty message on the wire; it now reads `Missing required field: <field>`.

## Tests
- Updated all error-shape assertions across api, adapter, utils, and web.
- New `apps/adapter/src/__tests__/guestbook-errors.test.ts` covers profanity, missing field, invalid handle, and unauthenticated sign.

## Verification
- api: 27 tests, adapter: 44, web: 54, utils: 30 — all pass.
- Typecheck and lint clean on all touched packages; oxfmt formatted.