### PR TITLE
fix(ci): run each preview destroy step even when one fails

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,10 +61,21 @@ jobs:
       - uses: ./.github/actions/setup
 
       # Tears down web -> adapter -> api -> shared so no preview resources
-      # linger after the PR is merged or closed.
-      - name: Destroy preview stage
-        run: >
-          pnpm destroy:web --yes &&
-          pnpm destroy:adapter --yes &&
-          pnpm destroy:api --yes &&
-          pnpm destroy:shared --yes
+      # linger after the PR is merged or closed. Each step runs even when
+      # the previous one fails: one stack (e.g. the queue delete racing a
+      # still-bound worker) must never block the rest of the teardown.
+      - name: Destroy web
+        if: always()
+        run: pnpm destroy:web --yes
+
+      - name: Destroy adapter
+        if: always()
+        run: pnpm destroy:adapter --yes
+
+      - name: Destroy api
+        if: always()
+        run: pnpm destroy:api --yes
+
+      - name: Destroy shared
+        if: always()
+        run: pnpm destroy:shared --yes


### PR DESCRIPTION
PR 121's merge showed the failure: destroy:web tried to delete tom-work-queue-pr-121 while the preview api/adapter workers still bound it, Cloudflare refused with QueueInUseByWorkerBinding, and the && chain aborted before adapter/api/shared destroys ran, leaking preview resources.

Split the teardown into four steps with if: always() so one stack failure never blocks the rest. Verified by manually destroying the pr-121 orphans (adapter, api, shared) after the failed run.

Note: the retain() queue copies did not skip their deletes in practice, so this workflow net stays useful regardless.