### PR TITLE
test(e2e): cover guestbook entries read path on staging

### DIFF
--- a/apps/e2e/tests-staging/data.smoke.spec.ts
+++ b/apps/e2e/tests-staging/data.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { expectNoPageErrors } from "../src/helpers";
+import { expectNoPageErrors, fetchWithBackoff } from "../src/helpers";
 
 /**
  * Real-data flows against the staging stage: list pages hydrate live CMS /
@@ -80,5 +80,27 @@ test.describe("staging real data", () => {
       await expect(page.locator('textarea[name="message"]')).toBeVisible();
     }
     await expectNoErrors(page);
+  });
+
+  test("guestbook entries API returns an entry list from the stage database", async ({
+    request,
+  }) => {
+    // Regression cover for the missing-table outage: the bundle pointed at
+    // a database without guestbook tables, so this answered 5xx (then 4xx
+    // under problem details) instead of an entry list on every stage. The
+    // read path flaps transiently through Hyperdrive, so poll for a healthy
+    // answer: a persistent outage fails every attempt and goes red.
+    test.setTimeout(180_000);
+    const adapter = process.env.E2E_STAGING_ADAPTER_URL ?? "https://staging-adapter.tom.so";
+    await expect
+      .poll(
+        async () => {
+          const response = await fetchWithBackoff(request, `${adapter}/guestbook/entries`);
+          const body = await response.json().catch(() => null);
+          return { status: response.status(), isList: Array.isArray(body) };
+        },
+        { message: "guestbook entries must answer 200 with a list", timeout: 120_000 },
+      )
+      .toEqual({ status: 200, isList: true });
   });
 });


### PR DESCRIPTION
The missing-table outage answered 5xx (then 4xx under problem details) on every stage, and no test caught it: the staging suite only asserted the guestbook form renders.

Adds a staging smoke test asserting GET /guestbook/entries answers 200 with a JSON list. It polls because the read path flaps transiently through Hyperdrive; a persistent outage fails every attempt and goes red. Verified green against live staging.