### PR TITLE
feat(logging): include request context and URL on logs and spans

### DIFF
--- a/apps/adapter/src/integrations/guestbook/index.ts
+++ b/apps/adapter/src/integrations/guestbook/index.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { Effect, Option, Schema } from "effect";
+import { Effect, Layer, Option, Schema } from "effect";
 import { DatabaseService, type GuestbookEntry } from "@tom/db/service";
 import { checkProfanity } from "@tom/utils/profanity";
 import { makeTomQueueLayer, TomQueueService } from "@tom/utils/services/queue";
@@ -71,7 +71,7 @@ const guestbookStatus = (error: GuestbookFlowError): number => {
 const guestbookMessage = (
   error: GuestbookFlowError & {
     readonly message?: string;
-    readonly field?: string;
+    readonly field?: string | undefined;
   },
 ): string =>
   error._tag === "MissingFieldError"
@@ -87,10 +87,9 @@ const runGuestbook = <T>(
     Effect.tryPromise(() => readCloudflareEnv(env)).pipe(
       Effect.flatMap((resolved) =>
         effect.pipe(
-          Effect.provide(createDbLayer(resolved)),
           // No-op binding wrapper for routes that never send, and enables
           // the sign route's best-effort enqueue without blocking the reply.
-          Effect.provide(makeTomQueueLayer(resolved)),
+          Effect.provide(Layer.mergeAll(createDbLayer(resolved), makeTomQueueLayer(resolved))),
         ),
       ),
       // HttpError carries the response status; client-flow failures map to
@@ -310,7 +309,9 @@ export const guestbookIntegration = new Elysia({ name: "guestbook" })
         });
         yield* Effect.sync(() => {
           cookie.guestbook_session.remove();
-          cookie.guestbook_user.value = JSON.stringify(user);
+          cookie.guestbook_user.value = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))(
+            user,
+          );
           cookie.guestbook_user.update({
             httpOnly: true,
             secure: env.NODE_ENV === "production",

--- a/apps/adapter/src/integrations/polar/index.ts
+++ b/apps/adapter/src/integrations/polar/index.ts
@@ -107,7 +107,7 @@ const createPolarCustomer = (
         fetch(`${polarBaseUrl(env)}/v1/customers/`, {
           method: "POST",
           headers: authHeaders(env.POLAR_ACCESS_TOKEN),
-          body: JSON.stringify({
+          body: Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))({
             email: input.email,
             name: input.name,
             external_id: input.externalId,

--- a/apps/api/src/services/og.ts
+++ b/apps/api/src/services/og.ts
@@ -55,32 +55,31 @@ export const getTemplate = (
   }
 };
 
-export const generateOgImageEffect = (
+export const generateOgImageEffect = Effect.fn("og.generate")(function* (
   title: string,
   summary: string,
   requester: string,
   templateParam?: string,
-) =>
-  Effect.gen(function* () {
-    yield* Effect.logInfo("Generating OG image");
-    const fontData = yield* fontFetchEffect;
-    const template = getTemplate(requester, templateParam);
+) {
+  yield* Effect.logInfo("Generating OG image");
+  const fontData = yield* fontFetchEffect;
+  const template = getTemplate(requester, templateParam);
 
-    const html = template({ title, summary });
+  const html = template({ title, summary });
 
-    return new ImageResponse(html, {
-      width: 1200,
-      height: 630,
-      fonts: [
-        {
-          name: "Libre Caslon Condensed",
-          data: fontData,
-          weight: 400,
-          style: "normal",
-        },
-      ],
-    });
-  }).pipe(Effect.withSpan("og.generate"));
+  return new ImageResponse(html, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      {
+        name: "Libre Caslon Condensed",
+        data: fontData,
+        weight: 400,
+        style: "normal",
+      },
+    ],
+  });
+});
 
 export const validateOgParams = (title: string, summary: string) => {
   return Schema.decodeUnknownEffect(ogImageQueryParamsSchema)({

--- a/apps/api/src/services/polar.ts
+++ b/apps/api/src/services/polar.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { PolarApiError } from "@tom/types/errors";
 import { HttpStatus } from "@tom/constants/http";
 import { logApiFailure, toProblemResponse } from "@tom/utils/services/worker";
@@ -36,7 +36,7 @@ export const createPolarCheckout = (
         fetch(`${baseUrl}/v1/checkouts/`, {
           method: "POST",
           headers: authHeaders(accessToken),
-          body: JSON.stringify({
+          body: Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))({
             products: params.products,
             successUrl: params.successUrl,
             customerId: params.customerId,
@@ -75,7 +75,7 @@ export const createPolarCustomerSession = (
         fetch(`${baseUrl}/v1/customer-sessions/`, {
           method: "POST",
           headers: authHeaders(accessToken),
-          body: JSON.stringify({
+          body: Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))({
             customerId: params.customerId,
             returnUrl: params.returnUrl,
           }),

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -18,6 +18,9 @@ export default async function middleware(request: Request, next: () => Promise<R
   const logContext: LogContext = {
     serviceName: "tom-web",
     requestId: crypto.randomUUID(),
+    method: request.method,
+    path: new URL(request.url).pathname,
+    url: request.url,
     logLevel: logLevelFromEnv(env),
     ...(otel && { otel }),
   };

--- a/infra/gtm/http.ts
+++ b/infra/gtm/http.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
 import { CredentialsError, GtmCredentials } from "./credentials.ts";
 import { HttpError, mapStatusToError } from "./errors.ts";
 import type { HttpMethodError } from "./errors.ts";
@@ -237,8 +238,7 @@ const jsonFetch = <A>(
       return yield* mapStatusToError(res.status, text);
     }
     return yield* Effect.try({
-      // oxlint-disable-next-line effect/preferSchemaOverJson -- JSON.parse is the single boundary before Schema validation would occur; generic jsonFetch cannot use fromJsonString without ConstraintDecoder issues
-      try: () => JSON.parse(text) as A,
+      try: () => Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown))(text) as A,
       catch: () =>
         new HttpError({ message: "invalid JSON response", status: res.status, body: text }),
     });

--- a/infra/gtm/version.ts
+++ b/infra/gtm/version.ts
@@ -90,11 +90,11 @@ export const VersionProvider = () =>
           if (!containerPath) return undefined;
           const header = yield* http
             .getLatestContainerVersionHeader(containerPath)
-            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined as never)));
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
           if (!header) return undefined;
           const version = yield* http
             .getContainerVersion(header.path)
-            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined as never)));
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
           if (!version) return undefined;
           return toAttrs(version);
         }),
@@ -115,17 +115,17 @@ export const VersionProvider = () =>
           if (!hasChanges) {
             const latest = yield* http
               .getLatestContainerVersionHeader(containerPath)
-              .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined as never)));
+              .pipe(Effect.catchTag("NotFound", () => Effect.void));
             if (latest) {
               const existing = yield* http
                 .getContainerVersion(latest.path)
-                .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined as never)));
+                .pipe(Effect.catchTag("NotFound", () => Effect.void));
               if (existing) {
                 const attrs = toAttrs(existing);
                 if (news.publish) {
                   const live = yield* http
                     .getLiveContainerVersion(containerPath)
-                    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined as never)));
+                    .pipe(Effect.catchTag("NotFound", () => Effect.void));
                   if (!live || live.path !== attrs.path) {
                     yield* http.publishContainerVersion(attrs.path).pipe(
                       Effect.catchTag("NotFound", () => Effect.void),

--- a/infra/shared.run.ts
+++ b/infra/shared.run.ts
@@ -124,7 +124,7 @@ export const tomSecrets = Effect.gen(function* () {
 export default Stack(
   "wwwtom",
   {
-    providers: Layer.mergeAll(Cloudflare.providers(), Axiom.providers()) as never,
+    providers: Layer.provideMerge(Cloudflare.providers(), Axiom.providers()) as never,
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {

--- a/packages/utils/__tests__/logging.test.ts
+++ b/packages/utils/__tests__/logging.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Effect } from "effect";
 import { otelConfigFromResolvedEnv, withLogging } from "../src/services/logging";
+import { attachRequestContext, getRequestContext } from "../src/services/worker";
 import { readCloudflareEnv } from "../src/services/config";
 
 type ConsoleLogRecord = {
@@ -37,6 +38,58 @@ describe("withLogging", () => {
         sessionId: "session-1",
         userId: "tom@mastodon.social",
       },
+    });
+  });
+
+  it("annotates method, path and url on logs", async () => {
+    const logs = captureLogs();
+    await Effect.runPromise(
+      withLogging(Effect.logInfo("hello"), {
+        serviceName: "tom-api",
+        requestId: "req-1",
+        method: "GET",
+        path: "/guestbook",
+        url: "https://example.com/guestbook",
+      }),
+    );
+    expect(logs[0]).toMatchObject({
+      annotations: {
+        requestId: "req-1",
+        method: "GET",
+        path: "/guestbook",
+        url: "https://example.com/guestbook",
+      },
+    });
+  });
+
+  it("annotates spans with request context and url", async () => {
+    const annotations = await Effect.runPromise(
+      withLogging(Effect.spanAnnotations, {
+        serviceName: "tom-api",
+        requestId: "req-1",
+        sessionId: "session-1",
+        method: "POST",
+        path: "/api/sign",
+        url: "https://example.com/api/sign",
+      }),
+    );
+    expect(annotations).toMatchObject({
+      requestId: "req-1",
+      sessionId: "session-1",
+      method: "POST",
+      path: "/api/sign",
+      url: "https://example.com/api/sign",
+    });
+  });
+
+  it("fills method, path and url from the request", () => {
+    const request = new Request("https://example.com/guestbook?page=2", { method: "POST" });
+    attachRequestContext(request, { requestId: "req-1" });
+    expect(getRequestContext(request)).toMatchObject({
+      requestId: "req-1",
+      method: "POST",
+      path: "/guestbook",
+      url: "https://example.com/guestbook?page=2",
     });
   });
 

--- a/packages/utils/src/services/logging.ts
+++ b/packages/utils/src/services/logging.ts
@@ -13,8 +13,8 @@ import { readCloudflareEnv, type CloudflareEnv, type ResolvedCloudflareEnv } fro
  *
  * - Console always writes structured JSON (captured by Workers Logs).
  * - With an AXIOM_TOKEN present, spans and log records export to the OTLP
- *   endpoint (Axiom cloud by default) so requestId/sessionId/userId
- *   annotations and Effect spans are queryable alongside the console
+ *   endpoint (Axiom cloud by default) so requestId/sessionId/userId and
+ *   method/path/url annotations and Effect spans are queryable alongside the console
  *   output. The ingest token is an IaC-minted Secrets Store binding in
  *   production (see infra/shared.run.ts); OTEL_ENDPOINT / OTEL_*_DATASET
  *   remain optional overrides.
@@ -33,6 +33,9 @@ export type LogContext = {
   readonly requestId?: string;
   readonly sessionId?: string;
   readonly userId?: string;
+  readonly method?: string;
+  readonly path?: string;
+  readonly url?: string;
   readonly logLevel?: "Debug" | "Info";
   readonly otel?: OtelConfig;
 };
@@ -73,12 +76,18 @@ type LogAnnotations = {
   requestId?: string;
   sessionId?: string;
   userId?: string;
+  method?: string;
+  path?: string;
+  url?: string;
 };
 
 const logAnnotations = (context: LogContext): LogAnnotations => ({
   ...(context.requestId && { requestId: context.requestId }),
   ...(context.sessionId && { sessionId: context.sessionId }),
   ...(context.userId && { userId: context.userId }),
+  ...(context.method && { method: context.method }),
+  ...(context.path && { path: context.path }),
+  ...(context.url && { url: context.url }),
 });
 
 /**
@@ -124,6 +133,7 @@ const makeLoggingLayer = (context: LogContext) => {
 export const withLogging = <A, E, R>(effect: Effect.Effect<A, E, R>, context: LogContext) =>
   effect.pipe(
     Effect.annotateLogs(logAnnotations(context)),
+    Effect.annotateSpans(logAnnotations(context)),
     Effect.provideService(References.MinimumLogLevel, context.logLevel ?? "Info"),
     Effect.provide(makeLoggingLayer(context)),
   );

--- a/packages/utils/src/services/worker.ts
+++ b/packages/utils/src/services/worker.ts
@@ -14,8 +14,8 @@ export const runEffect = <A, E>(effect: Effect.Effect<A, E>, context: LogContext
   Effect.runPromise(withLogging(effect, context));
 
 /**
- * Build the logging context for a request from the requestId/sessionId/userId
- * and OTEL config attached by the worker's onRequest middleware.
+ * Build the logging context for a request from the requestId/sessionId/userId,
+ * method/path/url, and OTEL config attached by the worker's onRequest middleware.
  */
 export const logContextFromRequest = (request: Request, serviceName: string): LogContext => ({
   serviceName,
@@ -114,15 +114,18 @@ export const getRequestEnv = (request: Request): CloudflareEnv => {
 };
 
 /**
- * Per-request logging context (requestId, sessionId, userId, log level, OTEL
- * config) attached by the worker entry's onRequest middleware and read back
- * by route handlers so every log line is correlated. Mirrors the
+ * Per-request logging context (requestId, sessionId, userId, method/path/url,
+ * log level, OTEL config) attached by the worker entry's onRequest middleware
+ * and read back by route handlers so every log line is correlated. Mirrors the
  * RequestWithEnv pattern.
  */
 export type RequestContext = {
   readonly requestId?: string;
   readonly sessionId?: string;
   readonly userId?: string;
+  readonly method?: string;
+  readonly path?: string;
+  readonly url?: string;
   readonly logLevel?: "Debug" | "Info";
   readonly otel?: OtelConfig;
 };
@@ -130,7 +133,12 @@ export type RequestContext = {
 type RequestWithContext = Request & { requestContext?: RequestContext };
 
 export const attachRequestContext = (request: Request, context: RequestContext): Request => {
-  (request as RequestWithContext).requestContext = context;
+  (request as RequestWithContext).requestContext = {
+    method: request.method,
+    path: new URL(request.url).pathname,
+    url: request.url,
+    ...context,
+  };
   return request;
 };
 

--- a/packages/utils/src/telegram.ts
+++ b/packages/utils/src/telegram.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Context, Effect, Layer, Redacted, Schema } from "effect";
 import { TelegramError } from "@tom/types/errors";
 import type { AlertLink, ErrorAlertDetails } from "@tom/schemas/telegram";
 import { MAX_ALERT_LENGTH, MAX_STACK_LENGTH } from "@tom/schemas/telegram";
@@ -96,7 +96,7 @@ export class TelegramService extends Context.Service<TelegramService, TelegramSe
             fetch(telegramUrl, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
+              body: Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))({
                 chat_id: chatId,
                 text,
                 parse_mode: "Markdown",


### PR DESCRIPTION
Axiom logs and spans now carry requestId, sessionId, userId plus method, path and url.

- withLogging annotates logs and spans with the same request attributes
- attachRequestContext auto-fills method/path/url from the Request
- web middleware adds method/path/url to the SSR log context
- new tests cover log annotations, span annotations and context fill

Also fixes the pre-existing root typecheck failures (verified identical on the clean tree):

- guestbook exactOptionalPropertyTypes error on field, merged chained provides
- JSON inside Effect contexts routed through Schema encode/decode
- Effect.succeed(undefined as never) replaced with Effect.void
- Axiom providers wired to Cloudflare providers with Layer.provideMerge
- OG image effect rewritten with Effect.fn (span name unchanged)

Verified: pnpm typecheck 17/17, pnpm lint 16/16, utils 38 tests, adapter 44 tests, api 27 tests, infra gtm 40 tests.