### PR TITLE
chore(ci): node24 action pins and reliable preview destroy

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,9 +1,9 @@
 name: Setup repository
 description: >-
-  Pin pnpm, restore the pnpm store cache, and install dependencies with
-  --frozen-lockfile. One definition for every workflow so the setup block
-  never drifts. Call after an explicit `actions/checkout` (local composite
-  actions require the workspace to exist first).
+  Provision Node 24, pin pnpm, restore the pnpm store cache, and install
+  dependencies with --frozen-lockfile. One definition for every workflow so
+  the setup block never drifts. Call after an explicit `actions/checkout`
+  (local composite actions require the workspace to exist first).
 inputs:
   install:
     description: Run `pnpm install --frozen-lockfile` after setup.
@@ -16,7 +16,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
     # The pnpm store is content-addressed and shared across every job on
     # this runner type, so one warm store makes each parallel job's
@@ -28,7 +32,7 @@ runs:
       run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> "$GITHUB_ENV"
 
     - name: Restore the pnpm store
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.PNPM_STORE_PATH }}
         # The lockfile is the single source of truth for the dependency
@@ -44,7 +48,7 @@ runs:
 
     - name: Cache Playwright browsers
       if: ${{ inputs.install-playwright == 'true' }}
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/ms-playwright
         # The lockfile pins the playwright version, which pins the browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
 
       # Unit tests run in every workspace with a `test` script: @tom/web,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
 
       - name: Deploy infrastructure

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
         with:
           install-playwright: "true"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-staging
           path: apps/e2e/playwright-report/
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload test traces
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-staging
           path: apps/e2e/test-results/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
         with:
           install-playwright: "true"
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: apps/e2e/playwright-report/
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test traces
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: apps/e2e/test-results/

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Local composite actions (oc-gate) require the workspace first.
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Local composite actions (oc-gate) require the workspace first.
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -1,0 +1,55 @@
+name: Sweep orphan PR previews
+
+# Closed PRs do not reliably dispatch the preview workflow's destroy job
+# (merges do; plain closes often produce no run at all), so teardown here
+# doubles as the backstop: every night, destroy the preview stages of
+# recently closed PRs. Destroying an already-gone stage is a no-op, and
+# each stack runs even when the previous one fails.
+on:
+  schedule:
+    # 03:41 UTC daily — clear of the e2e nightlies (02:17, 02:47).
+    - cron: "41 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: preview-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Destroy previews of closed PRs
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TOM_SECRETS: ${{ secrets.TOM_SECRETS }}
+      AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+      ALCHEMY_ENV_FILE: /dev/null
+      GITHUB_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+
+      - name: Destroy preview stages of recently closed PRs
+        run: |
+          cutoff=$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          prs=$(gh pr list --state closed --limit 100 --json number,closedAt \
+            --jq --arg cutoff "$cutoff" '.[] | select(.closedAt > $cutoff) | .number')
+          if [ -z "$prs" ]; then
+            echo "No recently closed PRs; nothing to sweep."
+            exit 0
+          fi
+          for pr in $prs; do
+            echo "Sweeping preview stage pr-$pr"
+            export ALCHEMY_STAGE="pr-$pr" PULL_REQUEST="$pr"
+            pnpm destroy:web --yes || true
+            pnpm destroy:adapter --yes || true
+            pnpm destroy:api --yes || true
+            pnpm destroy:shared --yes || true
+          done

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,8 +61,12 @@ jobs:
       # teardown. PULL_REQUEST keeps the code path identical to deploy.
       GITHUB_TOKEN: ${{ github.token }}
     steps:
+      # Teardown needs the infra code and secrets, not the PR head (which
+      # may already be deleted on close), so check out the base branch.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: dev
       - uses: ./.github/actions/setup
 
       # Tears down web -> adapter -> api -> shared so no preview resources

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
 
       # Deploys shared -> api -> adapter -> web. The web stack posts or
@@ -62,7 +62,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
 
       # Tears down web -> adapter -> api -> shared so no preview resources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/srht.yml
+++ b/.github/workflows/srht.yml
@@ -8,7 +8,7 @@ jobs:
   mirror:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Two CI fixes in one pass.

Actions run on latest Node, pinned by hash:

- actions/cache v4 to v6.1.0 (node24) — kills the Node 20 deprecation warning
- actions/checkout to v7.0.1 (node24) across all workflows
- pnpm/action-setup v6.0.8 to v6.0.10 (node24)
- actions/upload-artifact already at v7.0.1 (node24); version comment added
- shared setup composite now provisions Node 24 via setup-node v7.0.0, so every job runs latest Node instead of the runner default
- all pins carry version comments for the next bump
- anomalyco/opencode/github stays on @latest (tracks the agent by design)

Preview destroys on close, not just merge:

- verified with live probes: pr-122-web returns 200 after an unmerged close (lingers), pr-123-web returns 526 after merge (destroyed)
- the closed event often produces no workflow run at all for plain closes, so the destroy job cannot be the only teardown path
- destroy job now checks out dev (teardown needs infra code and secrets, not the PR head, which may be deleted)
- new preview-sweep workflow runs nightly (03:41 UTC) plus manual dispatch: destroys pr-N stages for PRs closed in the last 14 days, each stack resilient to the previous step failing