### PR TITLE
Reduce duplication by extracting shared helpers and definitions

### DIFF
--- a/apps/cms/src/blocks/Form/Country/options.ts
+++ b/apps/cms/src/blocks/Form/Country/options.ts
@@ -1,982 +1,249 @@
-export const countryOptions = [
-  {
-    label: "Afghanistan",
-    value: "AF",
-  },
-  {
-    label: "Åland Islands",
-    value: "AX",
-  },
-  {
-    label: "Albania",
-    value: "AL",
-  },
-  {
-    label: "Algeria",
-    value: "DZ",
-  },
-  {
-    label: "American Samoa",
-    value: "AS",
-  },
-  {
-    label: "Andorra",
-    value: "AD",
-  },
-  {
-    label: "Angola",
-    value: "AO",
-  },
-  {
-    label: "Anguilla",
-    value: "AI",
-  },
-  {
-    label: "Antarctica",
-    value: "AQ",
-  },
-  {
-    label: "Antigua and Barbuda",
-    value: "AG",
-  },
-  {
-    label: "Argentina",
-    value: "AR",
-  },
-  {
-    label: "Armenia",
-    value: "AM",
-  },
-  {
-    label: "Aruba",
-    value: "AW",
-  },
-  {
-    label: "Australia",
-    value: "AU",
-  },
-  {
-    label: "Austria",
-    value: "AT",
-  },
-  {
-    label: "Azerbaijan",
-    value: "AZ",
-  },
-  {
-    label: "Bahamas",
-    value: "BS",
-  },
-  {
-    label: "Bahrain",
-    value: "BH",
-  },
-  {
-    label: "Bangladesh",
-    value: "BD",
-  },
-  {
-    label: "Barbados",
-    value: "BB",
-  },
-  {
-    label: "Belarus",
-    value: "BY",
-  },
-  {
-    label: "Belgium",
-    value: "BE",
-  },
-  {
-    label: "Belize",
-    value: "BZ",
-  },
-  {
-    label: "Benin",
-    value: "BJ",
-  },
-  {
-    label: "Bermuda",
-    value: "BM",
-  },
-  {
-    label: "Bhutan",
-    value: "BT",
-  },
-  {
-    label: "Bolivia",
-    value: "BO",
-  },
-  {
-    label: "Bosnia and Herzegovina",
-    value: "BA",
-  },
-  {
-    label: "Botswana",
-    value: "BW",
-  },
-  {
-    label: "Bouvet Island",
-    value: "BV",
-  },
-  {
-    label: "Brazil",
-    value: "BR",
-  },
-  {
-    label: "British Indian Ocean Territory",
-    value: "IO",
-  },
-  {
-    label: "Brunei Darussalam",
-    value: "BN",
-  },
-  {
-    label: "Bulgaria",
-    value: "BG",
-  },
-  {
-    label: "Burkina Faso",
-    value: "BF",
-  },
-  {
-    label: "Burundi",
-    value: "BI",
-  },
-  {
-    label: "Cambodia",
-    value: "KH",
-  },
-  {
-    label: "Cameroon",
-    value: "CM",
-  },
-  {
-    label: "Canada",
-    value: "CA",
-  },
-  {
-    label: "Cape Verde",
-    value: "CV",
-  },
-  {
-    label: "Cayman Islands",
-    value: "KY",
-  },
-  {
-    label: "Central African Republic",
-    value: "CF",
-  },
-  {
-    label: "Chad",
-    value: "TD",
-  },
-  {
-    label: "Chile",
-    value: "CL",
-  },
-  {
-    label: "China",
-    value: "CN",
-  },
-  {
-    label: "Christmas Island",
-    value: "CX",
-  },
-  {
-    label: "Cocos (Keeling) Islands",
-    value: "CC",
-  },
-  {
-    label: "Colombia",
-    value: "CO",
-  },
-  {
-    label: "Comoros",
-    value: "KM",
-  },
-  {
-    label: "Congo",
-    value: "CG",
-  },
-  {
-    label: "Congo, The Democratic Republic of the",
-    value: "CD",
-  },
-  {
-    label: "Cook Islands",
-    value: "CK",
-  },
-  {
-    label: "Costa Rica",
-    value: "CR",
-  },
-  {
-    label: "Cote D'Ivoire",
-    value: "CI",
-  },
-  {
-    label: "Croatia",
-    value: "HR",
-  },
-  {
-    label: "Cuba",
-    value: "CU",
-  },
-  {
-    label: "Cyprus",
-    value: "CY",
-  },
-  {
-    label: "Czech Republic",
-    value: "CZ",
-  },
-  {
-    label: "Denmark",
-    value: "DK",
-  },
-  {
-    label: "Djibouti",
-    value: "DJ",
-  },
-  {
-    label: "Dominica",
-    value: "DM",
-  },
-  {
-    label: "Dominican Republic",
-    value: "DO",
-  },
-  {
-    label: "Ecuador",
-    value: "EC",
-  },
-  {
-    label: "Egypt",
-    value: "EG",
-  },
-  {
-    label: "El Salvador",
-    value: "SV",
-  },
-  {
-    label: "Equatorial Guinea",
-    value: "GQ",
-  },
-  {
-    label: "Eritrea",
-    value: "ER",
-  },
-  {
-    label: "Estonia",
-    value: "EE",
-  },
-  {
-    label: "Ethiopia",
-    value: "ET",
-  },
-  {
-    label: "Falkland Islands (Malvinas)",
-    value: "FK",
-  },
-  {
-    label: "Faroe Islands",
-    value: "FO",
-  },
-  {
-    label: "Fiji",
-    value: "FJ",
-  },
-  {
-    label: "Finland",
-    value: "FI",
-  },
-  {
-    label: "France",
-    value: "FR",
-  },
-  {
-    label: "French Guiana",
-    value: "GF",
-  },
-  {
-    label: "French Polynesia",
-    value: "PF",
-  },
-  {
-    label: "French Southern Territories",
-    value: "TF",
-  },
-  {
-    label: "Gabon",
-    value: "GA",
-  },
-  {
-    label: "Gambia",
-    value: "GM",
-  },
-  {
-    label: "Georgia",
-    value: "GE",
-  },
-  {
-    label: "Germany",
-    value: "DE",
-  },
-  {
-    label: "Ghana",
-    value: "GH",
-  },
-  {
-    label: "Gibraltar",
-    value: "GI",
-  },
-  {
-    label: "Greece",
-    value: "GR",
-  },
-  {
-    label: "Greenland",
-    value: "GL",
-  },
-  {
-    label: "Grenada",
-    value: "GD",
-  },
-  {
-    label: "Guadeloupe",
-    value: "GP",
-  },
-  {
-    label: "Guam",
-    value: "GU",
-  },
-  {
-    label: "Guatemala",
-    value: "GT",
-  },
-  {
-    label: "Guernsey",
-    value: "GG",
-  },
-  {
-    label: "Guinea",
-    value: "GN",
-  },
-  {
-    label: "Guinea-Bissau",
-    value: "GW",
-  },
-  {
-    label: "Guyana",
-    value: "GY",
-  },
-  {
-    label: "Haiti",
-    value: "HT",
-  },
-  {
-    label: "Heard Island and Mcdonald Islands",
-    value: "HM",
-  },
-  {
-    label: "Holy See (Vatican City State)",
-    value: "VA",
-  },
-  {
-    label: "Honduras",
-    value: "HN",
-  },
-  {
-    label: "Hong Kong",
-    value: "HK",
-  },
-  {
-    label: "Hungary",
-    value: "HU",
-  },
-  {
-    label: "Iceland",
-    value: "IS",
-  },
-  {
-    label: "India",
-    value: "IN",
-  },
-  {
-    label: "Indonesia",
-    value: "ID",
-  },
-  {
-    label: "Iran, Islamic Republic Of",
-    value: "IR",
-  },
-  {
-    label: "Iraq",
-    value: "IQ",
-  },
-  {
-    label: "Ireland",
-    value: "IE",
-  },
-  {
-    label: "Isle of Man",
-    value: "IM",
-  },
-  {
-    label: "Israel",
-    value: "IL",
-  },
-  {
-    label: "Italy",
-    value: "IT",
-  },
-  {
-    label: "Jamaica",
-    value: "JM",
-  },
-  {
-    label: "Japan",
-    value: "JP",
-  },
-  {
-    label: "Jersey",
-    value: "JE",
-  },
-  {
-    label: "Jordan",
-    value: "JO",
-  },
-  {
-    label: "Kazakhstan",
-    value: "KZ",
-  },
-  {
-    label: "Kenya",
-    value: "KE",
-  },
-  {
-    label: "Kiribati",
-    value: "KI",
-  },
-  {
-    label: "Democratic People's Republic of Korea",
-    value: "KP",
-  },
-  {
-    label: "Korea, Republic of",
-    value: "KR",
-  },
-  {
-    label: "Kosovo",
-    value: "XK",
-  },
-  {
-    label: "Kuwait",
-    value: "KW",
-  },
-  {
-    label: "Kyrgyzstan",
-    value: "KG",
-  },
-  {
-    label: "Lao People's Democratic Republic",
-    value: "LA",
-  },
-  {
-    label: "Latvia",
-    value: "LV",
-  },
-  {
-    label: "Lebanon",
-    value: "LB",
-  },
-  {
-    label: "Lesotho",
-    value: "LS",
-  },
-  {
-    label: "Liberia",
-    value: "LR",
-  },
-  {
-    label: "Libyan Arab Jamahiriya",
-    value: "LY",
-  },
-  {
-    label: "Liechtenstein",
-    value: "LI",
-  },
-  {
-    label: "Lithuania",
-    value: "LT",
-  },
-  {
-    label: "Luxembourg",
-    value: "LU",
-  },
-  {
-    label: "Macao",
-    value: "MO",
-  },
-  {
-    label: "Macedonia, The Former Yugoslav Republic of",
-    value: "MK",
-  },
-  {
-    label: "Madagascar",
-    value: "MG",
-  },
-  {
-    label: "Malawi",
-    value: "MW",
-  },
-  {
-    label: "Malaysia",
-    value: "MY",
-  },
-  {
-    label: "Maldives",
-    value: "MV",
-  },
-  {
-    label: "Mali",
-    value: "ML",
-  },
-  {
-    label: "Malta",
-    value: "MT",
-  },
-  {
-    label: "Marshall Islands",
-    value: "MH",
-  },
-  {
-    label: "Martinique",
-    value: "MQ",
-  },
-  {
-    label: "Mauritania",
-    value: "MR",
-  },
-  {
-    label: "Mauritius",
-    value: "MU",
-  },
-  {
-    label: "Mayotte",
-    value: "YT",
-  },
-  {
-    label: "Mexico",
-    value: "MX",
-  },
-  {
-    label: "Micronesia, Federated States of",
-    value: "FM",
-  },
-  {
-    label: "Moldova, Republic of",
-    value: "MD",
-  },
-  {
-    label: "Monaco",
-    value: "MC",
-  },
-  {
-    label: "Mongolia",
-    value: "MN",
-  },
-  {
-    label: "Montenegro",
-    value: "ME",
-  },
-  {
-    label: "Montserrat",
-    value: "MS",
-  },
-  {
-    label: "Morocco",
-    value: "MA",
-  },
-  {
-    label: "Mozambique",
-    value: "MZ",
-  },
-  {
-    label: "Myanmar",
-    value: "MM",
-  },
-  {
-    label: "Namibia",
-    value: "NA",
-  },
-  {
-    label: "Nauru",
-    value: "NR",
-  },
-  {
-    label: "Nepal",
-    value: "NP",
-  },
-  {
-    label: "Netherlands",
-    value: "NL",
-  },
-  {
-    label: "Netherlands Antilles",
-    value: "AN",
-  },
-  {
-    label: "New Caledonia",
-    value: "NC",
-  },
-  {
-    label: "New Zealand",
-    value: "NZ",
-  },
-  {
-    label: "Nicaragua",
-    value: "NI",
-  },
-  {
-    label: "Niger",
-    value: "NE",
-  },
-  {
-    label: "Nigeria",
-    value: "NG",
-  },
-  {
-    label: "Niue",
-    value: "NU",
-  },
-  {
-    label: "Norfolk Island",
-    value: "NF",
-  },
-  {
-    label: "Northern Mariana Islands",
-    value: "MP",
-  },
-  {
-    label: "Norway",
-    value: "NO",
-  },
-  {
-    label: "Oman",
-    value: "OM",
-  },
-  {
-    label: "Pakistan",
-    value: "PK",
-  },
-  {
-    label: "Palau",
-    value: "PW",
-  },
-  {
-    label: "Palestinian Territory, Occupied",
-    value: "PS",
-  },
-  {
-    label: "Panama",
-    value: "PA",
-  },
-  {
-    label: "Papua New Guinea",
-    value: "PG",
-  },
-  {
-    label: "Paraguay",
-    value: "PY",
-  },
-  {
-    label: "Peru",
-    value: "PE",
-  },
-  {
-    label: "Philippines",
-    value: "PH",
-  },
-  {
-    label: "Pitcairn",
-    value: "PN",
-  },
-  {
-    label: "Poland",
-    value: "PL",
-  },
-  {
-    label: "Portugal",
-    value: "PT",
-  },
-  {
-    label: "Puerto Rico",
-    value: "PR",
-  },
-  {
-    label: "Qatar",
-    value: "QA",
-  },
-  {
-    label: "Reunion",
-    value: "RE",
-  },
-  {
-    label: "Romania",
-    value: "RO",
-  },
-  {
-    label: "Russian Federation",
-    value: "RU",
-  },
-  {
-    label: "Rwanda",
-    value: "RW",
-  },
-  {
-    label: "Saint Helena",
-    value: "SH",
-  },
-  {
-    label: "Saint Kitts and Nevis",
-    value: "KN",
-  },
-  {
-    label: "Saint Lucia",
-    value: "LC",
-  },
-  {
-    label: "Saint Pierre and Miquelon",
-    value: "PM",
-  },
-  {
-    label: "Saint Vincent and the Grenadines",
-    value: "VC",
-  },
-  {
-    label: "Samoa",
-    value: "WS",
-  },
-  {
-    label: "San Marino",
-    value: "SM",
-  },
-  {
-    label: "Sao Tome and Principe",
-    value: "ST",
-  },
-  {
-    label: "Saudi Arabia",
-    value: "SA",
-  },
-  {
-    label: "Senegal",
-    value: "SN",
-  },
-  {
-    label: "Serbia",
-    value: "RS",
-  },
-  {
-    label: "Seychelles",
-    value: "SC",
-  },
-  {
-    label: "Sierra Leone",
-    value: "SL",
-  },
-  {
-    label: "Singapore",
-    value: "SG",
-  },
-  {
-    label: "Slovakia",
-    value: "SK",
-  },
-  {
-    label: "Slovenia",
-    value: "SI",
-  },
-  {
-    label: "Solomon Islands",
-    value: "SB",
-  },
-  {
-    label: "Somalia",
-    value: "SO",
-  },
-  {
-    label: "South Africa",
-    value: "ZA",
-  },
-  {
-    label: "South Georgia and the South Sandwich Islands",
-    value: "GS",
-  },
-  {
-    label: "Spain",
-    value: "ES",
-  },
-  {
-    label: "Sri Lanka",
-    value: "LK",
-  },
-  {
-    label: "Sudan",
-    value: "SD",
-  },
-  {
-    label: "Suriname",
-    value: "SR",
-  },
-  {
-    label: "Svalbard and Jan Mayen",
-    value: "SJ",
-  },
-  {
-    label: "Swaziland",
-    value: "SZ",
-  },
-  {
-    label: "Sweden",
-    value: "SE",
-  },
-  {
-    label: "Switzerland",
-    value: "CH",
-  },
-  {
-    label: "Syrian Arab Republic",
-    value: "SY",
-  },
-  {
-    label: "Taiwan",
-    value: "TW",
-  },
-  {
-    label: "Tajikistan",
-    value: "TJ",
-  },
-  {
-    label: "Tanzania, United Republic of",
-    value: "TZ",
-  },
-  {
-    label: "Thailand",
-    value: "TH",
-  },
-  {
-    label: "Timor-Leste",
-    value: "TL",
-  },
-  {
-    label: "Togo",
-    value: "TG",
-  },
-  {
-    label: "Tokelau",
-    value: "TK",
-  },
-  {
-    label: "Tonga",
-    value: "TO",
-  },
-  {
-    label: "Trinidad and Tobago",
-    value: "TT",
-  },
-  {
-    label: "Tunisia",
-    value: "TN",
-  },
-  {
-    label: "Turkey",
-    value: "TR",
-  },
-  {
-    label: "Turkmenistan",
-    value: "TM",
-  },
-  {
-    label: "Turks and Caicos Islands",
-    value: "TC",
-  },
-  {
-    label: "Tuvalu",
-    value: "TV",
-  },
-  {
-    label: "Uganda",
-    value: "UG",
-  },
-  {
-    label: "Ukraine",
-    value: "UA",
-  },
-  {
-    label: "United Arab Emirates",
-    value: "AE",
-  },
-  {
-    label: "United Kingdom",
-    value: "GB",
-  },
-  {
-    label: "United States",
-    value: "US",
-  },
-  {
-    label: "United States Minor Outlying Islands",
-    value: "UM",
-  },
-  {
-    label: "Uruguay",
-    value: "UY",
-  },
-  {
-    label: "Uzbekistan",
-    value: "UZ",
-  },
-  {
-    label: "Vanuatu",
-    value: "VU",
-  },
-  {
-    label: "Venezuela",
-    value: "VE",
-  },
-  {
-    label: "Viet Nam",
-    value: "VN",
-  },
-  {
-    label: "Virgin Islands, British",
-    value: "VG",
-  },
-  {
-    label: "Virgin Islands, U.S.",
-    value: "VI",
-  },
-  {
-    label: "Wallis and Futuna",
-    value: "WF",
-  },
-  {
-    label: "Western Sahara",
-    value: "EH",
-  },
-  {
-    label: "Yemen",
-    value: "YE",
-  },
-  {
-    label: "Zambia",
-    value: "ZM",
-  },
-  {
-    label: "Zimbabwe",
-    value: "ZW",
-  },
+const entries: Array<readonly [value: string, label: string]> = [
+  ["AF", "Afghanistan"],
+  ["AX", "Åland Islands"],
+  ["AL", "Albania"],
+  ["DZ", "Algeria"],
+  ["AS", "American Samoa"],
+  ["AD", "Andorra"],
+  ["AO", "Angola"],
+  ["AI", "Anguilla"],
+  ["AQ", "Antarctica"],
+  ["AG", "Antigua and Barbuda"],
+  ["AR", "Argentina"],
+  ["AM", "Armenia"],
+  ["AW", "Aruba"],
+  ["AU", "Australia"],
+  ["AT", "Austria"],
+  ["AZ", "Azerbaijan"],
+  ["BS", "Bahamas"],
+  ["BH", "Bahrain"],
+  ["BD", "Bangladesh"],
+  ["BB", "Barbados"],
+  ["BY", "Belarus"],
+  ["BE", "Belgium"],
+  ["BZ", "Belize"],
+  ["BJ", "Benin"],
+  ["BM", "Bermuda"],
+  ["BT", "Bhutan"],
+  ["BO", "Bolivia"],
+  ["BA", "Bosnia and Herzegovina"],
+  ["BW", "Botswana"],
+  ["BV", "Bouvet Island"],
+  ["BR", "Brazil"],
+  ["IO", "British Indian Ocean Territory"],
+  ["BN", "Brunei Darussalam"],
+  ["BG", "Bulgaria"],
+  ["BF", "Burkina Faso"],
+  ["BI", "Burundi"],
+  ["KH", "Cambodia"],
+  ["CM", "Cameroon"],
+  ["CA", "Canada"],
+  ["CV", "Cape Verde"],
+  ["KY", "Cayman Islands"],
+  ["CF", "Central African Republic"],
+  ["TD", "Chad"],
+  ["CL", "Chile"],
+  ["CN", "China"],
+  ["CX", "Christmas Island"],
+  ["CC", "Cocos (Keeling) Islands"],
+  ["CO", "Colombia"],
+  ["KM", "Comoros"],
+  ["CG", "Congo"],
+  ["CD", "Congo, The Democratic Republic of the"],
+  ["CK", "Cook Islands"],
+  ["CR", "Costa Rica"],
+  ["CI", "Cote D'Ivoire"],
+  ["HR", "Croatia"],
+  ["CU", "Cuba"],
+  ["CY", "Cyprus"],
+  ["CZ", "Czech Republic"],
+  ["DK", "Denmark"],
+  ["DJ", "Djibouti"],
+  ["DM", "Dominica"],
+  ["DO", "Dominican Republic"],
+  ["EC", "Ecuador"],
+  ["EG", "Egypt"],
+  ["SV", "El Salvador"],
+  ["GQ", "Equatorial Guinea"],
+  ["ER", "Eritrea"],
+  ["EE", "Estonia"],
+  ["ET", "Ethiopia"],
+  ["FK", "Falkland Islands (Malvinas)"],
+  ["FO", "Faroe Islands"],
+  ["FJ", "Fiji"],
+  ["FI", "Finland"],
+  ["FR", "France"],
+  ["GF", "French Guiana"],
+  ["PF", "French Polynesia"],
+  ["TF", "French Southern Territories"],
+  ["GA", "Gabon"],
+  ["GM", "Gambia"],
+  ["GE", "Georgia"],
+  ["DE", "Germany"],
+  ["GH", "Ghana"],
+  ["GI", "Gibraltar"],
+  ["GR", "Greece"],
+  ["GL", "Greenland"],
+  ["GD", "Grenada"],
+  ["GP", "Guadeloupe"],
+  ["GU", "Guam"],
+  ["GT", "Guatemala"],
+  ["GG", "Guernsey"],
+  ["GN", "Guinea"],
+  ["GW", "Guinea-Bissau"],
+  ["GY", "Guyana"],
+  ["HT", "Haiti"],
+  ["HM", "Heard Island and Mcdonald Islands"],
+  ["VA", "Holy See (Vatican City State)"],
+  ["HN", "Honduras"],
+  ["HK", "Hong Kong"],
+  ["HU", "Hungary"],
+  ["IS", "Iceland"],
+  ["IN", "India"],
+  ["ID", "Indonesia"],
+  ["IR", "Iran, Islamic Republic Of"],
+  ["IQ", "Iraq"],
+  ["IE", "Ireland"],
+  ["IM", "Isle of Man"],
+  ["IL", "Israel"],
+  ["IT", "Italy"],
+  ["JM", "Jamaica"],
+  ["JP", "Japan"],
+  ["JE", "Jersey"],
+  ["JO", "Jordan"],
+  ["KZ", "Kazakhstan"],
+  ["KE", "Kenya"],
+  ["KI", "Kiribati"],
+  ["KP", "Democratic People's Republic of Korea"],
+  ["KR", "Korea, Republic of"],
+  ["XK", "Kosovo"],
+  ["KW", "Kuwait"],
+  ["KG", "Kyrgyzstan"],
+  ["LA", "Lao People's Democratic Republic"],
+  ["LV", "Latvia"],
+  ["LB", "Lebanon"],
+  ["LS", "Lesotho"],
+  ["LR", "Liberia"],
+  ["LY", "Libyan Arab Jamahiriya"],
+  ["LI", "Liechtenstein"],
+  ["LT", "Lithuania"],
+  ["LU", "Luxembourg"],
+  ["MO", "Macao"],
+  ["MK", "Macedonia, The Former Yugoslav Republic of"],
+  ["MG", "Madagascar"],
+  ["MW", "Malawi"],
+  ["MY", "Malaysia"],
+  ["MV", "Maldives"],
+  ["ML", "Mali"],
+  ["MT", "Malta"],
+  ["MH", "Marshall Islands"],
+  ["MQ", "Martinique"],
+  ["MR", "Mauritania"],
+  ["MU", "Mauritius"],
+  ["YT", "Mayotte"],
+  ["MX", "Mexico"],
+  ["FM", "Micronesia, Federated States of"],
+  ["MD", "Moldova, Republic of"],
+  ["MC", "Monaco"],
+  ["MN", "Mongolia"],
+  ["ME", "Montenegro"],
+  ["MS", "Montserrat"],
+  ["MA", "Morocco"],
+  ["MZ", "Mozambique"],
+  ["MM", "Myanmar"],
+  ["NA", "Namibia"],
+  ["NR", "Nauru"],
+  ["NP", "Nepal"],
+  ["NL", "Netherlands"],
+  ["AN", "Netherlands Antilles"],
+  ["NC", "New Caledonia"],
+  ["NZ", "New Zealand"],
+  ["NI", "Nicaragua"],
+  ["NE", "Niger"],
+  ["NG", "Nigeria"],
+  ["NU", "Niue"],
+  ["NF", "Norfolk Island"],
+  ["MP", "Northern Mariana Islands"],
+  ["NO", "Norway"],
+  ["OM", "Oman"],
+  ["PK", "Pakistan"],
+  ["PW", "Palau"],
+  ["PS", "Palestinian Territory, Occupied"],
+  ["PA", "Panama"],
+  ["PG", "Papua New Guinea"],
+  ["PY", "Paraguay"],
+  ["PE", "Peru"],
+  ["PH", "Philippines"],
+  ["PN", "Pitcairn"],
+  ["PL", "Poland"],
+  ["PT", "Portugal"],
+  ["PR", "Puerto Rico"],
+  ["QA", "Qatar"],
+  ["RE", "Reunion"],
+  ["RO", "Romania"],
+  ["RU", "Russian Federation"],
+  ["RW", "Rwanda"],
+  ["SH", "Saint Helena"],
+  ["KN", "Saint Kitts and Nevis"],
+  ["LC", "Saint Lucia"],
+  ["PM", "Saint Pierre and Miquelon"],
+  ["VC", "Saint Vincent and the Grenadines"],
+  ["WS", "Samoa"],
+  ["SM", "San Marino"],
+  ["ST", "Sao Tome and Principe"],
+  ["SA", "Saudi Arabia"],
+  ["SN", "Senegal"],
+  ["RS", "Serbia"],
+  ["SC", "Seychelles"],
+  ["SL", "Sierra Leone"],
+  ["SG", "Singapore"],
+  ["SK", "Slovakia"],
+  ["SI", "Slovenia"],
+  ["SB", "Solomon Islands"],
+  ["SO", "Somalia"],
+  ["ZA", "South Africa"],
+  ["GS", "South Georgia and the South Sandwich Islands"],
+  ["ES", "Spain"],
+  ["LK", "Sri Lanka"],
+  ["SD", "Sudan"],
+  ["SR", "Suriname"],
+  ["SJ", "Svalbard and Jan Mayen"],
+  ["SZ", "Swaziland"],
+  ["SE", "Sweden"],
+  ["CH", "Switzerland"],
+  ["SY", "Syrian Arab Republic"],
+  ["TW", "Taiwan"],
+  ["TJ", "Tajikistan"],
+  ["TZ", "Tanzania, United Republic of"],
+  ["TH", "Thailand"],
+  ["TL", "Timor-Leste"],
+  ["TG", "Togo"],
+  ["TK", "Tokelau"],
+  ["TO", "Tonga"],
+  ["TT", "Trinidad and Tobago"],
+  ["TN", "Tunisia"],
+  ["TR", "Turkey"],
+  ["TM", "Turkmenistan"],
+  ["TC", "Turks and Caicos Islands"],
+  ["TV", "Tuvalu"],
+  ["UG", "Uganda"],
+  ["UA", "Ukraine"],
+  ["AE", "United Arab Emirates"],
+  ["GB", "United Kingdom"],
+  ["US", "United States"],
+  ["UM", "United States Minor Outlying Islands"],
+  ["UY", "Uruguay"],
+  ["UZ", "Uzbekistan"],
+  ["VU", "Vanuatu"],
+  ["VE", "Venezuela"],
+  ["VN", "Viet Nam"],
+  ["VG", "Virgin Islands, British"],
+  ["VI", "Virgin Islands, U.S."],
+  ["WF", "Wallis and Futuna"],
+  ["EH", "Western Sahara"],
+  ["YE", "Yemen"],
+  ["ZM", "Zambia"],
+  ["ZW", "Zimbabwe"],
 ];
+
+export const countryOptions = entries.map(([value, label]) => ({ label, value }));

--- a/infra/gtm/__tests__/driver.ts
+++ b/infra/gtm/__tests__/driver.ts
@@ -49,4 +49,32 @@ export const findGtmProvider = <R extends ResourceLike>(
     (service) => service as GtmProviderService<R>,
   );
 
+import { Trigger, TriggerProvider, type TriggerProps } from "../trigger.ts";
+
+export const testWorkspace = "accounts/123/containers/C1/workspaces/1";
+
+export const withTriggerProvider = (state: FakeState) =>
+  Layer.provideMerge(TriggerProvider(), makeTestLayer(state));
+
+export const reconcileTrigger = async (
+  state: FakeState,
+  props: TriggerProps,
+  id = "my-trigger",
+): Promise<unknown> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* findGtmProvider(Trigger);
+      return yield* provider.reconcile({
+        id,
+        fqn: `Gtm.Trigger/${id}`,
+        instanceId: "test-instance",
+        news: props,
+        olds: undefined,
+        output: undefined,
+        session: testSession,
+        bindings: [],
+      });
+    }).pipe(Effect.provide(withTriggerProvider(state))),
+  );
+
 export type { FakeState };

--- a/infra/gtm/__tests__/tag.test.ts
+++ b/infra/gtm/__tests__/tag.test.ts
@@ -3,36 +3,19 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Unowned } from "alchemy/AdoptPolicy";
 import { Tag, TagProvider, type TagProps } from "../tag.ts";
-import { Trigger, TriggerProvider, type TriggerProps } from "../trigger.ts";
+import { Trigger } from "../trigger.ts";
 import { makeFakeState } from "../fake.ts";
-import { findGtmProvider, makeTestLayer, testSession } from "./driver.ts";
+import {
+  findGtmProvider,
+  makeTestLayer,
+  reconcileTrigger,
+  testSession,
+  testWorkspace,
+  withTriggerProvider,
+} from "./driver.ts";
 
 const withTagProvider = (state: ReturnType<typeof makeFakeState>) =>
   Layer.provideMerge(TagProvider(), makeTestLayer(state));
-
-const withTriggerProvider = (state: ReturnType<typeof makeFakeState>) =>
-  Layer.provideMerge(TriggerProvider(), makeTestLayer(state));
-
-const reconcileTrigger = async (
-  state: ReturnType<typeof makeFakeState>,
-  props: TriggerProps,
-  id = "my-trigger",
-): Promise<unknown> =>
-  Effect.runPromise(
-    Effect.gen(function* () {
-      const provider = yield* findGtmProvider(Trigger);
-      return yield* provider.reconcile({
-        id,
-        fqn: `Gtm.Trigger/${id}`,
-        instanceId: "test-instance",
-        news: props,
-        olds: undefined,
-        output: undefined,
-        session: testSession,
-        bindings: [],
-      });
-    }).pipe(Effect.provide(withTriggerProvider(state))),
-  );
 
 const reconcileTag = async (
   state: ReturnType<typeof makeFakeState>,
@@ -58,23 +41,23 @@ const reconcileTag = async (
 describe("Trigger provider", () => {
   it("creates customEvent trigger", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const attrs = (await reconcileTrigger(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "evt",
       type: "customEvent",
       parameter: [{ type: "template", key: "eventName", value: "my_event" }],
     })) as { triggerId: string; path: string; name: string };
     expect(attrs.triggerId).toBeDefined();
-    expect(attrs.path).toContain(ws);
-    expect(state.calls.some((c) => c.method === "POST" && c.path === `${ws}/triggers`)).toBe(true);
+    expect(attrs.path).toContain(testWorkspace);
+    expect(
+      state.calls.some((c) => c.method === "POST" && c.path === `${testWorkspace}/triggers`),
+    ).toBe(true);
   });
 
   it("updates with fingerprint", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const created = (await reconcileTrigger(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "evt",
       type: "customEvent",
     })) as { fingerprint: string };
@@ -83,7 +66,7 @@ describe("Trigger provider", () => {
     const updated = (await reconcileTrigger(
       state,
       {
-        workspacePath: ws,
+        workspacePath: testWorkspace,
         name: "evt",
         type: "customEvent",
         notes: "hello",
@@ -97,9 +80,8 @@ describe("Trigger provider", () => {
 
   it("read marks foreign trigger as Unowned", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
-    state.triggers.set(`${ws}/triggers/1`, {
-      path: `${ws}/triggers/1`,
+    state.triggers.set(`${testWorkspace}/triggers/1`, {
+      path: `${testWorkspace}/triggers/1`,
       accountId: "123",
       containerId: "C1",
       workspaceId: "1",
@@ -117,7 +99,7 @@ describe("Trigger provider", () => {
           id: "evt",
           fqn: "Gtm.Trigger/evt",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "evt", type: "customEvent" },
+          olds: { workspacePath: testWorkspace, name: "evt", type: "customEvent" },
           output: undefined,
         });
       }).pipe(Effect.provide(withTriggerProvider(state))),
@@ -127,9 +109,8 @@ describe("Trigger provider", () => {
 
   it("delete removes trigger", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const created = (await reconcileTrigger(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "evt",
       type: "customEvent",
     })) as { path: string };
@@ -140,7 +121,7 @@ describe("Trigger provider", () => {
           id: "evt",
           fqn: "Gtm.Trigger/evt",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "evt", type: "customEvent" },
+          olds: { workspacePath: testWorkspace, name: "evt", type: "customEvent" },
           output: {
             accountId: "123",
             containerId: "C1",
@@ -165,11 +146,10 @@ describe("Trigger provider", () => {
 describe("Tag provider", () => {
   it("creates tag wired to trigger via firingTriggerId", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const trig = (await reconcileTrigger(
       state,
       {
-        workspacePath: ws,
+        workspacePath: testWorkspace,
         name: "evt",
         type: "customEvent",
       },
@@ -177,7 +157,7 @@ describe("Tag provider", () => {
     )) as { triggerId: string };
 
     const tag = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "my-tag",
       type: "html",
       parameter: [{ type: "template", key: "html", value: "<b>hi</b>" }],
@@ -188,10 +168,13 @@ describe("Tag provider", () => {
 
   it("setup/teardown wiring via tagName", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
-    await reconcileTag(state, { workspacePath: ws, name: "setup-tag", type: "html" }, "setup-tag");
+    await reconcileTag(
+      state,
+      { workspacePath: testWorkspace, name: "setup-tag", type: "html" },
+      "setup-tag",
+    );
     const main = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "main-tag",
       type: "html",
       setupTag: [{ tagName: "setup-tag" }],
@@ -202,14 +185,13 @@ describe("Tag provider", () => {
 
   it("updates with fingerprint and preserves wiring", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const trig = (await reconcileTrigger(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "evt",
       type: "customEvent",
     })) as { triggerId: string };
     const created = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "my-tag",
       type: "html",
       firingTriggerId: [trig.triggerId],
@@ -217,7 +199,7 @@ describe("Tag provider", () => {
     state.calls.length = 0;
     await new Promise((r) => setTimeout(r, 2));
     const updated = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "my-tag",
       type: "html",
       firingTriggerId: [trig.triggerId],
@@ -230,9 +212,8 @@ describe("Tag provider", () => {
 
   it("read marks foreign tag as Unowned", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
-    state.tags.set(`${ws}/tags/1`, {
-      path: `${ws}/tags/1`,
+    state.tags.set(`${testWorkspace}/tags/1`, {
+      path: `${testWorkspace}/tags/1`,
       accountId: "123",
       containerId: "C1",
       workspaceId: "1",
@@ -250,7 +231,7 @@ describe("Tag provider", () => {
           id: "my-tag",
           fqn: "Gtm.Tag/my-tag",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "my-tag", type: "html" },
+          olds: { workspacePath: testWorkspace, name: "my-tag", type: "html" },
           output: undefined,
         });
       }).pipe(Effect.provide(withTagProvider(state))),
@@ -260,9 +241,8 @@ describe("Tag provider", () => {
 
   it("delete removes tag", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const created = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "my-tag",
       type: "html",
     })) as { path: string };
@@ -273,7 +253,7 @@ describe("Tag provider", () => {
           id: "my-tag",
           fqn: "Gtm.Tag/my-tag",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "my-tag", type: "html" },
+          olds: { workspacePath: testWorkspace, name: "my-tag", type: "html" },
           output: {
             accountId: "123",
             containerId: "C1",
@@ -296,11 +276,10 @@ describe("Tag provider", () => {
 
   it("customEvent trigger + tag integration", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const trig = (await reconcileTrigger(
       state,
       {
-        workspacePath: ws,
+        workspacePath: testWorkspace,
         name: "my_custom_event",
         type: "customEvent",
         parameter: [{ type: "template", key: "eventName", value: "my_event" }],
@@ -320,7 +299,7 @@ describe("Tag provider", () => {
     expect(trig.customEventFilter).toBeDefined();
 
     const tag = (await reconcileTag(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "my-tag",
       type: "html",
       parameter: [{ type: "template", key: "html", value: "<script>hi</script>" }],

--- a/infra/gtm/__tests__/variable.test.ts
+++ b/infra/gtm/__tests__/variable.test.ts
@@ -3,16 +3,18 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Unowned } from "alchemy/AdoptPolicy";
 import { Variable, VariableProvider, type VariableProps } from "../variable.ts";
-import { Trigger, TriggerProvider } from "../trigger.ts";
 import { Folder, FolderProvider } from "../folder.ts";
 import { makeFakeState } from "../fake.ts";
-import { findGtmProvider, makeTestLayer, testSession } from "./driver.ts";
+import {
+  findGtmProvider,
+  makeTestLayer,
+  reconcileTrigger,
+  testSession,
+  testWorkspace,
+} from "./driver.ts";
 
 const withVariableProvider = (state: ReturnType<typeof makeFakeState>) =>
   Layer.provideMerge(VariableProvider(), makeTestLayer(state));
-
-const withTriggerProvider = (state: ReturnType<typeof makeFakeState>) =>
-  Layer.provideMerge(TriggerProvider(), makeTestLayer(state));
 
 const withFolderProvider = (state: ReturnType<typeof makeFakeState>) =>
   Layer.provideMerge(FolderProvider(), makeTestLayer(state));
@@ -36,27 +38,6 @@ const reconcileVariable = async (
         bindings: [],
       });
     }).pipe(Effect.provide(withVariableProvider(state))),
-  );
-
-const reconcileTrigger = async (
-  state: ReturnType<typeof makeFakeState>,
-  props: { workspacePath: string; name: string; type: string },
-  id = "my-trigger",
-): Promise<unknown> =>
-  Effect.runPromise(
-    Effect.gen(function* () {
-      const provider = yield* findGtmProvider(Trigger);
-      return yield* provider.reconcile({
-        id,
-        fqn: `Gtm.Trigger/${id}`,
-        instanceId: "test-instance",
-        news: props as never,
-        olds: undefined,
-        output: undefined,
-        session: testSession,
-        bindings: [],
-      });
-    }).pipe(Effect.provide(withTriggerProvider(state))),
   );
 
 const reconcileFolder = async (
@@ -83,32 +64,32 @@ const reconcileFolder = async (
 describe("Variable provider", () => {
   it("creates variable with parameters and formatValue", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const attrs = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "myVar",
       type: "template",
       parameter: [{ type: "template", key: "value", value: "hello" }],
       formatValue: { convertToBoolean: true },
     })) as { variableId: string; path: string; formatValue: unknown };
     expect(attrs.variableId).toBeDefined();
-    expect(attrs.path).toContain(ws);
+    expect(attrs.path).toContain(testWorkspace);
     expect(attrs.formatValue).toEqual({ convertToBoolean: true });
-    expect(state.calls.some((c) => c.method === "POST" && c.path === `${ws}/variables`)).toBe(true);
+    expect(
+      state.calls.some((c) => c.method === "POST" && c.path === `${testWorkspace}/variables`),
+    ).toBe(true);
   });
 
   it("wires enabling/disabling triggers via triggerId", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const trig = (await reconcileTrigger(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "evt",
       type: "customEvent",
     })) as {
       triggerId: string;
     };
     const v = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "condVar",
       type: "c",
       enablingTriggerId: [trig.triggerId],
@@ -120,12 +101,14 @@ describe("Variable provider", () => {
 
   it("references parentFolderId", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
-    const folder = (await reconcileFolder(state, { workspacePath: ws, name: "my-folder" })) as {
+    const folder = (await reconcileFolder(state, {
+      workspacePath: testWorkspace,
+      name: "my-folder",
+    })) as {
       folderId: string;
     };
     const v = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "folderVar",
       type: "v",
       parentFolderId: folder.folderId,
@@ -135,16 +118,15 @@ describe("Variable provider", () => {
 
   it("updates with fingerprint", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const created = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "myVar",
       type: "v",
     })) as { fingerprint: string };
     state.calls.length = 0;
     await new Promise((r) => setTimeout(r, 2));
     const updated = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "myVar",
       type: "v",
       notes: "updated",
@@ -156,9 +138,8 @@ describe("Variable provider", () => {
 
   it("read marks foreign variable as Unowned", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
-    state.variables.set(`${ws}/variables/1`, {
-      path: `${ws}/variables/1`,
+    state.variables.set(`${testWorkspace}/variables/1`, {
+      path: `${testWorkspace}/variables/1`,
       accountId: "123",
       containerId: "C1",
       workspaceId: "1",
@@ -176,7 +157,7 @@ describe("Variable provider", () => {
           id: "myVar",
           fqn: "Gtm.Variable/myVar",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "myVar", type: "v" },
+          olds: { workspacePath: testWorkspace, name: "myVar", type: "v" },
           output: undefined,
         });
       }).pipe(Effect.provide(withVariableProvider(state))),
@@ -186,9 +167,8 @@ describe("Variable provider", () => {
 
   it("delete removes variable", async () => {
     const state = makeFakeState();
-    const ws = "accounts/123/containers/C1/workspaces/1";
     const created = (await reconcileVariable(state, {
-      workspacePath: ws,
+      workspacePath: testWorkspace,
       name: "myVar",
       type: "v",
     })) as { path: string };
@@ -199,7 +179,7 @@ describe("Variable provider", () => {
           id: "myVar",
           fqn: "Gtm.Variable/myVar",
           instanceId: "test-instance",
-          olds: { workspacePath: ws, name: "myVar", type: "v" },
+          olds: { workspacePath: testWorkspace, name: "myVar", type: "v" },
           output: {
             accountId: "123",
             containerId: "C1",

--- a/infra/gtm/schemas.ts
+++ b/infra/gtm/schemas.ts
@@ -75,20 +75,24 @@ export const WorkspaceSchema = Schema.Struct({
 });
 export type Workspace = Schema.Schema.Type<typeof WorkspaceSchema>;
 
-export const ContainerDraftSchema = Schema.Struct({
+const containerWritableFields = {
   name: Schema.String,
   domainName: Schema.optional(Schema.Array(Schema.String)),
   usageContext: Schema.optional(Schema.Array(ContainerUsageContextSchema)),
   notes: Schema.optional(Schema.String),
   fingerprint: Schema.optional(Schema.String),
-});
+};
+
+export const ContainerDraftSchema = Schema.Struct(containerWritableFields);
 export type ContainerDraft = Schema.Schema.Type<typeof ContainerDraftSchema>;
 
-export const WorkspaceDraftSchema = Schema.Struct({
+const workspaceWritableFields = {
   name: Schema.String,
   description: Schema.optional(Schema.String),
   fingerprint: Schema.optional(Schema.String),
-});
+};
+
+export const WorkspaceDraftSchema = Schema.Struct(workspaceWritableFields);
 export type WorkspaceDraft = Schema.Schema.Type<typeof WorkspaceDraftSchema>;
 
 export const ListContainersResponseSchema = Schema.Struct({
@@ -161,16 +165,10 @@ export const ConsentSettingsSchema = Schema.Struct({
 });
 export type ConsentSettings = Schema.Schema.Type<typeof ConsentSettingsSchema>;
 
-export const TagSchema = Schema.Struct({
-  path: Schema.String,
-  accountId: Schema.String,
-  containerId: Schema.String,
-  workspaceId: Schema.String,
-  tagId: Schema.String,
+const tagWritableFields = {
   name: Schema.String,
   type: Schema.String,
   parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  fingerprint: Schema.optional(Schema.String),
   firingTriggerId: Schema.optional(Schema.Array(Schema.String)),
   blockingTriggerId: Schema.optional(Schema.Array(Schema.String)),
   setupTag: Schema.optional(Schema.Array(SetupTagSchema)),
@@ -188,9 +186,48 @@ export const TagSchema = Schema.Struct({
   consentSettings: Schema.optional(ConsentSettingsSchema),
   monitoringMetadata: Schema.optional(ParameterSchema),
   monitoringMetadataTagNameKey: Schema.optional(Schema.String),
+  fingerprint: Schema.optional(Schema.String),
+};
+
+export const TagSchema = Schema.Struct({
+  path: Schema.String,
+  accountId: Schema.String,
+  containerId: Schema.String,
+  workspaceId: Schema.String,
+  tagId: Schema.String,
+  ...tagWritableFields,
   tagManagerUrl: Schema.optional(Schema.String),
 });
 export type Tag = Schema.Schema.Type<typeof TagSchema>;
+
+const triggerWritableFields = {
+  name: Schema.String,
+  type: Schema.String,
+  parameter: Schema.optional(Schema.Array(ParameterSchema)),
+  filter: Schema.optional(Schema.Array(ConditionSchema)),
+  customEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
+  autoEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
+  parentFolderId: Schema.optional(Schema.String),
+  notes: Schema.optional(Schema.String),
+  waitForTags: Schema.optional(ParameterSchema),
+  checkValidation: Schema.optional(ParameterSchema),
+  waitForTagsTimeout: Schema.optional(ParameterSchema),
+  uniqueTriggerId: Schema.optional(ParameterSchema),
+  eventName: Schema.optional(ParameterSchema),
+  interval: Schema.optional(ParameterSchema),
+  limit: Schema.optional(ParameterSchema),
+  selector: Schema.optional(ParameterSchema),
+  intervalSeconds: Schema.optional(ParameterSchema),
+  maxTimerLengthSeconds: Schema.optional(ParameterSchema),
+  verticalScrollPercentageList: Schema.optional(ParameterSchema),
+  horizontalScrollPercentageList: Schema.optional(ParameterSchema),
+  visibilitySelector: Schema.optional(ParameterSchema),
+  visiblePercentageMin: Schema.optional(ParameterSchema),
+  visiblePercentageMax: Schema.optional(ParameterSchema),
+  continuousTimeMinMilliseconds: Schema.optional(ParameterSchema),
+  totalTimeMinMilliseconds: Schema.optional(ParameterSchema),
+  fingerprint: Schema.optional(Schema.String),
+};
 
 export const TriggerSchemaStruct = Schema.Struct({
   path: Schema.String,
@@ -198,90 +235,16 @@ export const TriggerSchemaStruct = Schema.Struct({
   containerId: Schema.String,
   workspaceId: Schema.String,
   triggerId: Schema.String,
-  name: Schema.String,
-  type: Schema.String,
-  parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  filter: Schema.optional(Schema.Array(ConditionSchema)),
-  customEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
-  autoEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
-  fingerprint: Schema.optional(Schema.String),
-  parentFolderId: Schema.optional(Schema.String),
-  notes: Schema.optional(Schema.String),
+  ...triggerWritableFields,
   tagManagerUrl: Schema.optional(Schema.String),
-  waitForTags: Schema.optional(ParameterSchema),
-  checkValidation: Schema.optional(ParameterSchema),
-  waitForTagsTimeout: Schema.optional(ParameterSchema),
-  uniqueTriggerId: Schema.optional(ParameterSchema),
-  eventName: Schema.optional(ParameterSchema),
-  interval: Schema.optional(ParameterSchema),
-  limit: Schema.optional(ParameterSchema),
-  selector: Schema.optional(ParameterSchema),
-  intervalSeconds: Schema.optional(ParameterSchema),
-  maxTimerLengthSeconds: Schema.optional(ParameterSchema),
-  verticalScrollPercentageList: Schema.optional(ParameterSchema),
-  horizontalScrollPercentageList: Schema.optional(ParameterSchema),
-  visibilitySelector: Schema.optional(ParameterSchema),
-  visiblePercentageMin: Schema.optional(ParameterSchema),
-  visiblePercentageMax: Schema.optional(ParameterSchema),
-  continuousTimeMinMilliseconds: Schema.optional(ParameterSchema),
-  totalTimeMinMilliseconds: Schema.optional(ParameterSchema),
 });
 export type Trigger = Schema.Schema.Type<typeof TriggerSchemaStruct>;
 export const TriggerSchema = TriggerSchemaStruct;
 
-export const TagDraftSchema = Schema.Struct({
-  name: Schema.String,
-  type: Schema.String,
-  parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  firingTriggerId: Schema.optional(Schema.Array(Schema.String)),
-  blockingTriggerId: Schema.optional(Schema.Array(Schema.String)),
-  setupTag: Schema.optional(Schema.Array(SetupTagSchema)),
-  teardownTag: Schema.optional(Schema.Array(TeardownTagSchema)),
-  parentFolderId: Schema.optional(Schema.String),
-  tagFiringOption: Schema.optional(
-    Schema.Literals(["oncePerEvent", "oncePerLoad", "unlimited", "tagFiringOptionUnspecified"]),
-  ),
-  paused: Schema.optional(Schema.Boolean),
-  notes: Schema.optional(Schema.String),
-  scheduleStartMs: Schema.optional(Schema.String),
-  scheduleEndMs: Schema.optional(Schema.String),
-  liveOnly: Schema.optional(Schema.Boolean),
-  priority: Schema.optional(ParameterSchema),
-  consentSettings: Schema.optional(ConsentSettingsSchema),
-  monitoringMetadata: Schema.optional(ParameterSchema),
-  monitoringMetadataTagNameKey: Schema.optional(Schema.String),
-  fingerprint: Schema.optional(Schema.String),
-});
+export const TagDraftSchema = Schema.Struct(tagWritableFields);
 export type TagDraft = Schema.Schema.Type<typeof TagDraftSchema>;
 
-export const TriggerDraftSchema = Schema.Struct({
-  name: Schema.String,
-  type: Schema.String,
-  parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  filter: Schema.optional(Schema.Array(ConditionSchema)),
-  customEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
-  autoEventFilter: Schema.optional(Schema.Array(ConditionSchema)),
-  parentFolderId: Schema.optional(Schema.String),
-  notes: Schema.optional(Schema.String),
-  waitForTags: Schema.optional(ParameterSchema),
-  checkValidation: Schema.optional(ParameterSchema),
-  waitForTagsTimeout: Schema.optional(ParameterSchema),
-  uniqueTriggerId: Schema.optional(ParameterSchema),
-  eventName: Schema.optional(ParameterSchema),
-  interval: Schema.optional(ParameterSchema),
-  limit: Schema.optional(ParameterSchema),
-  selector: Schema.optional(ParameterSchema),
-  intervalSeconds: Schema.optional(ParameterSchema),
-  maxTimerLengthSeconds: Schema.optional(ParameterSchema),
-  verticalScrollPercentageList: Schema.optional(ParameterSchema),
-  horizontalScrollPercentageList: Schema.optional(ParameterSchema),
-  visibilitySelector: Schema.optional(ParameterSchema),
-  visiblePercentageMin: Schema.optional(ParameterSchema),
-  visiblePercentageMax: Schema.optional(ParameterSchema),
-  continuousTimeMinMilliseconds: Schema.optional(ParameterSchema),
-  totalTimeMinMilliseconds: Schema.optional(ParameterSchema),
-  fingerprint: Schema.optional(Schema.String),
-});
+export const TriggerDraftSchema = Schema.Struct(triggerWritableFields);
 export type TriggerDraft = Schema.Schema.Type<typeof TriggerDraftSchema>;
 
 export const ListTagsResponseSchema = Schema.Struct({
@@ -311,40 +274,32 @@ export const VariableFormatValueSchema = Schema.Struct({
 });
 export type VariableFormatValue = Schema.Schema.Type<typeof VariableFormatValueSchema>;
 
+const variableWritableFields = {
+  name: Schema.String,
+  type: Schema.String,
+  parameter: Schema.optional(Schema.Array(ParameterSchema)),
+  parentFolderId: Schema.optional(Schema.String),
+  notes: Schema.optional(Schema.String),
+  scheduleStartMs: Schema.optional(Schema.String),
+  scheduleEndMs: Schema.optional(Schema.String),
+  formatValue: Schema.optional(VariableFormatValueSchema),
+  enablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
+  disablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
+  fingerprint: Schema.optional(Schema.String),
+};
+
 export const VariableSchema = Schema.Struct({
   path: Schema.String,
   accountId: Schema.String,
   containerId: Schema.String,
   workspaceId: Schema.String,
   variableId: Schema.String,
-  name: Schema.String,
-  type: Schema.String,
-  parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  fingerprint: Schema.optional(Schema.String),
-  parentFolderId: Schema.optional(Schema.String),
-  notes: Schema.optional(Schema.String),
+  ...variableWritableFields,
   tagManagerUrl: Schema.optional(Schema.String),
-  scheduleStartMs: Schema.optional(Schema.String),
-  scheduleEndMs: Schema.optional(Schema.String),
-  formatValue: Schema.optional(VariableFormatValueSchema),
-  enablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
-  disablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
 });
 export type Variable = Schema.Schema.Type<typeof VariableSchema>;
 
-export const VariableDraftSchema = Schema.Struct({
-  name: Schema.String,
-  type: Schema.String,
-  parameter: Schema.optional(Schema.Array(ParameterSchema)),
-  parentFolderId: Schema.optional(Schema.String),
-  notes: Schema.optional(Schema.String),
-  scheduleStartMs: Schema.optional(Schema.String),
-  scheduleEndMs: Schema.optional(Schema.String),
-  formatValue: Schema.optional(VariableFormatValueSchema),
-  enablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
-  disablingTriggerId: Schema.optional(Schema.Array(Schema.String)),
-  fingerprint: Schema.optional(Schema.String),
-});
+export const VariableDraftSchema = Schema.Struct(variableWritableFields);
 export type VariableDraft = Schema.Schema.Type<typeof VariableDraftSchema>;
 
 export const ListVariablesResponseSchema = Schema.Struct({
@@ -353,24 +308,24 @@ export const ListVariablesResponseSchema = Schema.Struct({
 });
 export type ListVariablesResponse = Schema.Schema.Type<typeof ListVariablesResponseSchema>;
 
+const folderWritableFields = {
+  name: Schema.String,
+  notes: Schema.optional(Schema.String),
+  fingerprint: Schema.optional(Schema.String),
+};
+
 export const FolderSchema = Schema.Struct({
   path: Schema.String,
   accountId: Schema.String,
   containerId: Schema.String,
   workspaceId: Schema.String,
   folderId: Schema.String,
-  name: Schema.String,
-  notes: Schema.optional(Schema.String),
-  fingerprint: Schema.optional(Schema.String),
+  ...folderWritableFields,
   tagManagerUrl: Schema.optional(Schema.String),
 });
 export type Folder = Schema.Schema.Type<typeof FolderSchema>;
 
-export const FolderDraftSchema = Schema.Struct({
-  name: Schema.String,
-  notes: Schema.optional(Schema.String),
-  fingerprint: Schema.optional(Schema.String),
-});
+export const FolderDraftSchema = Schema.Struct(folderWritableFields);
 export type FolderDraft = Schema.Schema.Type<typeof FolderDraftSchema>;
 
 export const ListFoldersResponseSchema = Schema.Struct({

--- a/packages/arena/src/client.ts
+++ b/packages/arena/src/client.ts
@@ -98,13 +98,17 @@ export type Fetch = (
   },
 ) => Promise<Response>;
 
-/**
- * Bridge @aredotna/sdk responses to the local schema types. The SDK's own
- * response types don't overlap the schema types, so every SDK call needs a
- * type bridge; a single-assertion helper keeps that in one place instead of
- * chained `as unknown as` casts at each call site.
- */
+/** Bridge SDK responses to local schema types in one place. */
 const toLocal = <T>(promise: Promise<unknown>): Promise<T> => promise as Promise<T>;
+
+const sdkEffect = <T>(run: () => Promise<unknown>): Effect.Effect<T, HttpError> =>
+  Effect.tryPromise({ try: () => toLocal<T>(run()), catch: mapArenaError });
+
+const formatSort = (sort?: string, direction?: string): string | undefined => {
+  if (sort && direction) return `${sort}_${direction}`;
+  if (sort) return sort;
+  return undefined;
+};
 
 export type DateProvider = { now(): number };
 
@@ -125,12 +129,8 @@ export function paginationQueryString(
   const attrs: string[] = [];
   if (page) attrs.push(`page=${page}`);
   if (per) attrs.push(`per_page=${per}`);
-  // Arena API expects combined sort value: "position_desc", "created_at_asc", etc.
-  if (sort && direction) {
-    attrs.push(`sort=${sort}_${direction}`);
-  } else if (sort) {
-    attrs.push(`sort=${sort}`);
-  }
+  const combined = formatSort(sort, direction);
+  if (combined) attrs.push(`sort=${combined}`);
   if (forceRefresh) attrs.push(`date=${dateProvider.now()}`);
   return attrs.join("&");
 }
@@ -161,11 +161,8 @@ function toSdkQuery(options: PaginationAttributes | undefined): SdkQuery {
   const result: SdkQuery = {};
   if (page) result.page = page;
   if (per) result.per = per;
-  if (sort && direction) {
-    result.sort = `${sort}_${direction}`;
-  } else if (sort) {
-    result.sort = sort;
-  }
+  const combined = formatSort(sort, direction);
+  if (combined) result.sort = combined;
   return result;
 }
 
@@ -287,10 +284,7 @@ export class ArenaClient implements ArenaApi {
   }
 
   me(): Effect.Effect<MeApiResponse, HttpError> {
-    return Effect.tryPromise({
-      try: () => toLocal<MeApiResponse>(this.arena.me()),
-      catch: mapArenaError,
-    });
+    return sdkEffect<MeApiResponse>(() => this.arena.me());
   }
 
   channels(options?: PaginationAttributes): Effect.Effect<GetChannelsApiResponse, HttpError> {
@@ -300,34 +294,22 @@ export class ArenaClient implements ArenaApi {
   user(id: number | string): ArenaUserApi {
     return {
       get: (): Effect.Effect<GetUserApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<GetUserApiResponse>(this.arena.users.get(id)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetUserApiResponse>(() => this.arena.users.get(id)),
       channels: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetUserChannelsApiResponse, HttpError> =>
         this.getJsonWithPaginationQuery(`users/${id}/channels`, options),
       following: (): Effect.Effect<GetUserFollowingApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<GetUserFollowingApiResponse>(this.arena.users.following(id)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetUserFollowingApiResponse>(() => this.arena.users.following(id)),
       followers: (): Effect.Effect<GetUserFollowersApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<GetUserFollowersApiResponse>(this.arena.users.followers(id)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetUserFollowersApiResponse>(() => this.arena.users.followers(id)),
     };
   }
 
   group(slug: string): ArenaGroupApi {
     return {
       get: (): Effect.Effect<GetGroupApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<GetGroupApiResponse>(this.arena.groups.get(slug)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetGroupApiResponse>(() => this.arena.groups.get(slug)),
       channels: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetGroupChannelsApiResponse, HttpError> =>
@@ -340,56 +322,34 @@ export class ArenaClient implements ArenaApi {
       contents: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetChannelContentsApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<GetChannelContentsApiResponse>(
-              this.arena.channels.contents(slug, toSdkQuery(options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetChannelContentsApiResponse>(() =>
+          this.arena.channels.contents(slug, toSdkQuery(options) as any),
+        ),
       connections: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetConnectionsApiResponse[], HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<GetConnectionsApiResponse[]>(
-              this.arena.channels.connections(slug, toSdkQuery(options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetConnectionsApiResponse[]>(() =>
+          this.arena.channels.connections(slug, toSdkQuery(options) as any),
+        ),
       create: (status?: ChannelStatus): Effect.Effect<CreateChannelApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<CreateChannelApiResponse>(
-              this.arena.channels.create({
-                title: slug,
-                visibility: status as "public" | "private" | "closed",
-              } as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<CreateChannelApiResponse>(() =>
+          this.arena.channels.create({
+            title: slug,
+            visibility: status as "public" | "private" | "closed",
+          } as any),
+        ),
       update: (data: { title: string; status?: ChannelStatus }): Effect.Effect<void, HttpError> =>
-        Effect.tryPromise({
-          try: () => {
-            const body: ChannelUpdateBody = { title: data.title };
-            if (data.status) body.visibility = data.status;
-            return toLocal<void>(this.arena.channels.update(slug, body as any));
-          },
-          catch: mapArenaError,
+        sdkEffect<void>(() => {
+          const body: ChannelUpdateBody = { title: data.title };
+          if (data.status) body.visibility = data.status;
+          return this.arena.channels.update(slug, body as any);
         }),
       get: (options?: PaginationAttributes): Effect.Effect<GetChannelsApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<GetChannelsApiResponse>(
-              this.arena.channels.get(slug, toSdkQuery(options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetChannelsApiResponse>(() =>
+          this.arena.channels.get(slug, toSdkQuery(options) as any),
+        ),
       delete: (): Effect.Effect<void, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<void>(this.arena.channels.delete(slug)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<void>(() => this.arena.channels.delete(slug)),
       thumb: (): Effect.Effect<GetChannelThumbApiResponse, HttpError> =>
         this.getJson(`channels/${slug}/thumb`),
     };
@@ -400,37 +360,23 @@ export class ArenaClient implements ArenaApi {
       channels: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetBlockChannelsApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<GetBlockChannelsApiResponse>(
-              this.arena.blocks.connections(id, toSdkQuery(options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetBlockChannelsApiResponse>(() =>
+          this.arena.blocks.connections(id, toSdkQuery(options) as any),
+        ),
       get: (): Effect.Effect<GetBlockApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<GetBlockApiResponse>(this.arena.blocks.get(id)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetBlockApiResponse>(() => this.arena.blocks.get(id)),
       update: (data: {
         title?: string;
         description?: string;
         content?: string;
       }): Effect.Effect<void, HttpError> =>
-        Effect.tryPromise({
-          try: () => toLocal<void>(this.arena.blocks.update(id, data as any)),
-          catch: mapArenaError,
-        }),
+        sdkEffect<void>(() => this.arena.blocks.update(id, data as any)),
       comments: (
         options?: PaginationAttributes,
       ): Effect.Effect<GetBlockCommentApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<GetBlockCommentApiResponse>(
-              this.arena.blocks.comments(id, toSdkQuery(options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<GetBlockCommentApiResponse>(() =>
+          this.arena.blocks.comments(id, toSdkQuery(options) as any),
+        ),
     };
   }
 
@@ -440,46 +386,30 @@ export class ArenaClient implements ArenaApi {
         query: string,
         options?: PaginationAttributes,
       ): Effect.Effect<SearchApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<SearchApiResponse>(
-              this.arena.search.query(toSdkSearchQuery(query, undefined, options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<SearchApiResponse>(() =>
+          this.arena.search.query(toSdkSearchQuery(query, undefined, options) as any),
+        ),
       blocks: (
         query: string,
         options?: PaginationAttributes,
       ): Effect.Effect<SearchApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<SearchApiResponse>(
-              this.arena.search.query(toSdkSearchQuery(query, "blocks", options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<SearchApiResponse>(() =>
+          this.arena.search.query(toSdkSearchQuery(query, "blocks", options) as any),
+        ),
       channels: (
         query: string,
         options?: PaginationAttributes,
       ): Effect.Effect<SearchApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<SearchApiResponse>(
-              this.arena.search.query(toSdkSearchQuery(query, "channels", options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<SearchApiResponse>(() =>
+          this.arena.search.query(toSdkSearchQuery(query, "channels", options) as any),
+        ),
       users: (
         query: string,
         options?: PaginationAttributes,
       ): Effect.Effect<SearchApiResponse, HttpError> =>
-        Effect.tryPromise({
-          try: () =>
-            toLocal<SearchApiResponse>(
-              this.arena.search.query(toSdkSearchQuery(query, "users", options) as any),
-            ),
-          catch: mapArenaError,
-        }),
+        sdkEffect<SearchApiResponse>(() =>
+          this.arena.search.query(toSdkSearchQuery(query, "users", options) as any),
+        ),
     };
   }
 

--- a/packages/schemas/src/branded.ts
+++ b/packages/schemas/src/branded.ts
@@ -1,142 +1,41 @@
-/**
- * Branded types for Arena API IDs.
- *
- * Branded types create nominal types that prevent accidental mixing of
- * different ID types (e.g., passing a channel ID where a user ID is expected).
- *
- * Usage:
- * ```typescript
- * import { ArenaUserId } from "@tom/schemas/branded"
- *
- * // Parse and validate
- * const result = Schema.decodeUnknownEffect(ArenaUserId)(123)
- * // In case of error, EffectEither will contain the error
- *
- * // Encode back to number
- * const num = Schema.encode(ArenaUserId)(userId)
- * ```
- */
+/** Nominal IDs. They stop mixing of ID kinds. */
 import { Schema } from "effect";
 
-/**
- * Branded type for Arena user IDs.
- *
- * Used in:
- * - ArenaUserSchema.id
- * - ArenaEmbeddedUserSchema.id
- * - ArenaCommentEntitySchema.user_id
- * - ArenaChannelSchema.user_id
- */
 export const ArenaUserId = Schema.Number.pipe(Schema.brand("ArenaUserId"));
 export type ArenaUserId = Schema.Schema.Type<typeof ArenaUserId>;
 
-/**
- * Branded type for Arena channel IDs.
- *
- * Used in:
- * - ArenaChannelSchema.id
- */
 export const ArenaChannelId = Schema.Number.pipe(Schema.brand("ArenaChannelId"));
 export type ArenaChannelId = Schema.Schema.Type<typeof ArenaChannelId>;
 
-/**
- * Branded type for Arena block IDs.
- *
- * Used in:
- * - ArenaBaseBlockSchema.id
- * - ArenaBlockCommentSchema.commentable_id
- */
 export const ArenaBlockId = Schema.Number.pipe(Schema.brand("ArenaBlockId"));
 export type ArenaBlockId = Schema.Schema.Type<typeof ArenaBlockId>;
 
-/**
- * Branded type for Arena group IDs.
- *
- * Used in:
- * - ArenaGroupSchema.id
- */
 export const ArenaGroupId = Schema.Number.pipe(Schema.brand("ArenaGroupId"));
 export type ArenaGroupId = Schema.Schema.Type<typeof ArenaGroupId>;
 
-/**
- * Branded type for Arena connection IDs.
- *
- * Used in:
- * - ArenaConnectionSchema.id
- * - ConnectionDataSchema.connection_id
- */
 export const ArenaConnectionId = Schema.Number.pipe(Schema.brand("ArenaConnectionId"));
 export type ArenaConnectionId = Schema.Schema.Type<typeof ArenaConnectionId>;
 
-/**
- * Branded type for Arena comment IDs.
- *
- * Used in:
- * - ArenaBlockCommentSchema.id
- */
 export const ArenaCommentId = Schema.Number.pipe(Schema.brand("ArenaCommentId"));
 export type ArenaCommentId = Schema.Schema.Type<typeof ArenaCommentId>;
 
-/**
- * Branded type for Payload post IDs.
- * Note: Can be either number or string (union type)
- */
-export const PayloadPostId = Schema.Union([
-  Schema.Number.pipe(Schema.brand("PayloadPostId")),
-  Schema.String.pipe(Schema.brand("PayloadPostId")),
-]);
+const numberOrString = <Brand extends string>(brand: Brand) =>
+  Schema.Union([Schema.Number.pipe(Schema.brand(brand)), Schema.String.pipe(Schema.brand(brand))]);
+
+export const PayloadPostId = numberOrString("PayloadPostId");
 export type PayloadPostId = Schema.Schema.Type<typeof PayloadPostId>;
 
-/**
- * Branded type for Payload work IDs.
- * Note: Can be either number or string (union type)
- */
-export const PayloadWorkId = Schema.Union([
-  Schema.Number.pipe(Schema.brand("PayloadWorkId")),
-  Schema.String.pipe(Schema.brand("PayloadWorkId")),
-]);
+export const PayloadWorkId = numberOrString("PayloadWorkId");
 export type PayloadWorkId = Schema.Schema.Type<typeof PayloadWorkId>;
 
-/**
- * Branded type for Payload media IDs.
- */
 export const PayloadMediaId = Schema.Number.pipe(Schema.brand("PayloadMediaId"));
 export type PayloadMediaId = Schema.Schema.Type<typeof PayloadMediaId>;
 
-/**
- * Parse and validate a numeric ID into ArenaUserId.
- * Use for parsing user IDs atAPI boundaries.
- */
+/** Parse IDs at API boundaries. */
 export const parseArenaUserId = Schema.decodeUnknownEffect(ArenaUserId);
-
-/**
- * Parse and validate a numeric ID into ArenaChannelId.
- */
 export const parseArenaChannelId = Schema.decodeUnknownEffect(ArenaChannelId);
-
-/**
- * Parse and validate a numeric ID into ArenaBlockId.
- */
 export const parseArenaBlockId = Schema.decodeUnknownEffect(ArenaBlockId);
-
-/**
- * Parse and validate a numeric ID into ArenaGroupId.
- */
 export const parseArenaGroupId = Schema.decodeUnknownEffect(ArenaGroupId);
-
-/**
- * Parse and validate a numeric ID into ArenaConnectionId.
- */
 export const parseArenaConnectionId = Schema.decodeUnknownEffect(ArenaConnectionId);
-
-/**
- * Parse and validate a numeric ID into ArenaCommentId.
- */
 export const parseArenaCommentId = Schema.decodeUnknownEffect(ArenaCommentId);
-
-/**
- * Parse and validate a numeric ID into PayloadMediaId.
- */
 export const parsePayloadMediaId = Schema.decodeUnknownEffect(PayloadMediaId);
-
-// Note: PayloadPostId and PayloadWorkId are unions, parsing may need custom logic

--- a/packages/schemas/src/payload.ts
+++ b/packages/schemas/src/payload.ts
@@ -156,8 +156,7 @@ export const PayloadMetaSchema = Schema.Struct({
   image: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
-export const PayloadPostSchema = Schema.Struct({
-  id: PayloadPostId,
+const payloadEntryFields = {
   title: Schema.String,
   summary: Schema.optional(Schema.NullOr(Schema.String)),
   publishedAt: Schema.String,
@@ -169,21 +168,16 @@ export const PayloadPostSchema = Schema.Struct({
   createdAt: Schema.String,
   updatedAt: Schema.String,
   meta: Schema.optional(PayloadMetaSchema),
+};
+
+export const PayloadPostSchema = Schema.Struct({
+  id: PayloadPostId,
+  ...payloadEntryFields,
 });
 
 export const PayloadWorkSchema = Schema.Struct({
   id: PayloadWorkId,
-  title: Schema.String,
-  summary: Schema.optional(Schema.NullOr(Schema.String)),
-  publishedAt: Schema.String,
-  slug: Schema.String,
-  content: Schema.optional(Schema.Union([Schema.String, PayloadRichContentSchema])),
-  heroImage: Schema.optional(Schema.NullOr(PayloadHeroImageSchema)),
-  arenaSlug: Schema.optional(Schema.NullOr(Schema.String)),
-  arenaTitle: Schema.optional(Schema.NullOr(Schema.String)),
-  createdAt: Schema.String,
-  updatedAt: Schema.String,
-  meta: Schema.optional(PayloadMetaSchema),
+  ...payloadEntryFields,
 });
 
 export const PayloadResponseSchema = <A, I, R>(itemSchema: Schema.Codec<A, I, R>) =>

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -1,5 +1,12 @@
 import { Schema } from "effect";
 
+const messageFields = { message: Schema.String };
+
+const messageCauseFields = {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Unknown),
+};
+
 export class ImageError extends Schema.TaggedError<ImageError>()("ImageError", {
   response: Schema.Unknown,
   cause: Schema.optional(Schema.Unknown),
@@ -11,13 +18,12 @@ export class PolarApiError extends Schema.TaggedError<PolarApiError>()("PolarApi
   operation: Schema.String,
 }) {}
 
-export class ArenaConfigError extends Schema.TaggedError<ArenaConfigError>()("ArenaConfigError", {
-  message: Schema.String,
-}) {}
+export class ArenaConfigError extends Schema.TaggedError<ArenaConfigError>()(
+  "ArenaConfigError",
+  messageFields,
+) {}
 
-export class SearchError extends Schema.TaggedError<SearchError>()("SearchError", {
-  message: Schema.String,
-}) {}
+export class SearchError extends Schema.TaggedError<SearchError>()("SearchError", messageFields) {}
 
 export class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
   message: Schema.String,
@@ -27,10 +33,7 @@ export class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
 
 export class DatabaseConnectionError extends Schema.TaggedError<DatabaseConnectionError>()(
   "DatabaseConnectionError",
-  {
-    message: Schema.String,
-    cause: Schema.optional(Schema.Unknown),
-  },
+  messageCauseFields,
 ) {}
 
 export class StoredProcedureError extends Schema.TaggedError<StoredProcedureError>()(
@@ -67,21 +70,20 @@ export class MissingFieldError extends Schema.TaggedError<MissingFieldError>()(
   },
 ) {}
 
-export class ProfanityError extends Schema.TaggedError<ProfanityError>()("ProfanityError", {
-  message: Schema.String,
-}) {}
+export class ProfanityError extends Schema.TaggedError<ProfanityError>()(
+  "ProfanityError",
+  messageFields,
+) {}
 
 export class AuthenticationError extends Schema.TaggedError<AuthenticationError>()(
   "AuthenticationError",
-  {
-    message: Schema.String,
-  },
+  messageFields,
 ) {}
 
-export class NodeinfoError extends Schema.TaggedError<NodeinfoError>()("NodeinfoError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Unknown),
-}) {}
+export class NodeinfoError extends Schema.TaggedError<NodeinfoError>()(
+  "NodeinfoError",
+  messageCauseFields,
+) {}
 
 export class FontFetchError extends Schema.TaggedError<FontFetchError>()("FontFetchError", {
   message: Schema.String,
@@ -95,9 +97,7 @@ export class ValidationError extends Schema.TaggedError<ValidationError>()("Vali
 
 export class ImageGenerationError extends Schema.TaggedError<ImageGenerationError>()(
   "ImageGenerationError",
-  {
-    message: Schema.String,
-  },
+  messageFields,
 ) {}
 
 export class TelegramError extends Schema.TaggedError<TelegramError>()("TelegramError", {
@@ -114,27 +114,25 @@ export class InfrastructureConfigError extends Schema.TaggedError<Infrastructure
   },
 ) {}
 
-export class SecretsError extends Schema.TaggedError<SecretsError>()("SecretsError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Unknown),
-}) {}
+export class SecretsError extends Schema.TaggedError<SecretsError>()(
+  "SecretsError",
+  messageCauseFields,
+) {}
 
 export class WorkerEnvMissingError extends Schema.TaggedError<WorkerEnvMissingError>()(
   "WorkerEnvMissingError",
-  {
-    message: Schema.String,
-  },
+  messageFields,
 ) {}
 
-export class QueueError extends Schema.TaggedError<QueueError>()("QueueError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Unknown),
-}) {}
+export class QueueError extends Schema.TaggedError<QueueError>()(
+  "QueueError",
+  messageCauseFields,
+) {}
 
-export class RunnerError extends Schema.TaggedError<RunnerError>()("RunnerError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Unknown),
-}) {}
+export class RunnerError extends Schema.TaggedError<RunnerError>()(
+  "RunnerError",
+  messageCauseFields,
+) {}
 
 export class GitHubApiError extends Schema.TaggedError<GitHubApiError>()("GitHubApiError", {
   message: Schema.String,
@@ -142,7 +140,7 @@ export class GitHubApiError extends Schema.TaggedError<GitHubApiError>()("GitHub
   cause: Schema.optional(Schema.Unknown),
 }) {}
 
-export class TurboCacheError extends Schema.TaggedError<TurboCacheError>()("TurboCacheError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Unknown),
-}) {}
+export class TurboCacheError extends Schema.TaggedError<TurboCacheError>()(
+  "TurboCacheError",
+  messageCauseFields,
+) {}


### PR DESCRIPTION
This change reduces code duplication across the monorepo. The same patterns appear in many places. Now they are defined once and reused.

## Changes

### Data structures
- **Country options**: Replace verbose object array with compact tuple format. Map back at export. Saves 733 lines.
- **GTM schemas**: Extract writable field definitions (`containerWritableFields`, `workspaceWritableFields`, `tagWritableFields`, `triggerWritableFields`, `variableWritableFields`, `folderWritableFields`). Draft schemas now spread these shared definitions.
- **Payload schemas**: Extract `payloadEntryFields` shared between `PayloadPostSchema` and `PayloadWorkSchema`.

### Test code
- **GTM driver**: Move `testWorkspace` constant, `withTriggerProvider`, and `reconcileTrigger` to driver.ts (shared location).
- **GTM tests**: Import these from driver instead of defining locally. Replace hardcoded workspace strings with `testWorkspace` constant.

### Client code
- **Arena client**: Extract `sdkEffect()` helper to wrap repeated `Effect.tryPromise` + `toLocal` + error mapping. Extract `formatSort()` helper to combine sort and direction fields.
- **Branded types**: Remove verbose comments. Extract `numberOrString()` helper for union branded types.

### Error classes
- **Error types**: Extract `messageFields` and `messageCauseFields` shared across multiple error class definitions.

## Result

Shared logic is now defined in one place. Changes are easier. Files are smaller. Maintenance is clearer.