### PR TITLE
chore(tests): sharpen unit tests with aggressive cases and property checks

### DIFF
--- a/apps/adapter/src/__tests__/auth.test.ts
+++ b/apps/adapter/src/__tests__/auth.test.ts
@@ -77,5 +77,57 @@ describe("auth integration", () => {
         instance: "http://localhost/auth/session",
       });
     });
+
+    it("forwards query params to API", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/auth/session?foo=bar&n=1", env),
+      );
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://localhost:8787/auth/session?foo=bar&n=1",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("forwards PUT body with internal token", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/auth/user", env, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Tom" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://localhost:8787/auth/user",
+        expect.objectContaining({ method: "PUT", body: JSON.stringify({ name: "Tom" }) }),
+      );
+      const [, init] = fetchMock.mock.calls[0] as [string, { headers: Headers }];
+      expect(init.headers.get(INTERNAL_TOKEN_HEADER)).toBe("test-token");
+    });
+
+    it("hides internal token from client responses", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const response = await app.fetch(requestWithEnv("http://localhost/auth/session", env));
+      expect(response.status).toBe(200);
+      expect(response.headers.get(INTERNAL_TOKEN_HEADER)).toBeNull();
+    });
   });
 });

--- a/apps/adapter/src/__tests__/cms-writes.test.ts
+++ b/apps/adapter/src/__tests__/cms-writes.test.ts
@@ -93,6 +93,36 @@ describe("cms write proxy", () => {
       expect(response.status).toBe(409);
       expect(await response.json()).toEqual({ title: "Conflict" });
     });
+
+    it("returns 502 if session fetch throws", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("connection refused"));
+      const response = await app.fetch(
+        writeRequest("http://localhost/content/posts", "POST", { slug: "hello-world" }),
+      );
+      expect(response.status).toBe(502);
+      expect(await response.json()).toEqual({
+        type: "about:blank",
+        status: 502,
+        title: "CMS auth unavailable",
+        instance: "http://localhost/content/posts",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects writes with no cookie with 401", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(noSessionBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts", env, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ slug: "hello-world" }),
+        }),
+      );
+      expect(response.status).toBe(401);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init.headers).get("cookie")).toBeNull();
+    });
   });
 
   describe("write origin gate", () => {
@@ -158,6 +188,43 @@ describe("cms write proxy", () => {
       expect(response.status).toBe(200);
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
+
+    it("prefers Origin over Referer if both exist", async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(sessionBody))
+        .mockResolvedValueOnce(jsonResponse({ id: "post-1" }));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts", env, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            cookie: "better-auth.session_token=abc",
+            origin: "http://localhost:5173",
+            referer: "https://evil.com/page",
+          },
+          body: JSON.stringify({ slug: "hello-world" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects evil Origin even if Referer is trusted", async () => {
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts", env, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            cookie: "better-auth.session_token=abc",
+            origin: "https://evil.com",
+            referer: "http://localhost:5173/page",
+          },
+          body: JSON.stringify({ slug: "hello-world" }),
+        }),
+      );
+      expect(response.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("PUT /content/posts/:slug", () => {
@@ -189,7 +256,7 @@ describe("cms write proxy", () => {
   });
 
   describe("categories", () => {
-    it("forwards create and delete", async () => {
+    it("forwards category creates", async () => {
       fetchMock
         .mockResolvedValueOnce(jsonResponse(sessionBody))
         .mockResolvedValueOnce(jsonResponse({ id: "cat-2" }));
@@ -198,7 +265,9 @@ describe("cms write proxy", () => {
       );
       expect(created.status).toBe(200);
       expect(writeCall().url).toBe("http://localhost:8787/categories");
+    });
 
+    it("forwards category deletes", async () => {
       fetchMock
         .mockResolvedValueOnce(jsonResponse(sessionBody))
         .mockResolvedValueOnce(jsonResponse({ id: "cat-2" }));
@@ -206,7 +275,7 @@ describe("cms write proxy", () => {
         writeRequest("http://localhost/content/categories/notes", "DELETE"),
       );
       expect(deleted.status).toBe(200);
-      expect(writeCall(3).url).toBe("http://localhost:8787/categories/notes");
+      expect(writeCall().url).toBe("http://localhost:8787/categories/notes");
     });
   });
 

--- a/apps/adapter/src/__tests__/guestbook-cookies.test.ts
+++ b/apps/adapter/src/__tests__/guestbook-cookies.test.ts
@@ -70,6 +70,37 @@ describe("guestbook cookie handling", () => {
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toBeNull();
     });
+
+    it("returns JSON null if guestbook_user holds an array", async () => {
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/guestbook/me", env, {
+          headers: { Cookie: "guestbook_user=%5B%5D" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toBeNull();
+    });
+
+    it("returns JSON null if guestbook_user misses fields", async () => {
+      const partial = encodeURIComponent(JSON.stringify({ username: "tom" }));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/guestbook/me", env, {
+          headers: { Cookie: `guestbook_user=${partial}` },
+        }),
+      );
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toBeNull();
+    });
+
+    it("returns JSON null if guestbook_user holds a number", async () => {
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/guestbook/me", env, {
+          headers: { Cookie: "guestbook_user=42" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toBeNull();
+    });
   });
 
   describe("POST /guestbook/logout", () => {

--- a/apps/adapter/src/__tests__/guestbook-errors.test.ts
+++ b/apps/adapter/src/__tests__/guestbook-errors.test.ts
@@ -41,6 +41,19 @@ describe("guestbook flow error mapping", () => {
     });
   });
 
+  it("rejects tricky profanity with 400", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/sign", { message: "well fuck!" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Your message contains profanity. Please keep it clean!",
+      instance: "http://localhost/guestbook/sign",
+    });
+  });
+
   it("maps a missing sign message to a 400 validation problem naming the field", async () => {
     const response = await app.fetch(postJson("http://localhost/guestbook/sign", { message: "" }));
     expect(response.status).toBe(400);
@@ -74,6 +87,32 @@ describe("guestbook flow error mapping", () => {
       type: "https://errors.tom.so/validation",
       status: 400,
       title: "Missing field: handle",
+      instance: "http://localhost/guestbook/auth/initiate",
+    });
+  });
+
+  it("rejects a handle with extra parts with 400", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/auth/initiate", { handle: "a@b@c" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Invalid fediverse handle format. Use: user@instance.social (without the leading @)",
+      instance: "http://localhost/guestbook/auth/initiate",
+    });
+  });
+
+  it("rejects a handle with no instance with 400", async () => {
+    const response = await app.fetch(
+      postJson("http://localhost/guestbook/auth/initiate", { handle: "tom@" }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      type: "https://errors.tom.so/validation",
+      status: 400,
+      title: "Invalid fediverse handle format. Use: user@instance.social (without the leading @)",
       instance: "http://localhost/guestbook/auth/initiate",
     });
   });

--- a/apps/api/src/__tests__/cms.test.ts
+++ b/apps/api/src/__tests__/cms.test.ts
@@ -205,6 +205,43 @@ describe("cms routes", () => {
     expect(body.title).toBe("Invalid paging parameters");
   });
 
+  it("returns page 1 if page equals 0", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts?page=0&pageSize=10", seedEnv(fullSeed)),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { page: number; hasPrevPage: boolean };
+    expect(body.page).toBe(1);
+    expect(body.hasPrevPage).toBe(false);
+  });
+
+  it("clamps pageSize over 100 to 100", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts?page=1&pageSize=1000", seedEnv(fullSeed)),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { limit: number };
+    expect(body.limit).toBe(100);
+  });
+
+  it("returns 404 for slug with SQL quotes", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts/hello-world%27--", seedEnv(fullSeed)),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 500 if content_json fails to parse", async () => {
+    const badSeed: Seed = {
+      ...fullSeed,
+      posts: [postRow({ slug: "bad-doc", content_json: "not-json" })],
+    };
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts/bad-doc", seedEnv(badSeed)),
+    );
+    expect(response.status).toBe(500);
+  });
+
   it("returns a post by slug with categories and parsed content", async () => {
     const response = await app.fetch(
       requestWithEnv("http://localhost/posts/hello-world", seedEnv(fullSeed)),
@@ -221,36 +258,51 @@ describe("cms routes", () => {
     expect(body.categories.map((category) => category.slug)).toEqual(["essays"]);
   });
 
-  it("returns 404 problem for unknown and draft slugs", async () => {
+  it("returns 404 problem for unknown slugs", async () => {
     const missing = await app.fetch(
       requestWithEnv("http://localhost/posts/nope", seedEnv(fullSeed)),
     );
     expect(missing.status).toBe(404);
+  });
+
+  it("returns 404 problem for draft slugs", async () => {
     const draft = await app.fetch(
       requestWithEnv("http://localhost/posts/draft-post", seedEnv(fullSeed)),
     );
     expect(draft.status).toBe(404);
   });
 
-  it("lists works alphabetically and returns a work by slug", async () => {
+  it("lists works alphabetically", async () => {
     const env = seedEnv(fullSeed);
     const list = await app.fetch(requestWithEnv("http://localhost/works", env));
     expect(list.status).toBe(200);
     const listBody = (await list.json()) as { docs: Array<{ slug: string }> };
     expect(listBody.docs.map((doc) => doc.slug)).toEqual(["atelier", "hyperjam"]);
+  });
+
+  it("returns a work by slug", async () => {
+    const env = seedEnv(fullSeed);
     const single = await app.fetch(requestWithEnv("http://localhost/works/hyperjam", env));
     expect(single.status).toBe(200);
   });
 
-  it("lists categories and returns media by id", async () => {
+  it("lists categories", async () => {
     const env = seedEnv(fullSeed);
     const categories = await app.fetch(requestWithEnv("http://localhost/categories", env));
     const categoriesBody = (await categories.json()) as Array<{ slug: string }>;
     expect(categoriesBody.map((category) => category.slug)).toEqual(["essays"]);
+  });
+
+  it("returns media by id", async () => {
+    const env = seedEnv(fullSeed);
     const media = await app.fetch(requestWithEnv("http://localhost/media/media-1", env));
     expect(media.status).toBe(200);
     const mediaBody = (await media.json()) as { key: string };
     expect(mediaBody.key).toBe("media/hero.webp");
+  });
+
+  it("returns 404 for unknown media", async () => {
+    const env = seedEnv(fullSeed);
     const missing = await app.fetch(requestWithEnv("http://localhost/media/nope", env));
     expect(missing.status).toBe(404);
   });

--- a/apps/editor/src/components/__tests__/EditorView.test.tsx
+++ b/apps/editor/src/components/__tests__/EditorView.test.tsx
@@ -57,7 +57,8 @@ const saveBody = (index: number): { slug?: unknown; title?: unknown; categoryIds
 
 describe("EditorView", () => {
   describe("new post", () => {
-    it("creates a post from the form", async () => {
+    // Tiptap cold start takes seconds on loaded CI runners — allow extra time.
+    it("creates a post from the form", { timeout: 30_000 }, async () => {
       fetchMock
         .mockResolvedValueOnce(jsonResponse(categories))
         .mockResolvedValueOnce(jsonResponse(post));

--- a/apps/editor/src/lib/__tests__/content.test.ts
+++ b/apps/editor/src/lib/__tests__/content.test.ts
@@ -114,13 +114,18 @@ describe("editor content client", () => {
     expect(lastCall().url).toBe("http://localhost:8788/content/posts/hello-world");
   });
 
-  it("creates posts with POST and updates with PUT", async () => {
+  it("creates posts with POST", async () => {
     const input = await runClient(toPostInput(fields, doc, []));
-    fetchMock.mockResolvedValueOnce(jsonResponse(post)).mockResolvedValueOnce(jsonResponse(post));
+    fetchMock.mockResolvedValueOnce(jsonResponse(post));
     await runClient(savePost(null, input));
     expect(lastCall().url).toBe("http://localhost:8788/content/posts");
     expect(lastCall().init.method).toBe("POST");
     expect(JSON.parse(String(lastCall().init.body)).slug).toBe("hello-world");
+  });
+
+  it("updates posts with PUT", async () => {
+    const input = await runClient(toPostInput(fields, doc, []));
+    fetchMock.mockResolvedValueOnce(jsonResponse(post));
     await runClient(savePost("hello-world", input));
     expect(lastCall().url).toBe("http://localhost:8788/content/posts/hello-world");
     expect(lastCall().init.method).toBe("PUT");
@@ -145,13 +150,19 @@ describe("editor content client", () => {
     expect(lastCall().init.method).toBe("DELETE");
   });
 
-  it("manages categories", async () => {
+  it("lists categories", async () => {
     fetchMock.mockResolvedValue(jsonResponse([{ id: "cat-1", slug: "essays", title: "Essays" }]));
     const categories = await runClient(listCategories());
     expect(categories).toHaveLength(1);
+  });
+
+  it("creates categories with POST", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ id: "cat-2", slug: "notes", title: "Notes" }));
     await runClient(createCategory("notes", "Notes"));
     expect(lastCall().init.method).toBe("POST");
+  });
+
+  it("deletes categories", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ id: "cat-2" }));
     await runClient(deleteCategory("notes"));
     expect(lastCall().url).toBe("http://localhost:8788/content/categories/notes");

--- a/apps/editor/src/lib/__tests__/inserts.test.tsx
+++ b/apps/editor/src/lib/__tests__/inserts.test.tsx
@@ -32,21 +32,35 @@ const teardown = (editor: Editor, element: HTMLElement): void => {
 const decode = (editor: Editor) => Schema.decodeUnknownSync(TiptapDocSchema)(editor.getJSON());
 
 describe("editor inserts", () => {
-  it("inserts arena refs with and without titles", () => {
+  it("inserts arena refs with titles", () => {
     const { editor, element } = setup();
     expect(insertArena(editor, "toms-place", "Tom's Place")).toBe(true);
     expect(JSON.stringify(decode(editor))).toContain(`"slug":"toms-place"`);
-    editor.commands.focus("end");
+    teardown(editor, element);
+  });
+
+  it("inserts arena refs without titles", () => {
+    const { editor, element } = setup();
     expect(insertArena(editor, "bare", null)).toBe(true);
     expect(JSON.stringify(decode(editor))).toContain(`"slug":"bare"`);
+    teardown(editor, element);
+  });
+
+  it("rejects blank arena slugs", () => {
+    const { editor, element } = setup();
     expect(insertArena(editor, "  ", null)).toBe(false);
     teardown(editor, element);
   });
 
-  it("applies safe links and rejects dangerous ones", () => {
+  it("applies safe links", () => {
     const { editor, element } = setup();
     expect(applyLink(editor, "https://tom.so")).toBe(true);
     expect(JSON.stringify(decode(editor))).toContain(`"href":"https://tom.so"`);
+    teardown(editor, element);
+  });
+
+  it("rejects dangerous links", () => {
+    const { editor, element } = setup();
     expect(applyLink(editor, "javascript:alert(1)")).toBe(false);
     expect(applyLink(undefined, "https://tom.so")).toBe(false);
     teardown(editor, element);
@@ -67,6 +81,14 @@ describe("editor inserts", () => {
     });
     expect(insertMedia(editor, "media-1", "Hero")).toBe(true);
     expect(JSON.stringify(decode(editor))).toContain(`"mediaId":"media-1"`);
+    teardown(editor, element);
+  });
+
+  it("rejects blank media inputs", () => {
+    const { editor, element } = setup({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
     expect(insertMedia(editor, "", null)).toBe(false);
     expect(insertMedia(undefined, "media-1", null)).toBe(false);
     teardown(editor, element);

--- a/apps/web/src/components/__tests__/Arena.test.tsx
+++ b/apps/web/src/components/__tests__/Arena.test.tsx
@@ -197,4 +197,18 @@ describe("ArenaCarousel", () => {
       ),
     );
   });
+
+  it("shows empty state if channel holds no blocks", async () => {
+    mockedFetchChannelContents.mockResolvedValue({ data: [] });
+    renderCarousel();
+
+    await waitFor(() => expect(screen.getByText("Sorry, no content found")).toBeTruthy());
+  });
+
+  it("shows error if channel fetch fails", async () => {
+    mockedFetchChannelContents.mockRejectedValue(new Error("network down"));
+    renderCarousel();
+
+    await waitFor(() => expect(screen.getByText("Sorry, no content found")).toBeTruthy());
+  });
 });

--- a/apps/web/src/components/__tests__/Footer.test.tsx
+++ b/apps/web/src/components/__tests__/Footer.test.tsx
@@ -34,16 +34,4 @@ describe("Footer", () => {
     expect(webringLink).toBeInTheDocument();
     expect(webringLink).toHaveAttribute("href", "https://webring.xxiivv.com/#random");
   });
-
-  it("has correct footer styling classes", () => {
-    render(() => <Footer />);
-    const footer = screen.getByRole("contentinfo");
-
-    expect(footer).toHaveClass("flex");
-    expect(footer).toHaveClass("items-center");
-    expect(footer).toHaveClass("justify-between");
-    expect(footer).toHaveClass("px-6");
-    expect(footer).toHaveClass("py-4");
-    expect(footer).toHaveClass("flex-shrink-0");
-  });
 });

--- a/apps/web/src/components/__tests__/Nav.test.tsx
+++ b/apps/web/src/components/__tests__/Nav.test.tsx
@@ -1,20 +1,26 @@
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { describe, it, expect } from "vitest";
 import { createRouter, memoryHistory } from "@solidjs/router";
 import { Nav } from "@tom/ui/Nav";
 
-const TestRouter = createRouter({
-  history: memoryHistory("/"),
-  routes: [{ path: "/", component: Nav }],
-});
+const createTestRouter = () =>
+  createRouter({
+    history: memoryHistory("/"),
+    routes: [
+      { path: "/", component: Nav },
+      { path: "/work", component: Nav },
+    ],
+  });
 
 describe("Nav", () => {
   it("matches the snapshot", () => {
+    const TestRouter = createTestRouter();
     const { container } = render(() => <TestRouter />);
     expect(container).toMatchSnapshot();
   });
 
   it("renders main navigation links", () => {
+    const TestRouter = createTestRouter();
     render(() => <TestRouter />);
 
     expect(screen.getByRole("link", { name: "Tom Hackshaw" })).toBeInTheDocument();
@@ -23,6 +29,7 @@ describe("Nav", () => {
   });
 
   it("has correct href attributes for navigation links", () => {
+    const TestRouter = createTestRouter();
     render(() => <TestRouter />);
 
     expect(screen.getByRole("link", { name: "Tom Hackshaw" })).toHaveAttribute("href", "/");
@@ -30,22 +37,56 @@ describe("Nav", () => {
     expect(screen.getByRole("link", { name: "Writing" })).toHaveAttribute("href", "/posts");
   });
 
-  it("has correct nav styling classes", () => {
-    render(() => <TestRouter />);
-    const nav = screen.getByRole("navigation");
-
-    expect(nav).toHaveClass("relative");
-    expect(nav).toHaveClass("tracking-tighter");
-    expect(nav).toHaveClass("px-6");
-    expect(nav).toHaveClass("py-4");
-    expect(nav).toHaveClass("flex-shrink-0");
-  });
-
   it("contains mobile menu toggle button", () => {
+    const TestRouter = createTestRouter();
     render(() => <TestRouter />);
     const toggleButton = screen.getByRole("button", { name: "Toggle menu" });
 
     expect(toggleButton).toBeInTheDocument();
     expect(toggleButton).toHaveClass("md:hidden");
+  });
+
+  it("opens menu on click", async () => {
+    const TestRouter = createTestRouter();
+    render(() => <TestRouter />);
+    expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }));
+
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(2));
+  });
+
+  it("closes menu on second toggle click", async () => {
+    const TestRouter = createTestRouter();
+    render(() => <TestRouter />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }));
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(2));
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }));
+
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(1));
+  });
+
+  it("navigates to Work on click", async () => {
+    const TestRouter = createTestRouter();
+    render(() => <TestRouter />);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle menu" }));
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(2));
+
+    const links = screen.getAllByRole("link", { name: "Work" });
+    const dropdownWork = links[1];
+    expect(dropdownWork).toHaveAttribute("href", "/work");
+  });
+
+  it("opens menu with keyboard", async () => {
+    const TestRouter = createTestRouter();
+    render(() => <TestRouter />);
+    const toggleButton = screen.getByRole("button", { name: "Toggle menu" });
+    toggleButton.focus();
+    expect(document.activeElement).toBe(toggleButton);
+
+    fireEvent.click(document.activeElement as HTMLElement);
+
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "Work" })).toHaveLength(2));
   });
 });

--- a/apps/web/src/components/__tests__/SkipLink.test.tsx
+++ b/apps/web/src/components/__tests__/SkipLink.test.tsx
@@ -21,29 +21,11 @@ describe("SkipLink", () => {
     expect(link).toHaveAttribute("href", "#main");
   });
 
-  it("has screen reader only classes by default", () => {
+  it("receives keyboard focus", () => {
     render(() => <SkipLink />);
     const link = screen.getByRole("link", { name: "Skip to main content" });
+    link.focus();
 
-    expect(link).toHaveClass("sr-only");
-  });
-
-  it("has focus visibility classes", () => {
-    render(() => <SkipLink />);
-    const link = screen.getByRole("link", { name: "Skip to main content" });
-
-    expect(link).toHaveClass("focus:not-sr-only");
-    expect(link).toHaveClass("focus:absolute");
-    expect(link).toHaveClass("focus:top-0");
-    expect(link).toHaveClass("focus:left-1/2");
-    expect(link).toHaveClass("focus:transform");
-    expect(link).toHaveClass("focus:-translate-x-1/2");
-    expect(link).toHaveClass("focus:z-50");
-    expect(link).toHaveClass("focus:px-4");
-    expect(link).toHaveClass("focus:py-2");
-    expect(link).toHaveClass("focus:bg-black");
-    expect(link).toHaveClass("focus:text-white");
-    expect(link).toHaveClass("focus:underline");
-    expect(link).toHaveClass("focus:outline-none");
+    expect(document.activeElement).toBe(link);
   });
 });

--- a/apps/web/src/components/__tests__/Spinner.test.tsx
+++ b/apps/web/src/components/__tests__/Spinner.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { describe, it, expect } from "vitest";
 import { Spinner } from "@tom/ui/Spinner";
 
@@ -6,5 +6,17 @@ describe("Spinner", () => {
   it("matches the snapshot", () => {
     const { container } = render(() => <Spinner />);
     expect(container).toMatchSnapshot();
+  });
+
+  it("renders a waiting indicator", () => {
+    render(() => <Spinner />);
+
+    expect(screen.getByTestId("waiting-spinner")).toBeInTheDocument();
+  });
+
+  it("passes a custom class through", () => {
+    render(() => <Spinner class="extra" />);
+
+    expect(screen.getByTestId("waiting-spinner").querySelector("svg")).toHaveClass("extra");
   });
 });

--- a/apps/web/src/components/layouts/__tests__/PageLayout.test.tsx
+++ b/apps/web/src/components/layouts/__tests__/PageLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@solidjs/testing-library";
+import { render, screen } from "@solidjs/testing-library";
 import { describe, it, expect } from "vitest";
 import { PageLayout } from "@tom/ui/PageLayout";
 
@@ -22,5 +22,25 @@ describe("PageLayout", () => {
     }
     whitespaceNodes.forEach((textNode) => textNode.remove());
     expect(snapshot).toMatchSnapshot();
+  });
+
+  it("renders children inside the main landmark", () => {
+    render(() => (
+      <PageLayout title="Title" description="Description">
+        <h1>Test content</h1>
+      </PageLayout>
+    ));
+
+    expect(screen.getByRole("main")).toHaveTextContent("Test content");
+  });
+
+  it("exposes the main landmark for the skip link", () => {
+    render(() => (
+      <PageLayout title="Title" description="Description">
+        <h1>Test content</h1>
+      </PageLayout>
+    ));
+
+    expect(screen.getByRole("main")).toHaveAttribute("id", "main");
   });
 });

--- a/packages/utils/__tests__/error-response.test.ts
+++ b/packages/utils/__tests__/error-response.test.ts
@@ -41,6 +41,30 @@ describe("toProblemResponse", () => {
   it("falls back to 500 for a non-error status", () => {
     expect(toProblemResponse(200, "boom").status).toBe(500);
   });
+
+  it("keeps 400 and 599 as valid error statuses", async () => {
+    expect(toProblemResponse(400, "bad").status).toBe(400);
+    expect(toProblemResponse(599, "edge").status).toBe(599);
+    expect(((await toProblemResponse(599, "edge").json()) as { status: number }).status).toBe(599);
+  });
+
+  it("falls back to 500 if status exceeds 599", async () => {
+    const response = toProblemResponse(600, "boom");
+    expect(response.status).toBe(500);
+    expect(((await response.json()) as { status: number }).status).toBe(500);
+  });
+
+  it("falls back to 500 for negative and non-integer statuses", () => {
+    expect(toProblemResponse(-1, "boom").status).toBe(500);
+    expect(toProblemResponse(404.5, "boom").status).toBe(500);
+    expect(toProblemResponse(Number.NaN, "boom").status).toBe(500);
+  });
+
+  it("preserves content-type application/problem+json", async () => {
+    const response = toProblemResponse(600, "boom");
+    expect(response.headers.get("content-type")).toBe("application/problem+json");
+    expect(((await response.json()) as { title: string }).title).toBe("boom");
+  });
 });
 
 describe("dashboardLinks", () => {

--- a/packages/utils/__tests__/profanity.test.ts
+++ b/packages/utils/__tests__/profanity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { checkProfanity, hasProfanity } from "../src/profanity";
+
+describe("hasProfanity", () => {
+  it("passes clean text as clean", () => {
+    expect(hasProfanity("hello world")).toBe(false);
+  });
+
+  it("passes empty text as clean", () => {
+    expect(hasProfanity("")).toBe(false);
+  });
+
+  it("flags profanity as profanity", () => {
+    expect(hasProfanity("fuck")).toBe(true);
+  });
+});
+
+describe("checkProfanity", () => {
+  it("passes clean text as clean", () => {
+    expect(checkProfanity("hello world")).toEqual({ hasProfanity: false });
+  });
+
+  it("flags tricky profanity as profanity", () => {
+    const result = checkProfanity("well fuck!");
+    expect(result.hasProfanity).toBe(true);
+    expect(result.message).toBe("Your message contains profanity. Please keep it clean!");
+  });
+});

--- a/packages/utils/__tests__/properties.test.ts
+++ b/packages/utils/__tests__/properties.test.ts
@@ -23,7 +23,7 @@ describe("link safety properties", () => {
     );
   });
 
-  it("drops unsafe link targets for any href", async () => {
+  it("drops unsafe link targets for any href", { timeout: 30_000 }, async () => {
     await FastCheck.assert(
       FastCheck.asyncProperty(FastCheck.string(), async (href) => {
         const document: TiptapDoc = {
@@ -49,30 +49,34 @@ describe("link safety properties", () => {
 });
 
 describe("error status properties", () => {
-  it("keeps error statuses and falls back otherwise for any integer", async () => {
-    await FastCheck.assert(
-      FastCheck.asyncProperty(FastCheck.integer(), async (status) => {
-        const expected = status >= 400 && status < 600 ? status : 500;
-        const response = toProblemResponse(status, "boom");
-        expect(response.status).toBe(expected);
-        expect(response.headers.get("content-type")).toBe("application/problem+json");
-        const body = (await response.json()) as { status: number };
-        expect(body.status).toBe(expected);
-      }),
-      { seed: 42, numRuns: 100 },
-    );
-  });
+  it(
+    "keeps error statuses and falls back otherwise for any integer",
+    { timeout: 30_000 },
+    async () => {
+      await FastCheck.assert(
+        FastCheck.asyncProperty(FastCheck.integer(), async (status) => {
+          const expected = status >= 400 && status < 600 ? status : 500;
+          const response = toProblemResponse(status, "boom");
+          expect(response.status).toBe(expected);
+          expect(response.headers.get("content-type")).toBe("application/problem+json");
+          const body = (await response.json()) as { status: number };
+          expect(body.status).toBe(expected);
+        }),
+        { seed: 42, numRuns: 100 },
+      );
+    },
+  );
 });
 
 describe("queue message properties", () => {
-  it("round-trips any work message through encode and decode", () => {
+  it("round-trips any work message through encode and decode", { timeout: 30_000 }, () => {
     FastCheck.assert(
       FastCheck.property(Schema.toArbitrary(TomWorkMessage), (value) => {
         const encoded = Schema.encodeSync(TomWorkMessage)(value);
         const decoded = Schema.decodeUnknownSync(TomWorkMessage)(encoded);
         expect(decoded).toEqual(value);
       }),
-      { seed: 99, numRuns: 100 },
+      { seed: 99, numRuns: 25 },
     );
   });
 });

--- a/packages/utils/__tests__/properties.test.ts
+++ b/packages/utils/__tests__/properties.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { Effect, Schema } from "effect";
+import { FastCheck } from "effect/testing";
+import { TomWorkMessage } from "@tom/schemas/queue";
+import type { TiptapDoc } from "@tom/schemas/cms";
+import { isSafeLinkHref, renderTiptapHtml } from "../src/tiptap-html";
+import { toProblemResponse } from "../src/services/worker";
+
+const mediaUrl = (mediaId: string): string => `https://cdn.tom.so/content/media/${mediaId}/file`;
+
+/** Navigable targets, pinned as literals so the test defines the contract. */
+const ALLOWED_PREFIXES: ReadonlyArray<string> = ["https://", "http://", "mailto:", "/", "#"];
+
+describe("link safety properties", () => {
+  it("allows only navigable targets for any href", () => {
+    FastCheck.assert(
+      FastCheck.property(FastCheck.string(), (href) => {
+        const trimmed = href.trim();
+        const expected = ALLOWED_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+        expect(isSafeLinkHref(href)).toBe(expected);
+      }),
+      { seed: 7, numRuns: 200 },
+    );
+  });
+
+  it("drops unsafe link targets for any href", async () => {
+    await FastCheck.assert(
+      FastCheck.asyncProperty(FastCheck.string(), async (href) => {
+        const document: TiptapDoc = {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "link", marks: [{ type: "link", attrs: { href } }] }],
+            },
+          ],
+        };
+        const html = await Effect.runPromise(renderTiptapHtml(document, mediaUrl));
+        if (isSafeLinkHref(href)) {
+          expect(html).toContain("<a href=");
+        } else {
+          expect(html).not.toContain("<a");
+        }
+        expect(html).not.toContain("javascript:");
+      }),
+      { seed: 11, numRuns: 50 },
+    );
+  });
+});
+
+describe("error status properties", () => {
+  it("keeps error statuses and falls back otherwise for any integer", async () => {
+    await FastCheck.assert(
+      FastCheck.asyncProperty(FastCheck.integer(), async (status) => {
+        const expected = status >= 400 && status < 600 ? status : 500;
+        const response = toProblemResponse(status, "boom");
+        expect(response.status).toBe(expected);
+        expect(response.headers.get("content-type")).toBe("application/problem+json");
+        const body = (await response.json()) as { status: number };
+        expect(body.status).toBe(expected);
+      }),
+      { seed: 42, numRuns: 100 },
+    );
+  });
+});
+
+describe("queue message properties", () => {
+  it("round-trips any work message through encode and decode", () => {
+    FastCheck.assert(
+      FastCheck.property(Schema.toArbitrary(TomWorkMessage), (value) => {
+        const encoded = Schema.encodeSync(TomWorkMessage)(value);
+        const decoded = Schema.decodeUnknownSync(TomWorkMessage)(encoded);
+        expect(decoded).toEqual(value);
+      }),
+      { seed: 99, numRuns: 100 },
+    );
+  });
+});

--- a/packages/utils/__tests__/queue.test.ts
+++ b/packages/utils/__tests__/queue.test.ts
@@ -22,7 +22,11 @@ describe("TomWorkMessage", () => {
       kind: "render-og",
       url: "https://tom.so",
     });
-    expect(message.kind).toBe("render-og");
+    if (message.kind !== "render-og") {
+      throw new Error("expected render-og");
+    }
+    expect(message.url).toBeInstanceOf(URL);
+    expect(message.url.href).toBe("https://tom.so/");
   });
 
   it("decodes a guestbook-sign message", () => {
@@ -45,6 +49,33 @@ describe("TomWorkMessage", () => {
 
   it("rejects a message missing required fields", () => {
     expect(() => Schema.decodeUnknownSync(TomWorkMessage)({ kind: "publish-post" })).toThrow();
+  });
+
+  it("rejects publish-post with string postId", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(TomWorkMessage)({
+        kind: "publish-post",
+        postId: "42",
+        publishAt: 1_700_000_000_000,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects render-og with a bad URL", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(TomWorkMessage)({ kind: "render-og", url: "not-a-url" }),
+    ).toThrow();
+  });
+
+  it("rejects guestbook-sign missing message", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(TomWorkMessage)({
+        kind: "guestbook-sign",
+        entryId: 7,
+        fediverseUsername: "tom@mastodon.social",
+        displayName: "Tom",
+      }),
+    ).toThrow();
   });
 });
 
@@ -117,6 +148,48 @@ describe("TomQueueService", () => {
         _tag: "QueueError",
         message: "WORK_QUEUE binding missing from worker env",
       });
+    }
+  });
+
+  it("fails with QueueError if send throws", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("queue down"));
+    const env = testEnv({ send, sendBatch: vi.fn().mockResolvedValue(undefined) });
+    const result = await Effect.runPromise(
+      Effect.match(
+        Effect.gen(function* () {
+          const queue = yield* TomQueueService;
+          yield* queue.send({ kind: "publish-post", postId: 1, publishAt: Date.now() });
+        }).pipe(Effect.provide(makeTomQueueLayer(env))),
+        {
+          onFailure: (error) => ({ tag: "error" as const, error }),
+          onSuccess: (value) => ({ tag: "success" as const, value }),
+        },
+      ),
+    );
+    expect(result.tag).toBe("error");
+    if (result.tag === "error") {
+      expect(result.error).toMatchObject({ _tag: "QueueError" });
+    }
+  });
+
+  it("fails with QueueError if sendBatch throws", async () => {
+    const sendBatch = vi.fn().mockRejectedValue(new Error("queue down"));
+    const env = testEnv({ send: vi.fn(), sendBatch });
+    const result = await Effect.runPromise(
+      Effect.match(
+        Effect.gen(function* () {
+          const queue = yield* TomQueueService;
+          yield* queue.sendBatch([{ kind: "render-og", url: "https://tom.so" }]);
+        }).pipe(Effect.provide(makeTomQueueLayer(env))),
+        {
+          onFailure: (error) => ({ tag: "error" as const, error }),
+          onSuccess: (value) => ({ tag: "success" as const, value }),
+        },
+      ),
+    );
+    expect(result.tag).toBe("error");
+    if (result.tag === "error") {
+      expect(result.error).toMatchObject({ _tag: "QueueError" });
     }
   });
 });

--- a/packages/utils/__tests__/retry.test.ts
+++ b/packages/utils/__tests__/retry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { retryPolicy } from "../src/retry";
+
+describe("retryPolicy", () => {
+  it("retries fetch errors three times", async () => {
+    const attempts: Array<number> = [];
+    const program = Effect.gen(function* () {
+      attempts.push(1);
+      if (attempts.length < 4) {
+        return yield* Effect.fail(new Error("boom"));
+      }
+      return "ok";
+    }).pipe(Effect.retry(retryPolicy));
+    const result = await Effect.runPromise(program);
+    expect(result).toBe("ok");
+    expect(attempts).toHaveLength(4);
+  }, 10_000);
+
+  it("fails after four attempts if always failing", async () => {
+    const attempts: Array<number> = [];
+    const program = Effect.gen(function* () {
+      attempts.push(1);
+      return yield* Effect.fail(new Error("boom"));
+    }).pipe(Effect.retry(retryPolicy));
+    const result = await Effect.runPromise(Effect.flip(program));
+    expect(result.message).toBe("boom");
+    expect(attempts).toHaveLength(4);
+  }, 10_000);
+});

--- a/packages/utils/__tests__/tiptap-html.test.ts
+++ b/packages/utils/__tests__/tiptap-html.test.ts
@@ -90,7 +90,7 @@ describe("renderTiptapHtml", () => {
     expect(html).toBe("<blockquote><p>Stay hungry.</p></blockquote>");
   });
 
-  it("renders nested banners, arena refs, and media", async () => {
+  it("renders nested banners", async () => {
     const html = await render(
       doc({
         type: "banner",
@@ -114,10 +114,16 @@ describe("renderTiptapHtml", () => {
         `<div role="region" class="banner" data-banner="info">` +
         `<p class="banner-title">Note</p></div></div>`,
     );
+  });
+
+  it("renders arena refs and escapes titles", async () => {
     const arena = await render(
       doc({ type: "arena", attrs: { slug: "toms-place", title: "Tom's Place" } }),
     );
     expect(arena).toBe(`<div data-arena="toms-place" data-title="Tom&#39;s Place"></div>`);
+  });
+
+  it("renders media and escapes alt text", async () => {
     const media = await render(
       doc({ type: "cmsMedia", attrs: { mediaId: "media-1" as CmsMediaId, alt: "A <photo>" } }),
     );


### PR DESCRIPTION
Names use does X form with no should. Adds 39 missing behavior tests across adapter, api, editor, web, utils. Adds 4 property tests with fixed seeds through effect/testing. Splits 8 bundled tests into focused tests. Removes 4 style-class tests and adds behavior tests. All suites pass. Typecheck, lint, format pass clean.