### PR TITLE
feat(editor): desktop two-column layouts and WYSIWYG canvas

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -1,4 +1,4 @@
-import { Match, Show, Switch, createSignal, onSettled } from "solid-js";
+import { Match, Show, Switch, createEffect, createSignal, onCleanup } from "solid-js";
 import { Effect } from "effect";
 import { Banner } from "@tom/ui/tomui/banner";
 import { Loader } from "@tom/ui/tomui/loader";
@@ -51,18 +51,23 @@ export const App = (props: { navigate?: (url: string) => void }) => {
   const navigate = props.navigate ?? assignUrl;
 
   // The list toolbar sticks below the header, so publish the header
-  // height for its sticky offset. Layout never depends on the value.
-  onSettled(() => {
-    const nav = document.querySelector(".editor-nav");
-    if (!(nav instanceof HTMLElement)) return;
-    const sync = (): void => {
-      document.documentElement.style.setProperty("--editor-nav-h", `${nav.offsetHeight}px`);
-    };
-    sync();
-    const observer = new ResizeObserver(sync);
-    observer.observe(nav);
-    return () => observer.disconnect();
-  });
+  // height for its sticky offset. The nav mounts only after sign-in
+  // resolves, so track the session: the effect re-runs post-commit once
+  // the nav exists. Layout never depends on the value.
+  createEffect(
+    () => session(),
+    () => {
+      const nav = document.querySelector(".editor-nav");
+      if (!(nav instanceof HTMLElement)) return;
+      const sync = (): void => {
+        document.documentElement.style.setProperty("--editor-nav-h", `${nav.offsetHeight}px`);
+      };
+      sync();
+      const observer = new ResizeObserver(sync);
+      observer.observe(nav);
+      onCleanup(() => observer.disconnect());
+    },
+  );
 
   const onSignOut = (): void => {
     void runClient(
@@ -73,8 +78,11 @@ export const App = (props: { navigate?: (url: string) => void }) => {
     );
   };
 
+  const wide = (): boolean =>
+    view().name === "edit" || view().name === "categories" || view().name === "media";
+
   return (
-    <main class="editor-shell">
+    <main class={`editor-shell${wide() ? " editor-shell-wide" : ""}`}>
       <Show when={error()}>{(message) => <Banner variant="error" description={message()} />}</Show>
       <Switch>
         <Match when={session() === undefined}>
@@ -126,7 +134,7 @@ export const App = (props: { navigate?: (url: string) => void }) => {
                   <PostList onEdit={(kind, slug) => setView({ name: "edit", kind, slug })} />
                 </Match>
                 <Match when={view().name === "categories"}>
-                  <CategoriesView onBack={() => setView({ name: "list" })} />
+                  <CategoriesView />
                 </Match>
                 <Match when={view().name === "media"}>
                   <MediaView onEdit={(kind, slug) => setView({ name: "edit", kind, slug })} />

--- a/apps/editor/src/components/CategoriesView.tsx
+++ b/apps/editor/src/components/CategoriesView.tsx
@@ -8,7 +8,7 @@ import { createCategory, deleteCategory, listCategories } from "../lib/content";
 import { runClient } from "../lib/api";
 
 /** Category manager: list, add, delete. Posts link by id from the edit view. */
-export const CategoriesView = (props: { onBack: () => void }) => {
+export const CategoriesView = () => {
   const [categories, setCategories] = createSignal<ReadonlyArray<CmsCategory>>([]);
   const [slug, setSlug] = createSignal("");
   const [title, setTitle] = createSignal("");
@@ -53,63 +53,60 @@ export const CategoriesView = (props: { onBack: () => void }) => {
 
   return (
     <div class="categories-view">
-      <Button
-        type="button"
-        size="sm"
-        variant="ghost"
-        class="justify-self-start"
-        onClick={props.onBack}
-      >
-        ← Back
-      </Button>
       <h2>Categories</h2>
       <Show when={error()}>{(message) => <Banner variant="error" description={message()} />}</Show>
-      <ul class="content-rows">
-        <For each={categories()}>
-          {(category) => (
-            <li class="content-row">
-              <span class="row-title">
-                {category.title} · {category.slug}
-              </span>
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary-destructive"
-                aria-label={`Delete category ${category.slug}`}
-                onClick={() => onDelete(category.slug)}
-              >
-                Delete
-              </Button>
-            </li>
-          )}
-        </For>
-      </ul>
-      <div class="panel">
-        <label class="field">
-          Slug
-          <Input
-            type="text"
-            value={slug()}
-            onInput={(event) => setSlug(event.currentTarget.value)}
-          />
-        </label>
-        <label class="field">
-          Title
-          <Input
-            type="text"
-            value={title()}
-            onInput={(event) => setTitle(event.currentTarget.value)}
-          />
-        </label>
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          class="justify-self-start"
-          onClick={onAdd}
-        >
-          Add category
-        </Button>
+      <div class="categories-layout">
+        <section class="categories-list">
+          <ul class="content-rows">
+            <For each={categories()}>
+              {(category) => (
+                <li class="content-row">
+                  <span class="row-title">
+                    {category.title} · {category.slug}
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary-destructive"
+                    aria-label={`Delete category ${category.slug}`}
+                    onClick={() => onDelete(category.slug)}
+                  >
+                    Delete
+                  </Button>
+                </li>
+              )}
+            </For>
+          </ul>
+        </section>
+        <aside class="categories-form">
+          <div class="panel">
+            <label class="field">
+              Slug
+              <Input
+                type="text"
+                value={slug()}
+                onInput={(event) => setSlug(event.currentTarget.value)}
+              />
+            </label>
+            <label class="field">
+              Title
+              <Input
+                type="text"
+                value={title()}
+                onInput={(event) => setTitle(event.currentTarget.value)}
+              />
+            </label>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              class="justify-self-start"
+              onClick={onAdd}
+            >
+              Add category
+            </Button>
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/apps/editor/src/components/EditorView.tsx
+++ b/apps/editor/src/components/EditorView.tsx
@@ -2,7 +2,6 @@ import { For, Show, createMemo, createSignal, onSettled } from "solid-js";
 import { Effect, Option, Schema } from "effect";
 import type { CmsError } from "@tom/types/errors";
 import type { CmsMedia, CmsPost, CmsWork, TiptapDoc } from "@tom/schemas/cms";
-import { renderTiptapHtml } from "@tom/utils/tiptap-html";
 import { Button } from "@tom/ui/tomui/button";
 import { Input } from "@tom/ui/tomui/input";
 import { InputGroup } from "@tom/ui/tomui/input-group";
@@ -145,7 +144,6 @@ const EditorBody = (props: { kind: ContentKind; initial: InitialData; onExit: ()
   >([]);
   const [savedSlug, setSavedSlug] = createSignal<string | null>(props.initial.slug);
   const [saveState, setSaveState] = createSignal<SaveState>({ status: "idle" });
-  const [showPreview, setShowPreview] = createSignal(false);
   const [showHistory, setShowHistory] = createSignal(false);
   /** Current history reload; revoked to noop when the panel unmounts. */
   type HistoryReload = { current: () => void };
@@ -165,28 +163,11 @@ const EditorBody = (props: { kind: ContentKind; initial: InitialData; onExit: ()
     element = current;
   };
   const mediaUrl = (mediaId: string): string => mediaFileUrl(adapterUrl(), mediaId);
-  const [previewHtml, setPreviewHtml] = createSignal("");
-
-  /** Render preview HTML; stale results lose to newer docs by identity. */
-  const renderPreview = (doc: TiptapDoc): void => {
-    void runClient(
-      renderTiptapHtml(doc, mediaUrl).pipe(
-        Effect.tap((html) =>
-          Effect.sync(() => {
-            if (handle.doc() === doc) setPreviewHtml(html);
-          }),
-        ),
-      ),
-    );
-  };
 
   const handle = createTiptap({
     element: () => element,
     initialDoc: () => props.initial.doc,
     mediaUrl,
-    onDoc: (doc) => {
-      if (showPreview()) renderPreview(doc);
-    },
   });
 
   onSettled(() => {
@@ -333,15 +314,6 @@ const EditorBody = (props: { kind: ContentKind; initial: InitialData; onExit: ()
     return state.status === "error" ? state.message : undefined;
   });
 
-  const togglePreview = (): void => {
-    const next = !showPreview();
-    setShowPreview(next);
-    if (next) {
-      const doc = handle.doc();
-      if (doc) renderPreview(doc);
-    }
-  };
-
   const codeActive = createMemo(() => {
     handle.version();
     return handle.editor()?.isActive("codeBlock") ?? false;
@@ -373,252 +345,252 @@ const EditorBody = (props: { kind: ContentKind; initial: InitialData; onExit: ()
           <Show when={saveState().status === "saved"}>
             <Badge variant="success">Saved</Badge>
           </Show>
-          <Show when={saveError()}>
-            {(message) => <Banner variant="error" description={message()} />}
-          </Show>
-          <Button
-            type="button"
-            size="sm"
-            variant="primary"
-            loading={saveState().status === "saving"}
-            onClick={onSave}
-          >
-            {savedSlug() === null ? "Create" : "Save"}
-          </Button>
-          <Show when={savedSlug() !== null}>
-            <Button type="button" size="sm" variant="secondary-destructive" onClick={onDelete}>
-              Delete
-            </Button>
+        </div>
+      </div>
+      <div class="editor-layout">
+        <aside class="editor-sidebar">
+          <div class="editor-actions">
             <Button
               type="button"
               size="sm"
-              variant="outline"
-              onClick={() => setShowHistory(!showHistory())}
+              variant="primary"
+              loading={saveState().status === "saving"}
+              onClick={onSave}
             >
-              {showHistory() ? "Hide history" : "History"}
+              {savedSlug() === null ? "Create" : "Save"}
             </Button>
-          </Show>
-        </div>
-      </div>
-      <Show when={showHistory() ? savedSlug() : null}>
-        {(slug) => (
-          <HistoryPanel
-            kind={props.kind}
-            slug={slug()}
-            onRestored={onRestored}
-            onReload={(reload) => {
-              historyReload.current = reload;
-            }}
-          />
-        )}
-      </Show>
-
-      <div class="editor-fields">
-        <label class="field">
-          Title
-          <Input
-            type="text"
-            value={fields().title}
-            onInput={(event) => setField("title", event.currentTarget.value)}
-          />
-        </label>
-        <label class="field">
-          Slug
-          <InputGroup>
-            <InputGroup.Input
-              type="text"
-              value={fields().slug}
-              onInput={(event) => setField("slug", event.currentTarget.value)}
-            />
-            <InputGroup.Button
-              type="button"
-              onClick={() => setField("slug", slugify(fields().title))}
-            >
-              Use title
-            </InputGroup.Button>
-          </InputGroup>
-        </label>
-        <label class="field">
-          Summary
-          <textarea
-            value={fields().summary}
-            onInput={(event) => setField("summary", event.currentTarget.value)}
-          />
-        </label>
-        <label class="field">
-          Status
-          <Select
-            value={fields().status}
-            options={[
-              { label: "Draft", value: "draft" },
-              { label: "Published", value: "published" },
-            ]}
-            onChange={(value) => setStatus(value)}
-          />
-        </label>
-        <label class="field">
-          Published at
-          <Input
-            type="datetime-local"
-            placeholder="YYYY-MM-DD HH:MM"
-            value={fields().publishedAt.slice(0, 16)}
-            onInput={(event) => setField("publishedAt", event.currentTarget.value)}
-          />
-        </label>
-      </div>
-
-      <Show when={props.kind === "posts"}>
-        <div class="my-4">
-          <Collapsible>
-            <Collapsible.DefaultTrigger>
-              Categories
-              {selectedCategories().length > 0 ? ` (${selectedCategories().length})` : ""}
-            </Collapsible.DefaultTrigger>
-            <Collapsible.DefaultPanel>
-              <Show
-                when={allCategories().length > 0}
-                fallback={<p class="text-sm text-tomui-subtle">No categories yet.</p>}
+            <Show when={savedSlug() !== null}>
+              <Button type="button" size="sm" variant="secondary-destructive" onClick={onDelete}>
+                Delete
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setShowHistory(!showHistory())}
               >
-                <For each={allCategories()}>
-                  {(category) => (
-                    <label class="check">
-                      <input
-                        type="checkbox"
-                        checked={selectedCategories().includes(category.id)}
-                        onChange={() => toggleCategory(category.id)}
-                      />
-                      {category.title}
-                    </label>
-                  )}
-                </For>
-              </Show>
-            </Collapsible.DefaultPanel>
-          </Collapsible>
-        </div>
-      </Show>
-
-      <Toolbar
-        editor={handle.editor}
-        version={handle.version}
-        activePanel={panel()}
-        onTogglePanel={(item) => openPanel(panel() === item ? "none" : item)}
-      />
-      <div ref={setElement} class="tiptap-editor" />
-
-      <div class="editor-panels">
-        <Show when={panelError()}>
-          {(message) => <Banner variant="error" description={message()} />}
-        </Show>
-        <Show when={panel() === "link"}>
-          <div class="panel">
-            <label class="field">
-              URL
-              <Input
-                type="text"
-                value={linkUrl()}
-                onInput={(event) => setLinkUrl(event.currentTarget.value)}
-              />
-            </label>
-            <Button type="button" size="sm" variant="secondary" onClick={onApplyLink}>
-              Apply
-            </Button>
+                {showHistory() ? "Hide history" : "History"}
+              </Button>
+            </Show>
+            <Show when={saveError()}>
+              {(message) => <Banner variant="error" description={message()} />}
+            </Show>
           </div>
-        </Show>
-        <Show when={panel() === "arena"}>
-          <div class="panel">
-            <label class="field">
-              Channel slug
-              <Input
-                type="text"
-                value={arenaSlug()}
-                onInput={(event) => setArenaSlug(event.currentTarget.value)}
-              />
-            </label>
-            <label class="field">
-              Title (optional)
-              <Input
-                type="text"
-                value={arenaTitle()}
-                onInput={(event) => setArenaTitle(event.currentTarget.value)}
-              />
-            </label>
-            <Button type="button" size="sm" variant="secondary" onClick={onInsertArena}>
-              Insert
-            </Button>
-          </div>
-        </Show>
-        <Show when={panel() === "media"}>
-          <div class="panel">
-            <label class="field">
-              File
-              <input
-                type="file"
-                accept="image/*,video/*"
-                onChange={(event) => setPickedFile(event.currentTarget.files?.[0])}
-              />
-            </label>
-            <label class="field">
-              Alt text
-              <Input
-                type="text"
-                value={mediaAlt()}
-                onInput={(event) => setMediaAlt(event.currentTarget.value)}
-              />
-            </label>
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              loading={uploading()}
-              disabled={pickedFile() === undefined || uploading()}
-              onClick={onUpload}
-            >
-              {uploading() ? "Uploading…" : "Upload and insert"}
-            </Button>
-            <MediaPicker onPick={onPickMedia} />
-          </div>
-        </Show>
-        <Show when={codeActive()}>
-          <div class="panel">
-            <label class="field">
-              File name
-              <Input
-                type="text"
-                value={codeAttrs()?.fileName ?? ""}
-                onInput={(event) => {
-                  setCodeOptions(handle.editor(), {
-                    language: codeAttrs()?.language ?? "",
-                    fileName:
-                      event.currentTarget.value === "" ? undefined : event.currentTarget.value,
-                    showLineNumbers: codeAttrs()?.showLineNumbers ?? false,
-                  });
+          <Show when={showHistory() ? savedSlug() : null}>
+            {(slug) => (
+              <HistoryPanel
+                kind={props.kind}
+                slug={slug()}
+                onRestored={onRestored}
+                onReload={(reload) => {
+                  historyReload.current = reload;
                 }}
               />
-            </label>
-            <label class="check">
-              <input
-                type="checkbox"
-                checked={codeAttrs()?.showLineNumbers ?? false}
-                onChange={(event) => {
-                  setCodeOptions(handle.editor(), {
-                    language: codeAttrs()?.language ?? "",
-                    fileName: codeAttrs()?.fileName,
-                    showLineNumbers: event.currentTarget.checked,
-                  });
-                }}
+            )}
+          </Show>
+
+          <div class="editor-fields">
+            <label class="field">
+              Title
+              <Input
+                type="text"
+                value={fields().title}
+                onInput={(event) => setField("title", event.currentTarget.value)}
               />
-              Line numbers
+            </label>
+            <label class="field">
+              Slug
+              <InputGroup>
+                <InputGroup.Input
+                  type="text"
+                  value={fields().slug}
+                  onInput={(event) => setField("slug", event.currentTarget.value)}
+                />
+                <InputGroup.Button
+                  type="button"
+                  onClick={() => setField("slug", slugify(fields().title))}
+                >
+                  Use title
+                </InputGroup.Button>
+              </InputGroup>
+            </label>
+            <label class="field">
+              Summary
+              <textarea
+                value={fields().summary}
+                onInput={(event) => setField("summary", event.currentTarget.value)}
+              />
+            </label>
+            <label class="field">
+              Status
+              <Select
+                value={fields().status}
+                options={[
+                  { label: "Draft", value: "draft" },
+                  { label: "Published", value: "published" },
+                ]}
+                onChange={(value) => setStatus(value)}
+              />
+            </label>
+            <label class="field">
+              Published at
+              <Input
+                type="datetime-local"
+                placeholder="YYYY-MM-DD HH:MM"
+                value={fields().publishedAt.slice(0, 16)}
+                onInput={(event) => setField("publishedAt", event.currentTarget.value)}
+              />
             </label>
           </div>
-        </Show>
+
+          <Show when={props.kind === "posts"}>
+            <div class="editor-categories">
+              <Collapsible>
+                <Collapsible.DefaultTrigger>
+                  Categories
+                  {selectedCategories().length > 0 ? ` (${selectedCategories().length})` : ""}
+                </Collapsible.DefaultTrigger>
+                <Collapsible.DefaultPanel>
+                  <Show
+                    when={allCategories().length > 0}
+                    fallback={<p class="text-sm text-tomui-subtle">No categories yet.</p>}
+                  >
+                    <For each={allCategories()}>
+                      {(category) => (
+                        <label class="check">
+                          <input
+                            type="checkbox"
+                            checked={selectedCategories().includes(category.id)}
+                            onChange={() => toggleCategory(category.id)}
+                          />
+                          {category.title}
+                        </label>
+                      )}
+                    </For>
+                  </Show>
+                </Collapsible.DefaultPanel>
+              </Collapsible>
+            </div>
+          </Show>
+        </aside>
+        <section class="editor-main">
+          <Toolbar
+            editor={handle.editor}
+            version={handle.version}
+            activePanel={panel()}
+            onTogglePanel={(item) => openPanel(panel() === item ? "none" : item)}
+          />
+          <div ref={setElement} class="tiptap-editor" />
+
+          <div class="editor-panels">
+            <Show when={panelError()}>
+              {(message) => <Banner variant="error" description={message()} />}
+            </Show>
+            <Show when={panel() === "link"}>
+              <div class="panel">
+                <label class="field">
+                  URL
+                  <Input
+                    type="text"
+                    value={linkUrl()}
+                    onInput={(event) => setLinkUrl(event.currentTarget.value)}
+                  />
+                </label>
+                <Button type="button" size="sm" variant="secondary" onClick={onApplyLink}>
+                  Apply
+                </Button>
+              </div>
+            </Show>
+            <Show when={panel() === "arena"}>
+              <div class="panel">
+                <label class="field">
+                  Channel slug
+                  <Input
+                    type="text"
+                    value={arenaSlug()}
+                    onInput={(event) => setArenaSlug(event.currentTarget.value)}
+                  />
+                </label>
+                <label class="field">
+                  Title (optional)
+                  <Input
+                    type="text"
+                    value={arenaTitle()}
+                    onInput={(event) => setArenaTitle(event.currentTarget.value)}
+                  />
+                </label>
+                <Button type="button" size="sm" variant="secondary" onClick={onInsertArena}>
+                  Insert
+                </Button>
+              </div>
+            </Show>
+            <Show when={panel() === "media"}>
+              <div class="panel">
+                <label class="field">
+                  File
+                  <input
+                    type="file"
+                    accept="image/*,video/*"
+                    onChange={(event) => setPickedFile(event.currentTarget.files?.[0])}
+                  />
+                </label>
+                <label class="field">
+                  Alt text
+                  <Input
+                    type="text"
+                    value={mediaAlt()}
+                    onInput={(event) => setMediaAlt(event.currentTarget.value)}
+                  />
+                </label>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  loading={uploading()}
+                  disabled={pickedFile() === undefined || uploading()}
+                  onClick={onUpload}
+                >
+                  {uploading() ? "Uploading…" : "Upload and insert"}
+                </Button>
+                <MediaPicker onPick={onPickMedia} />
+              </div>
+            </Show>
+            <Show when={codeActive()}>
+              <div class="panel">
+                <label class="field">
+                  File name
+                  <Input
+                    type="text"
+                    value={codeAttrs()?.fileName ?? ""}
+                    onInput={(event) => {
+                      setCodeOptions(handle.editor(), {
+                        language: codeAttrs()?.language ?? "",
+                        fileName:
+                          event.currentTarget.value === "" ? undefined : event.currentTarget.value,
+                        showLineNumbers: codeAttrs()?.showLineNumbers ?? false,
+                      });
+                    }}
+                  />
+                </label>
+                <label class="check">
+                  <input
+                    type="checkbox"
+                    checked={codeAttrs()?.showLineNumbers ?? false}
+                    onChange={(event) => {
+                      setCodeOptions(handle.editor(), {
+                        language: codeAttrs()?.language ?? "",
+                        fileName: codeAttrs()?.fileName,
+                        showLineNumbers: event.currentTarget.checked,
+                      });
+                    }}
+                  />
+                  Line numbers
+                </label>
+              </div>
+            </Show>
+          </div>
+        </section>
       </div>
-
-      <Button type="button" size="sm" variant="ghost" onClick={togglePreview}>
-        {showPreview() ? "Hide preview" : "Show preview"}
-      </Button>
-      <Show when={showPreview()}>
-        <div class="preview" innerHTML={previewHtml()} />
-      </Show>
     </div>
   );
 };

--- a/apps/editor/src/components/MediaView.tsx
+++ b/apps/editor/src/components/MediaView.tsx
@@ -117,69 +117,77 @@ export const MediaView = (props: { onEdit: (kind: ContentKind, slug: string) => 
 
   return (
     <div class="media-view">
-      <label class="field">
-        Search media
-        <Input
-          type="text"
-          value={query()}
-          placeholder="Filter by filename"
-          onInput={(event) => setQuery(event.currentTarget.value)}
-        />
-      </label>
-      <Show when={error()}>{(message) => <Banner variant="error" description={message()} />}</Show>
-      <Show
-        when={visible().length > 0}
-        fallback={<p class="history-empty">No media yet — upload from a post or work.</p>}
-      >
-        <div class="media-grid">
-          <For each={visible()}>
-            {(item) => (
-              <div class="media-card">
-                <Show
-                  when={item.mime.startsWith("video/")}
-                  fallback={
-                    <img
-                      class="media-thumb"
-                      src={mediaFileUrl(adapterUrl(), item.id)}
-                      alt={item.alt ?? ""}
-                      loading="lazy"
-                    />
-                  }
-                >
-                  <video
-                    class="media-thumb"
-                    src={mediaFileUrl(adapterUrl(), item.id)}
-                    muted
-                    preload="metadata"
-                  />
-                </Show>
-                <p class="media-name">{mediaFileName(item.key)}</p>
-                <div class="media-actions">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => toggleUsage(item.id)}
-                  >
-                    {openUsage() === item.id ? "Hide usage" : "Usage"}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary-destructive"
-                    onClick={() => onDelete(item)}
-                  >
-                    Delete
-                  </Button>
-                </div>
-                <Show when={openUsage() === item.id}>
-                  <UsageList usage={usage()[item.id]} onEdit={props.onEdit} />
-                </Show>
-              </div>
-            )}
-          </For>
-        </div>
-      </Show>
+      <div class="media-layout">
+        <aside class="media-sidebar">
+          <label class="field">
+            Search media
+            <Input
+              type="text"
+              value={query()}
+              placeholder="Filter by filename"
+              onInput={(event) => setQuery(event.currentTarget.value)}
+            />
+          </label>
+          <Show when={error()}>
+            {(message) => <Banner variant="error" description={message()} />}
+          </Show>
+        </aside>
+        <section class="media-results">
+          <Show
+            when={visible().length > 0}
+            fallback={<p class="history-empty">No media yet — upload from a post or work.</p>}
+          >
+            <div class="media-grid">
+              <For each={visible()}>
+                {(item) => (
+                  <div class="media-card">
+                    <Show
+                      when={item.mime.startsWith("video/")}
+                      fallback={
+                        <img
+                          class="media-thumb"
+                          src={mediaFileUrl(adapterUrl(), item.id)}
+                          alt={item.alt ?? ""}
+                          loading="lazy"
+                        />
+                      }
+                    >
+                      <video
+                        class="media-thumb"
+                        src={mediaFileUrl(adapterUrl(), item.id)}
+                        muted
+                        preload="metadata"
+                      />
+                    </Show>
+                    <p class="media-name">{mediaFileName(item.key)}</p>
+                    <div class="media-actions">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => toggleUsage(item.id)}
+                      >
+                        {openUsage() === item.id ? "Hide usage" : "Usage"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary-destructive"
+                        onClick={() => onDelete(item)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                    <Show when={openUsage() === item.id}>
+                      <UsageList usage={usage()[item.id]} onEdit={props.onEdit} />
+                    </Show>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </section>
+      </div>
     </div>
   );
 };

--- a/apps/editor/src/components/Toolbar.tsx
+++ b/apps/editor/src/components/Toolbar.tsx
@@ -91,7 +91,7 @@ export const EditorToolbar = (props: {
     `min-h-10 shrink-0${active ? " bg-tomui-fill font-medium" : ""}`;
 
   return (
-    <div class="flex flex-wrap items-center gap-2">
+    <div class="editor-toolbar flex flex-wrap items-center gap-2">
       <Toolbar aria-label="Formatting" class="min-w-0 max-w-full overflow-x-auto">
         <Toolbar.Button
           aria-pressed={boldActive() ? "true" : "false"}

--- a/apps/editor/src/components/__tests__/CategoriesView.test.tsx
+++ b/apps/editor/src/components/__tests__/CategoriesView.test.tsx
@@ -30,11 +30,8 @@ describe("CategoriesView", () => {
       .mockResolvedValueOnce(
         jsonResponse([...categories, { id: "cat-2", slug: "notes", title: "Notes" }]),
       );
-    const { findByLabelText, findByRole, findByText } = render(() => (
-      <CategoriesView onBack={() => undefined} />
-    ));
+    const { findByLabelText, findByRole, findByText } = render(() => <CategoriesView />);
     expect(await findByText("Essays · essays")).toBeInTheDocument();
-    expect(await findByRole("button", { name: "← Back" })).toBeInTheDocument();
     fireEvent.input(await findByLabelText("Slug"), { target: { value: "notes" } });
     fireEvent.input(await findByLabelText("Title"), { target: { value: "Notes" } });
     fireEvent.click(await findByRole("button", { name: "Add category" }));
@@ -45,7 +42,7 @@ describe("CategoriesView", () => {
 
   it("shows validation errors without saving", async () => {
     fetchMock.mockResolvedValue(jsonResponse(categories));
-    const { findByRole, findByText } = render(() => <CategoriesView onBack={() => undefined} />);
+    const { findByRole, findByText } = render(() => <CategoriesView />);
     await findByText("Essays · essays");
     fireEvent.click(await findByRole("button", { name: "Add category" }));
     expect(await findByText("Invalid category data")).toBeInTheDocument();
@@ -58,7 +55,7 @@ describe("CategoriesView", () => {
       .mockResolvedValueOnce(jsonResponse({ id: "cat-1" }))
       .mockResolvedValueOnce(jsonResponse([]));
     vi.spyOn(window, "confirm").mockReturnValue(true);
-    const { findByRole } = render(() => <CategoriesView onBack={() => undefined} />);
+    const { findByRole } = render(() => <CategoriesView />);
     fireEvent.click(await findByRole("button", { name: "Delete category essays" }));
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
     const [deleteUrl, deleteInit] = fetchMock.mock.calls[1] as [string, RequestInit];

--- a/apps/editor/src/components/__tests__/EditorView.test.tsx
+++ b/apps/editor/src/components/__tests__/EditorView.test.tsx
@@ -281,10 +281,11 @@ describe("EditorView", () => {
       fireEvent.click(await findByRole("button", { name: "Arena" }));
       fireEvent.input(await findByLabelText("Channel slug"), { target: { value: "toms-place" } });
       fireEvent.click(await findByRole("button", { name: "Insert" }));
-      fireEvent.click(await findByRole("button", { name: "Show preview" }));
       await vi.waitFor(() => {
-        const preview = container.querySelector(".preview") as HTMLElement | null;
-        expect(preview?.innerHTML).toContain(`data-arena="toms-place"`);
+        const node = container.querySelector(
+          '.tiptap-editor div[data-arena="toms-place"]',
+        ) as HTMLElement | null;
+        expect(node).not.toBeNull();
       });
     });
 

--- a/apps/editor/src/index.css
+++ b/apps/editor/src/index.css
@@ -16,7 +16,7 @@
 
 @layer components {
   .editor-shell {
-    @apply mx-auto max-w-3xl px-4 py-8 font-sans;
+    @apply mx-auto max-w-3xl px-4 pb-8 font-sans;
   }
 
   .signin-view {
@@ -28,7 +28,7 @@
   }
 
   .editor-nav {
-    @apply sticky top-0 z-30 -mx-4 mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-neutral-300 bg-white px-4 pb-4 dark:border-neutral-700 dark:bg-neutral-950;
+    @apply sticky top-0 z-30 -mx-4 mb-6 flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-neutral-300 bg-white px-4 pt-4 pb-4 dark:border-neutral-700 dark:bg-neutral-950;
   }
 
   .editor-title {
@@ -72,8 +72,70 @@
     @apply mb-4 flex flex-wrap items-center gap-2;
   }
 
+  .editor-layout {
+    @apply grid gap-4;
+  }
+
+  .editor-sidebar {
+    @apply grid content-start gap-4;
+  }
+
+  .editor-actions {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  .editor-categories {
+    @apply grid gap-2;
+  }
+
+  .editor-main {
+    @apply grid min-w-0 content-start;
+  }
+
+  @media (min-width: 1024px) {
+    .editor-shell-wide {
+      max-width: none;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+    }
+
+    .editor-shell-wide .editor-nav,
+    .editor-shell-wide .content-list-header {
+      margin-left: -1.5rem;
+      margin-right: -1.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+    }
+
+    .editor-layout {
+      grid-template-columns: 340px minmax(0, 1fr);
+      gap: 2rem;
+      align-items: start;
+    }
+
+    .editor-sidebar {
+      position: sticky;
+      top: calc(var(--editor-nav-h, 0px) + 16px);
+    }
+
+    .editor-main .tiptap-editor {
+      min-height: 60vh;
+    }
+
+    .editor-toolbar [data-tomui-component="Toolbar"] {
+      display: flex;
+      width: 100%;
+      max-width: none;
+    }
+
+    .editor-toolbar [data-tomui-component="Toolbar.Button"] {
+      flex: 1 1 auto;
+      justify-content: center;
+    }
+  }
+
   .editor-fields {
-    @apply mb-4 grid gap-3;
+    @apply grid gap-3;
   }
 
   .field {
@@ -94,13 +156,19 @@
     @apply min-h-64 rounded-b-lg border border-neutral-300 p-3 focus:outline-2 focus:outline-neutral-800 dark:border-neutral-700 dark:focus:outline-neutral-200;
   }
 
-  /* Canvas typography mirrors the preview scale so headings read as headings. */
+  /* Canvas typography matches the site scale so the editor reads as the page. */
+  .tiptap-editor p {
+    @apply pb-4 tracking-tight;
+  }
+
   .tiptap-editor h1 {
-    @apply pb-2 text-3xl font-medium tracking-tight;
+    @apply pb-2 text-4xl font-medium tracking-tight;
   }
 
   .tiptap-editor h2 {
-    @apply pb-2 text-2xl tracking-tight;
+    @apply pb-2 tracking-tight;
+    font-size: 1.75rem;
+    font-weight: 400;
   }
 
   .tiptap-editor h3 {
@@ -132,8 +200,25 @@
 
   /* CMS banners mirror the site's banner idiom (hairline + badge).
      The canvas carries no badge element (it would parse back into content),
-     so its label renders through ::before; preview has the real badge. */
-  .tiptap-editor .banner,
+     so its label renders through ::before; history preview has the real badge. */
+  .tiptap-editor .banner {
+    position: relative;
+    line-height: 1.5;
+    margin-top: 1rem;
+    margin-bottom: 0;
+    width: 100%;
+    border-width: 0 0 1px 0;
+    border-style: solid;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 1rem;
+    color: rgb(0 0 0);
+    border-color: rgb(209 213 219);
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
   .preview .banner {
     position: relative;
     line-height: 1.5;
@@ -191,12 +276,81 @@
     }
   }
 
+  /* Media figures match the site: rounded image, centered caption. */
+  .tiptap-editor figure {
+    @apply my-4;
+  }
+
+  .tiptap-editor img {
+    @apply rounded-md;
+  }
+
+  .tiptap-editor figcaption {
+    @apply mt-2 text-center text-sm text-neutral-500 dark:text-neutral-400;
+  }
+
+  /* Arena embeds render as carousels on the site; the canvas shows a
+     labeled placeholder at the same position in the flow. */
+  .tiptap-editor [data-arena]::after {
+    content: "Arena / " attr(data-arena);
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+    color: rgb(107 114 128);
+  }
+
   .tiptap-editor [data-arena],
   .tiptap-editor figure[data-media-id] {
     @apply my-2 border border-dashed border-neutral-400 p-2 dark:border-neutral-600;
   }
 
-  .tiptap-editor pre,
+  /* Code in the canvas matches the site code-block treatment. Shiki
+     highlighting runs at save time; the canvas shows plain mono text with
+     the same spacing, filename bar, and dark treatment. */
+  .tiptap-editor pre {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    tab-size: 2;
+    background-color: rgb(24 24 27);
+    color: rgb(244 244 245);
+  }
+
+  .tiptap-editor pre code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .tiptap-editor pre[data-filename]::before {
+    content: attr(data-filename);
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    padding: 0.5rem 1rem;
+    margin: -1rem -1rem 1rem;
+    background-color: rgb(243 244 246);
+    border-bottom: 1px solid rgb(229 231 235);
+    border-radius: 0.5rem 0.5rem 0 0;
+    color: rgb(75 85 99);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .tiptap-editor pre {
+      background-color: rgb(0 0 0);
+    }
+
+    .tiptap-editor pre[data-filename]::before {
+      background-color: rgb(31 41 55);
+      border-color: rgb(75 85 99);
+      color: rgb(156 163 175);
+    }
+  }
+
   .preview pre {
     @apply my-3 overflow-x-auto rounded-md bg-neutral-900 p-3 text-sm text-neutral-100 dark:bg-black;
   }
@@ -288,8 +442,71 @@
     @apply grid gap-4;
   }
 
+  .categories-layout {
+    @apply grid min-w-0 content-start gap-4;
+  }
+
+  .categories-list {
+    @apply grid min-w-0 content-start;
+  }
+
+  .categories-form {
+    @apply grid min-w-0 content-start;
+  }
+
+  @media (min-width: 1024px) {
+    .categories-layout {
+      grid-template-columns: 340px minmax(0, 1fr);
+      gap: 2rem;
+      align-items: start;
+    }
+
+    .categories-form {
+      grid-column: 1;
+      grid-row: 1;
+      position: sticky;
+      top: calc(var(--editor-nav-h, 0px) + 16px);
+    }
+
+    .categories-list {
+      grid-column: 2;
+      grid-row: 1;
+    }
+  }
+
   .media-view {
     @apply grid gap-4;
+  }
+
+  .media-layout {
+    @apply grid min-w-0 content-start gap-4;
+  }
+
+  .media-sidebar {
+    @apply grid min-w-0 content-start gap-4;
+  }
+
+  .media-results {
+    @apply grid min-w-0 content-start;
+  }
+
+  @media (min-width: 1024px) {
+    .media-layout {
+      grid-template-columns: 340px minmax(0, 1fr);
+      gap: 2rem;
+      align-items: start;
+    }
+
+    .media-sidebar {
+      position: sticky;
+      top: calc(var(--editor-nav-h, 0px) + 16px);
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .media-grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
   }
 
   .media-grid {
@@ -325,7 +542,7 @@
   }
 
   .history-panel {
-    @apply mb-4 grid gap-2 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800;
+    @apply grid gap-2 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800;
   }
 
   .history-rows {

--- a/apps/editor/src/lib/tiptap.ts
+++ b/apps/editor/src/lib/tiptap.ts
@@ -170,8 +170,6 @@ export const createTiptap = (options: {
   readonly element: () => HTMLElement | undefined;
   readonly initialDoc: () => TiptapDoc | undefined;
   readonly mediaUrl: (mediaId: string) => string;
-  /** Fires with the fresh doc on every transaction (preview rendering). */
-  readonly onDoc?: (doc: TiptapDoc) => void;
 }): TiptapHandle => {
   const [editor, setEditor] = createSignal<Editor | undefined>(undefined);
   const [version, setVersion] = createSignal(0);
@@ -192,7 +190,6 @@ export const createTiptap = (options: {
         // Read-then-set: the 2.0 beta drops notifications for updater fns.
         setVersion(version() + 1);
         setDirty(true);
-        options.onDoc?.(next);
       },
     });
     setEditor(instance);

--- a/apps/editor/src/test/setup.ts
+++ b/apps/editor/src/test/setup.ts
@@ -16,6 +16,18 @@ Object.defineProperty(window, "matchMedia", {
   }),
 });
 
+Object.defineProperty(window, "ResizeObserver", {
+  writable: true,
+  value: class {
+    constructor(callback: ResizeObserverCallback) {
+      void callback;
+    }
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  },
+});
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
Desktop-only CMS editor refresh, verified on dev-cms (https://dev-cms.tom.so).

- Edit view: full-width shell with 340px sticky sidebar (Save/Delete/History, fields, categories, history) and editor column on the right.
- Tiptap toolbar spans the editor column with evenly shared buttons on desktop.
- Categories view: full width, sticky entry form left, existing list right. Back button removed.
- Media view: full width, sticky search filter left, media grid right (4 columns past 1280px).
- Show/Hide preview toggle removed; the canvas mirrors frontend styles for banners, arena placeholders, media figures, and code blocks (incl. filename bar).
- Sticky navbar keeps its top gap; nav/section edges align in wide shell.
- Nav height measurement now tracks sign-in so all sticky offsets hold (previously never set).

Checks: editor typecheck, oxlint, oxfmt, 88 unit tests, and vite build pass. Live browser probe confirms sidebars stick below the navbar.