### PR TITLE
feat(poll): add Doodoo Dynamics Market Research Poll

### DIFF
--- a/apps/web/src/components/PollTrendChart.tsx
+++ b/apps/web/src/components/PollTrendChart.tsx
@@ -1,0 +1,82 @@
+import { Bollinger } from "@tom/ui/tomui/bollinger";
+import type { BollingerSeries } from "@tom/ui/tomui/bollinger";
+
+export interface PartySeries {
+  color: string;
+  name: string;
+  points: Array<number>;
+}
+
+interface PartySeed {
+  base: number;
+  color: string;
+  name: string;
+}
+
+export const POLL_MONTHS = [
+  "Sep 25",
+  "Oct 25",
+  "Nov 25",
+  "Dec 25",
+  "Jan 26",
+  "Feb 26",
+  "Mar 26",
+  "Apr 26",
+  "May 26",
+  "Jun 26",
+  "Jul 26",
+  "Aug 26",
+  "Sep 26",
+];
+
+const PARTIES: Array<PartySeed> = [
+  { base: 31, color: "#0A4DA6", name: "National" },
+  { base: 28, color: "#D62027", name: "Labour" },
+  { base: 10, color: "#2E9E4A", name: "Green" },
+  { base: 9, color: "#3F3F46", name: "NZ First" },
+  { base: 7, color: "#EAB308", name: "ACT" },
+  { base: 2.5, color: "#881337", name: "Te Pāti Māori" },
+];
+
+function walkFrom(start: number, months: number): Array<number> {
+  return Array.from({ length: months }, () => 0).reduce<Array<number>>(
+    (points, _, month) =>
+      month === 0
+        ? [start]
+        : [...points, Math.max(0.5, (points[month - 1] ?? start) + (Math.random() - 0.5) * 4)],
+    [],
+  );
+}
+
+export function generatePartyHistory(): Array<PartySeries> {
+  const walks = PARTIES.map((party) => ({
+    color: party.color,
+    name: party.name,
+    points: walkFrom(party.base, POLL_MONTHS.length),
+  }));
+  const totals = POLL_MONTHS.map((_, month) =>
+    walks.reduce((sum, walk) => sum + (walk.points[month] ?? 0), 0),
+  );
+  return walks.map((walk) => ({
+    color: walk.color,
+    name: walk.name,
+    points: walk.points.map((value, month) => (value / (totals[month] ?? 1)) * 100),
+  }));
+}
+
+export function PollTrendChart(props: { history: Array<PartySeries> }) {
+  const series = (): Array<BollingerSeries> =>
+    props.history.map((entry) => ({
+      color: entry.color,
+      label: entry.name,
+      values: entry.points,
+    }));
+  return (
+    <Bollinger
+      series={series()}
+      labels={POLL_MONTHS}
+      ariaLabel="Decided party vote over time with Bollinger bands"
+      caption="Decided party vote over time, with five-poll Bollinger bands (rolling mean ± two standard deviations)."
+    />
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,6 +6,7 @@ import About from "~/routes/about";
 import Accessibility from "~/routes/accessibility";
 import Guestbook, { fetchEntries } from "~/routes/guestbook";
 import Home from "~/routes/index";
+import Poll from "~/routes/poll";
 import PostPage from "~/routes/posts/[slug]";
 import PostsHome from "~/routes/posts/index";
 import Products from "~/routes/products";
@@ -88,6 +89,7 @@ export const Router = createRouter({
     { path: "/work/wwwork/hold", component: Hold },
     { path: "/work/wwwork/kawara", component: Kawara },
     { path: "/products", component: Products },
+    { path: "/poll", component: Poll },
     { path: "/purchase/:productId", component: Purchase },
     { path: "/worktable", component: Worktable },
     { path: "*404", component: NotFound },

--- a/apps/web/src/routes/__tests__/poll.test.tsx
+++ b/apps/web/src/routes/__tests__/poll.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import Poll, { allocateSeats } from "~/routes/poll";
+import { bollinger } from "@tom/ui/tomui/bollinger";
+import { generatePartyHistory } from "~/components/PollTrendChart";
+
+const PARTY_NAMES = ["National", "Labour", "Green", "NZ First", "ACT", "Te Pāti Māori"];
+
+const supportTable = () => screen.getByRole("table", { name: "Party support" });
+const seatsTable = () => screen.getByRole("table", { name: "Projected seats" });
+
+const columnValues = (table: HTMLElement, column: number): Array<number> =>
+  within(table)
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => {
+      const cells = within(row).getAllByRole("cell");
+      return Number(/([\d.]+)/.exec(cells[column]?.textContent ?? "")?.[1] ?? Number.NaN);
+    });
+
+describe("poll math", () => {
+  it("allocates all seats proportionally", () => {
+    expect(allocateSeats([50, 30, 20], 120)).toEqual([60, 36, 24]);
+  });
+
+  it("holds flat bands steady", () => {
+    const band = bollinger([10, 10, 10, 10, 10], 5, 2);
+    expect(band).toHaveLength(5);
+    for (const point of band) {
+      expect(point).toEqual({ lower: 10, mid: 10, upper: 10 });
+    }
+  });
+
+  it("normalizes every month to 100 percent", () => {
+    const history = generatePartyHistory();
+    expect(history).toHaveLength(6);
+    const months = history[0]?.points.length ?? 0;
+    expect(months).toBeGreaterThan(0);
+    Array.from({ length: months }).forEach((_, month) => {
+      const total = history.reduce((sum, entry) => sum + (entry.points[month] ?? 0), 0);
+      expect(total).toBeCloseTo(100, 5);
+    });
+  });
+});
+
+describe("poll page", () => {
+  it("renders a support row for every party", async () => {
+    render(() => <Poll />);
+    await waitFor(() => {
+      for (const name of PARTY_NAMES) {
+        expect(within(supportTable()).getByText(name)).toBeTruthy();
+      }
+    });
+    expect(screen.getByText("Media summary statement", { selector: "h2" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Spin it again" })).toBeTruthy();
+  });
+
+  it("splits 100 percent of support and 120 seats", async () => {
+    render(() => <Poll />);
+    await waitFor(() => expect(within(supportTable()).getAllByRole("row")).toHaveLength(7));
+    const support = columnValues(supportTable(), 1).reduce((sum, value) => sum + value, 0);
+    expect(support).toBeCloseTo(100, 0);
+    const seats = columnValues(seatsTable(), 1).reduce((sum, value) => sum + value, 0);
+    expect(seats).toBe(120);
+  });
+
+  it("spins new numbers on request", async () => {
+    render(() => <Poll />);
+    await waitFor(() => expect(within(supportTable()).getAllByRole("row")).toHaveLength(7));
+    const before = columnValues(supportTable(), 1).join();
+    fireEvent.click(screen.getByRole("button", { name: "Spin it again" }));
+    await waitFor(() => expect(columnValues(supportTable(), 1).join()).not.toBe(before));
+  });
+});

--- a/apps/web/src/routes/__tests__/poll.test.tsx
+++ b/apps/web/src/routes/__tests__/poll.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
-import Poll, { allocateSeats } from "~/routes/poll";
+import Poll, { allocateSeats, generateMethodology } from "~/routes/poll";
 import { bollinger } from "@tom/ui/tomui/bollinger";
 import { generatePartyHistory } from "~/components/PollTrendChart";
 
@@ -45,6 +45,16 @@ describe("poll math", () => {
       const total = history.reduce((sum, entry) => sum + (entry.points[month] ?? 0), 0);
       expect(total).toBeCloseTo(100, 5);
     });
+  });
+
+  it("keeps the methodology sample internally consistent", () => {
+    const method = generateMethodology();
+    expect(method.phone + method.online).toBe(method.sample);
+    const undecidedCount = Math.round((method.sample * method.undecided) / 100);
+    const refusedCount = Math.round((method.sample * method.refused) / 100);
+    expect(method.decided + undecidedCount + refusedCount).toBe(method.sample);
+    expect(method.moe).toBeGreaterThan(2.9);
+    expect(method.moe).toBeLessThan(3.3);
   });
 });
 

--- a/apps/web/src/routes/__tests__/poll.test.tsx
+++ b/apps/web/src/routes/__tests__/poll.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import Poll, { allocateSeats } from "~/routes/poll";
 import { bollinger } from "@tom/ui/tomui/bollinger";
@@ -17,6 +17,11 @@ const columnValues = (table: HTMLElement, column: number): Array<number> =>
       const cells = within(row).getAllByRole("cell");
       return Number(/([\d.]+)/.exec(cells[column]?.textContent ?? "")?.[1] ?? Number.NaN);
     });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe("poll math", () => {
   it("allocates all seats proportionally", () => {
@@ -70,5 +75,17 @@ describe("poll page", () => {
     const before = columnValues(supportTable(), 1).join();
     fireEvent.click(screen.getByRole("button", { name: "Spin it again" }));
     await waitFor(() => expect(columnValues(supportTable(), 1).join()).not.toBe(before));
+  });
+
+  it("flashes changed values after a spin, then fades", async () => {
+    const view = render(() => <Poll />);
+    await waitFor(() => expect(within(supportTable()).getAllByRole("row")).toHaveLength(7));
+    expect(view.container.querySelector(".poll-flash")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Spin it again" }));
+    await waitFor(() =>
+      expect(view.container.querySelectorAll(".poll-flash").length).toBeGreaterThan(0),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 2200));
+    expect(view.container.querySelector(".poll-flash")).toBeNull();
   });
 });

--- a/apps/web/src/routes/__tests__/poll.test.tsx
+++ b/apps/web/src/routes/__tests__/poll.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import Poll, { allocateSeats, generateMethodology } from "~/routes/poll";
-import { bollinger } from "@tom/ui/tomui/bollinger";
+import { computeBollingerBands } from "@tom/ui/tomui/bollinger";
 import { generatePartyHistory } from "~/components/PollTrendChart";
 
 const PARTY_NAMES = ["National", "Labour", "Green", "NZ First", "ACT", "Te Pāti Māori"];
@@ -28,8 +28,12 @@ describe("poll math", () => {
     expect(allocateSeats([50, 30, 20], 120)).toEqual([60, 36, 24]);
   });
 
+  it("awards leftover seats by largest remainder, not largest party", () => {
+    expect(allocateSeats([34.4, 33.3, 32.3], 120)).toEqual([41, 40, 39]);
+  });
+
   it("holds flat bands steady", () => {
-    const band = bollinger([10, 10, 10, 10, 10], 5, 2);
+    const band = computeBollingerBands([10, 10, 10, 10, 10], 5, 2);
     expect(band).toHaveLength(5);
     for (const point of band) {
       expect(point).toEqual({ lower: 10, mid: 10, upper: 10 });
@@ -49,10 +53,19 @@ describe("poll math", () => {
 
   it("keeps the methodology sample internally consistent", () => {
     const method = generateMethodology();
+    expect(method.sample).toBeGreaterThanOrEqual(980);
+    expect(method.sample).toBeLessThanOrEqual(1020);
     expect(method.phone + method.online).toBe(method.sample);
+    expect(method.phone / method.sample).toBeGreaterThan(0.6);
+    expect(method.phone / method.sample).toBeLessThan(0.8);
     const undecidedCount = Math.round((method.sample * method.undecided) / 100);
     const refusedCount = Math.round((method.sample * method.refused) / 100);
     expect(method.decided + undecidedCount + refusedCount).toBe(method.sample);
+    expect(method.decided).toBeGreaterThan(method.sample * 0.9);
+    expect(method.undecided).toBeGreaterThanOrEqual(1.8);
+    expect(method.undecided).toBeLessThanOrEqual(2.6);
+    expect(method.refused).toBeGreaterThanOrEqual(1);
+    expect(method.refused).toBeLessThanOrEqual(1.6);
     expect(method.moe).toBeGreaterThan(2.9);
     expect(method.moe).toBeLessThan(3.3);
   });
@@ -80,11 +93,29 @@ describe("poll page", () => {
   });
 
   it("spins new numbers on request", async () => {
+    let draws = 0;
+    vi.spyOn(Math, "random").mockImplementation(() => {
+      draws += 1;
+      return (draws * 0.13) % 1;
+    });
     render(() => <Poll />);
     await waitFor(() => expect(within(supportTable()).getAllByRole("row")).toHaveLength(7));
     const before = columnValues(supportTable(), 1).join();
     fireEvent.click(screen.getByRole("button", { name: "Spin it again" }));
     await waitFor(() => expect(columnValues(supportTable(), 1).join()).not.toBe(before));
+  });
+
+  it("shows integer seat swings and the refused figure", async () => {
+    render(() => <Poll />);
+    await waitFor(() => expect(within(seatsTable()).getAllByRole("row")).toHaveLength(7));
+    const swings = within(seatsTable())
+      .getAllByRole("row")
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[2]?.textContent ?? "");
+    for (const swing of swings) {
+      expect(swing).toMatch(/^(NC|↑\d+|↓\d+)$/);
+    }
+    expect(screen.getAllByText(/refused to answer/).length).toBeGreaterThan(0);
   });
 
   it("flashes changed values after a spin, then fades", async () => {

--- a/apps/web/src/routes/poll.tsx
+++ b/apps/web/src/routes/poll.tsx
@@ -19,11 +19,23 @@ export function allocateSeats(shares: Array<number>, totalSeats: number): Array<
   const quotas = shares.map((share) => (share / 100) * totalSeats);
   const floors = quotas.map((quota) => Math.floor(quota));
   const leftover = Math.max(0, totalSeats - floors.reduce((sum, seats) => sum + seats, 0));
-  const priority = quotas
-    .map((quota, index) => index)
-    .sort((a, b) => (quotas[b] ?? 0) - (quotas[a] ?? 0))
+  const remainders = quotas.map((quota) => quota - Math.floor(quota));
+  const priority = remainders
+    .map((_, index) => index)
+    .sort((a, b) => (remainders[b] ?? 0) - (remainders[a] ?? 0))
     .slice(0, leftover);
   return floors.map((seats, index) => seats + (priority.includes(index) ? 1 : 0));
+}
+
+function blocTotal(counts: Array<number>, names: Array<string>, bloc: Array<string>): number {
+  return names.reduce(
+    (sum, name, index) => sum + (bloc.includes(name) ? (counts[index] ?? 0) : 0),
+    0,
+  );
+}
+
+function isNoChange(delta: number): boolean {
+  return Math.abs(delta) < 0.05;
 }
 
 function formatPoints(value: number): string {
@@ -31,12 +43,18 @@ function formatPoints(value: number): string {
 }
 
 function formatChange(delta: number): string {
-  if (Math.abs(delta) < 0.05) return "NC";
-  return delta > 0 ? `↑${Math.abs(delta).toFixed(1)}` : `↓${Math.abs(delta).toFixed(1)}`;
+  if (isNoChange(delta)) return "NC";
+  const magnitude = Math.abs(delta).toFixed(1);
+  return delta > 0 ? `↑${magnitude}` : `↓${magnitude}`;
+}
+
+function formatSeatChange(delta: number): string {
+  if (isNoChange(delta)) return "NC";
+  return delta > 0 ? `↑${delta}` : `↓${Math.abs(delta)}`;
 }
 
 function supportVerb(delta: number): string {
-  if (Math.abs(delta) < 0.05) return "is unchanged on";
+  if (isNoChange(delta)) return "is unchanged on";
   if (delta > 0) return `is up ${Math.abs(delta).toFixed(1)} points to`;
   return `is down ${Math.abs(delta).toFixed(1)} points to`;
 }
@@ -100,6 +118,7 @@ export default function Poll() {
   const [methodology, setMethodology] = createSignal<Methodology>(EMPTY_METHODOLOGY);
   const [flashedSupport, setFlashedSupport] = createSignal<Array<number>>([]);
   const [flashedSeats, setFlashedSeats] = createSignal<Array<number>>([]);
+  const [flashedBloc, setFlashedBloc] = createSignal(false);
   const [flashedMethod, setFlashedMethod] = createSignal<Array<keyof Methodology>>([]);
   const flashTimer: FlashTimerRef = { current: undefined };
   // onSettled is a no-op during SSR, so the numbers only materialize in the
@@ -128,15 +147,10 @@ export default function Poll() {
   );
   const blocSeats = createMemo(() => {
     const names = history().map((entry) => entry.name);
-    const government = names.reduce(
-      (sum, name, index) => sum + (GOVERNMENT_BLOC.includes(name) ? (seats()[index] ?? 0) : 0),
-      0,
-    );
-    const opposition = names.reduce(
-      (sum, name, index) => sum + (OPPOSITION_BLOC.includes(name) ? (seats()[index] ?? 0) : 0),
-      0,
-    );
-    return { government, opposition };
+    return {
+      government: blocTotal(seats(), names, GOVERNMENT_BLOC),
+      opposition: blocTotal(seats(), names, OPPOSITION_BLOC),
+    };
   });
   const governmentVerdict = createMemo(() => {
     if (blocSeats().government >= 61)
@@ -149,6 +163,7 @@ export default function Poll() {
   const refresh = () => {
     const beforeShares = headline().map((share) => share.toFixed(1));
     const beforeSeats = seats();
+    const beforeBloc = blocSeats();
     const beforeMethod = methodology();
     const next = generatePartyHistory();
     const nextShares = next.map((entry) => (entry.points[entry.points.length - 1] ?? 0).toFixed(1));
@@ -156,12 +171,22 @@ export default function Poll() {
       next.map((entry) => entry.points[entry.points.length - 1] ?? 0),
       PARLIAMENT_SEATS,
     );
+    const nextNames = next.map((entry) => entry.name);
+    const nextBloc = {
+      government: blocTotal(nextSeats, nextNames, GOVERNMENT_BLOC),
+      opposition: blocTotal(nextSeats, nextNames, OPPOSITION_BLOC),
+    };
     const nextMethod = generateMethodology();
     setHistory(next);
     setMethodology(nextMethod);
     if (flashTimer.current !== undefined) clearTimeout(flashTimer.current);
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     setFlashedSupport(changedIndexes(nextShares, beforeShares));
     setFlashedSeats(changedIndexes(nextSeats, beforeSeats));
+    setFlashedBloc(
+      nextBloc.government !== beforeBloc.government ||
+        nextBloc.opposition !== beforeBloc.opposition,
+    );
     setFlashedMethod(
       (Object.keys(nextMethod) as Array<keyof Methodology>).filter(
         (key) => nextMethod[key] !== beforeMethod[key],
@@ -170,18 +195,19 @@ export default function Poll() {
     flashTimer.current = setTimeout(() => {
       setFlashedSupport([]);
       setFlashedSeats([]);
+      setFlashedBloc(false);
       setFlashedMethod([]);
     }, 1600);
   };
 
-  const supportCellClass = (index: number): string =>
-    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSupport().includes(index) ? FLASH_ON : ""}`;
-
-  const seatsCellClass = (index: number): string =>
-    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSeats().includes(index) ? FLASH_ON : ""}`;
-
   const flashText = (flashed: boolean): string =>
     `transition-colors duration-1000 ${flashed ? FLASH_ON : ""}`;
+
+  const valueCellClass = (flashed: boolean): string =>
+    `px-3 py-2 text-right tabular-nums ${flashText(flashed)}`;
+
+  const deltaCellClass = (flashed: boolean): string =>
+    `px-3 py-2 text-right font-semibold tabular-nums ${flashText(flashed)}`;
 
   const methodFlash = (key: keyof Methodology): string => flashText(flashedMethod().includes(key));
 
@@ -201,6 +227,9 @@ export default function Poll() {
         <p>Here are the headline results for September's Doodoo Dynamics Market Research Poll:</p>
       </BlurInSection>
       <BlurInSection delay={0.5}>
+        {/* Sync client-only data, not an async resource: generation is instant and
+            deferred to onSettled only for SSR agreement, so <Show> + <Spinner> is
+            the deliberate pattern here rather than <Loading>. */}
         <Show when={history().length > 0} fallback={<Spinner color="grey" />}>
           <div class="space-y-8">
             <PollTrendChart history={history()} />
@@ -221,10 +250,10 @@ export default function Poll() {
                     {(entry, index) => (
                       <tr class="border-b">
                         <td class="px-3 py-2">{entry.name}</td>
-                        <td class={supportCellClass(index())}>
+                        <td class={valueCellClass(flashedSupport().includes(index()))}>
                           {formatPoints(headline()[index()] ?? 0)}
                         </td>
-                        <td class="px-3 py-2 text-right font-semibold">
+                        <td class={deltaCellClass(flashedSupport().includes(index()))}>
                           {formatChange(deltas()[index()] ?? 0)}
                         </td>
                       </tr>
@@ -236,7 +265,10 @@ export default function Poll() {
                 <For each={history()}>
                   {(entry, index) => (
                     <p>
-                      {entry.name} {supportVerb(deltas()[index()] ?? 0)}{" "}
+                      {entry.name}{" "}
+                      <span class={flashText(flashedSupport().includes(index()))}>
+                        {supportVerb(deltas()[index()] ?? 0)}
+                      </span>{" "}
                       <span class={flashText(flashedSupport().includes(index()))}>
                         {formatPoints(headline()[index()] ?? 0)}
                       </span>
@@ -267,9 +299,11 @@ export default function Poll() {
                     {(entry, index) => (
                       <tr class="border-b">
                         <td class="px-3 py-2">{entry.name}</td>
-                        <td class={seatsCellClass(index())}>{seats()[index()] ?? 0}</td>
-                        <td class="px-3 py-2 text-right font-semibold">
-                          {formatChange(seatDeltas()[index()] ?? 0)}
+                        <td class={valueCellClass(flashedSeats().includes(index()))}>
+                          {seats()[index()] ?? 0}
+                        </td>
+                        <td class={deltaCellClass(flashedSeats().includes(index()))}>
+                          {formatSeatChange(seatDeltas()[index()] ?? 0)}
                         </td>
                       </tr>
                     )}
@@ -284,7 +318,11 @@ export default function Poll() {
                       <span class={flashText(flashedSeats().includes(index()))}>
                         {seats()[index()] ?? 0}
                       </span>{" "}
-                      seats ({seatChange(seatDeltas()[index()] ?? 0)}).
+                      seats (
+                      <span class={flashText(flashedSeats().includes(index()))}>
+                        {seatChange(seatDeltas()[index()] ?? 0)}
+                      </span>
+                      ).
                     </p>
                   )}
                 </For>
@@ -294,11 +332,12 @@ export default function Poll() {
               <h2>The blocs</h2>
               <p>
                 The combined projected seats for the Government Parties Bloc (National, New Zealand
-                First, ACT) is {blocSeats().government}.
+                First, ACT) is{" "}
+                <span class={flashText(flashedBloc())}>{blocSeats().government}</span>.
               </p>
               <p>
                 The combined seats for the Opposition Parties Bloc (Labour, Green, Te Pāti Māori) is{" "}
-                {blocSeats().opposition}.
+                <span class={flashText(flashedBloc())}>{blocSeats().opposition}</span>.
               </p>
               <p>{governmentVerdict()}</p>
             </section>
@@ -319,7 +358,9 @@ export default function Poll() {
                   <span class={methodFlash("undecided")}>
                     {methodology().undecided.toFixed(1)}%
                   </span>{" "}
-                  were undecided on the party vote question.
+                  were undecided on the party vote question, while{" "}
+                  <span class={methodFlash("refused")}>{methodology().refused.toFixed(1)}%</span>{" "}
+                  refused to answer.
                 </em>
               </p>
               <h2>Notes</h2>
@@ -333,7 +374,10 @@ export default function Poll() {
                 phone and{" "}
                 <span class={methodFlash("online")}>{formatCount(methodology().online)}</span> by
                 online panel. The number of decided voters on the vote questions was{" "}
-                <span class={methodFlash("decided")}>{formatCount(methodology().decided)}</span>.
+                <span class={methodFlash("decided")}>{formatCount(methodology().decided)}</span>. A
+                further{" "}
+                <span class={methodFlash("refused")}>{methodology().refused.toFixed(1)}%</span> of
+                respondents refused to answer the vote question.
               </p>
               <p>
                 For seat projections it is assumed all current parliamentary parties will win at

--- a/apps/web/src/routes/poll.tsx
+++ b/apps/web/src/routes/poll.tsx
@@ -1,0 +1,248 @@
+import { For, Show, createMemo, createSignal, onSettled } from "solid-js";
+import { PageLayout } from "@tom/ui/PageLayout";
+import { Spinner } from "@tom/ui/Spinner";
+import { Button } from "@tom/ui/tomui/button";
+import { BlurInSection } from "~/components/BlurInSection";
+import { BlurInText } from "~/components/BlurInText";
+import { PollTrendChart, generatePartyHistory } from "~/components/PollTrendChart";
+import type { PartySeries } from "~/components/PollTrendChart";
+
+const HEADLINE_MONTH = "September 2026";
+const PREVIOUS_MONTH = "August 2026";
+const HEADLINE_DATES = "Tuesday 01 September to Friday 04 September 2026";
+const PARLIAMENT_SEATS = 120;
+
+const GOVERNMENT_BLOC = ["National", "NZ First", "ACT"];
+const OPPOSITION_BLOC = ["Labour", "Green", "Te Pāti Māori"];
+
+export function allocateSeats(shares: Array<number>, totalSeats: number): Array<number> {
+  const quotas = shares.map((share) => (share / 100) * totalSeats);
+  const floors = quotas.map((quota) => Math.floor(quota));
+  const leftover = Math.max(0, totalSeats - floors.reduce((sum, seats) => sum + seats, 0));
+  const priority = quotas
+    .map((quota, index) => index)
+    .sort((a, b) => (quotas[b] ?? 0) - (quotas[a] ?? 0))
+    .slice(0, leftover);
+  return floors.map((seats, index) => seats + (priority.includes(index) ? 1 : 0));
+}
+
+function formatPoints(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatChange(delta: number): string {
+  if (Math.abs(delta) < 0.05) return "NC";
+  return delta > 0 ? `↑${Math.abs(delta).toFixed(1)}` : `↓${Math.abs(delta).toFixed(1)}`;
+}
+
+function supportClause(name: string, share: number, delta: number): string {
+  if (Math.abs(delta) < 0.05) return `${name} is unchanged on ${formatPoints(share)}.`;
+  if (delta > 0)
+    return `${name} is up ${Math.abs(delta).toFixed(1)} points to ${formatPoints(share)}.`;
+  return `${name} is down ${Math.abs(delta).toFixed(1)} points to ${formatPoints(share)}.`;
+}
+
+function seatClause(name: string, seats: number, delta: number): string {
+  if (delta === 0) return `${name} is unchanged on ${seats} seats.`;
+  if (delta > 0) return `${name} gains ${delta} to ${seats}.`;
+  return `${name} drops ${Math.abs(delta)} to ${seats}.`;
+}
+
+export default function Poll() {
+  const [history, setHistory] = createSignal<Array<PartySeries>>([]);
+  // onSettled is a no-op during SSR, so the numbers only materialize in the
+  // browser — the server and the first client render agree on the placeholder.
+  onSettled(() => {
+    setHistory(generatePartyHistory());
+  });
+
+  const headline = createMemo(() =>
+    history().map((entry) => entry.points[entry.points.length - 1] ?? 0),
+  );
+  const previous = createMemo(() =>
+    history().map((entry) => entry.points[entry.points.length - 2] ?? 0),
+  );
+  const deltas = createMemo(() =>
+    headline().map((share, index) => share - (previous()[index] ?? 0)),
+  );
+  const seats = createMemo(() => allocateSeats(headline(), PARLIAMENT_SEATS));
+  const previousSeats = createMemo(() => allocateSeats(previous(), PARLIAMENT_SEATS));
+  const seatDeltas = createMemo(() =>
+    seats().map((count, index) => count - (previousSeats()[index] ?? 0)),
+  );
+  const blocSeats = createMemo(() => {
+    const names = history().map((entry) => entry.name);
+    const government = names.reduce(
+      (sum, name, index) => sum + (GOVERNMENT_BLOC.includes(name) ? (seats()[index] ?? 0) : 0),
+      0,
+    );
+    const opposition = names.reduce(
+      (sum, name, index) => sum + (OPPOSITION_BLOC.includes(name) ? (seats()[index] ?? 0) : 0),
+      0,
+    );
+    return { government, opposition };
+  });
+  const governmentVerdict = createMemo(() => {
+    if (blocSeats().government >= 61)
+      return "On these numbers, the current three parties of Government would be able to form a Government.";
+    if (blocSeats().opposition >= 61)
+      return "On these numbers, the Opposition bloc would be able to form a Government.";
+    return "On these numbers, neither bloc commands a majority in Parliament.";
+  });
+
+  const refresh = () => {
+    setHistory(generatePartyHistory());
+  };
+
+  return (
+    <PageLayout
+      title="Doodoo Dynamics Market Research Poll"
+      description="September 2026 Doodoo Dynamics Market Research Poll: party vote, seat projection, and trend bands"
+      canonical="https://tom.so/poll"
+    >
+      <BlurInText
+        text={`Doodoo Dynamics Market Research Poll: ${HEADLINE_MONTH}`}
+        tag="h1"
+        baseDelay={0.1}
+        step={0.025}
+      />
+      <BlurInSection delay={0.3}>
+        <p>Here are the headline results for September's Doodoo Dynamics Market Research Poll:</p>
+      </BlurInSection>
+      <BlurInSection delay={0.5}>
+        <Show when={history().length > 0} fallback={<Spinner color="grey" />}>
+          <div class="space-y-8">
+            <PollTrendChart history={history()} />
+            <section class="space-y-4">
+              <h2>Party vote</h2>
+              <table aria-label="Party support" class="w-full border-collapse text-sm">
+                <thead>
+                  <tr class="border-b">
+                    <th class="px-3 py-2 text-left font-semibold">Party</th>
+                    <th class="px-3 py-2 text-right font-semibold">Support</th>
+                    <th class="px-3 py-2 text-right font-semibold">
+                      Change compared to {PREVIOUS_MONTH}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={history()}>
+                    {(entry, index) => (
+                      <tr class="border-b">
+                        <td class="px-3 py-2">{entry.name}</td>
+                        <td class="px-3 py-2 text-right tabular-nums">
+                          {formatPoints(headline()[index()] ?? 0)}
+                        </td>
+                        <td class="px-3 py-2 text-right font-semibold">
+                          {formatChange(deltas()[index()] ?? 0)}
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+              <div class="space-y-2">
+                <For each={history()}>
+                  {(entry, index) => (
+                    <p>
+                      {supportClause(entry.name, headline()[index()] ?? 0, deltas()[index()] ?? 0)}
+                    </p>
+                  )}
+                </For>
+              </div>
+            </section>
+            <section class="space-y-4">
+              <h2>Seat projection</h2>
+              <p>
+                This shows how many seats each party would win in Parliament, based on the decided
+                vote.
+              </p>
+              <table aria-label="Projected seats" class="w-full border-collapse text-sm">
+                <thead>
+                  <tr class="border-b">
+                    <th class="px-3 py-2 text-left font-semibold">Party</th>
+                    <th class="px-3 py-2 text-right font-semibold">Seats</th>
+                    <th class="px-3 py-2 text-right font-semibold">
+                      Change compared to {PREVIOUS_MONTH}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={history()}>
+                    {(entry, index) => (
+                      <tr class="border-b">
+                        <td class="px-3 py-2">{entry.name}</td>
+                        <td class="px-3 py-2 text-right tabular-nums">{seats()[index()] ?? 0}</td>
+                        <td class="px-3 py-2 text-right font-semibold">
+                          {formatChange(seatDeltas()[index()] ?? 0)}
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+              <div class="space-y-2">
+                <For each={history()}>
+                  {(entry, index) => (
+                    <p>
+                      {seatClause(entry.name, seats()[index()] ?? 0, seatDeltas()[index()] ?? 0)}
+                    </p>
+                  )}
+                </For>
+              </div>
+            </section>
+            <section class="space-y-4">
+              <h2>The blocs</h2>
+              <p>
+                The combined projected seats for the Government Parties Bloc (National, New Zealand
+                First, ACT) is {blocSeats().government}.
+              </p>
+              <p>
+                The combined seats for the Opposition Parties Bloc (Labour, Green, Te Pāti Māori) is{" "}
+                {blocSeats().opposition}.
+              </p>
+              <p>{governmentVerdict()}</p>
+            </section>
+            <section class="space-y-4">
+              <h2>Media summary statement</h2>
+              <p>
+                This poll should be formally referred to as the "Doodoo Dynamics Market Research
+                Poll".
+              </p>
+              <p>
+                <em>
+                  The poll was conducted by Doodoo Dynamics Market Research Ltd. It is a random poll
+                  of 1,000 adult New Zealanders and is weighted to the overall adult population. It
+                  was conducted by phone (landlines and mobile) and online between {HEADLINE_DATES},
+                  has a maximum margin of error of ±3.1% and 2.1% were undecided on the party vote
+                  question.
+                </em>
+              </p>
+              <h2>Notes</h2>
+              <p>
+                The scientific poll was conducted by Doodoo Dynamics Market Research and
+                commissioned by nobody in particular. The target population is adults aged 18+ who
+                live in New Zealand and are eligible and likely to vote. 1,000 respondents agreed to
+                participate, 700 by phone and 300 by online panel. The number of decided voters on
+                the vote questions was 965.
+              </p>
+              <p>
+                For seat projections it is assumed all current parliamentary parties will win at
+                least one electorate seat and be eligible for list MPs. However no overhang seats
+                are assumed or projected.
+              </p>
+              <p>
+                The results are weighted to reflect the overall voting adult population in terms of
+                gender, age, and area. Based on this sample of 1,000 respondents, the maximum
+                sampling error (for a result of 50%) is ±3.1%, at the 95% confidence level.
+              </p>
+            </section>
+            <Button type="button" variant="primary" onClick={refresh}>
+              Spin it again
+            </Button>
+          </div>
+        </Show>
+      </BlurInSection>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/routes/poll.tsx
+++ b/apps/web/src/routes/poll.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal, onSettled } from "solid-js";
+import { For, Show, createMemo, createSignal, onCleanup, onSettled } from "solid-js";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { Spinner } from "@tom/ui/Spinner";
 import { Button } from "@tom/ui/tomui/button";
@@ -48,12 +48,28 @@ function seatClause(name: string, seats: number, delta: number): string {
   return `${name} drops ${Math.abs(delta)} to ${seats}.`;
 }
 
+function changedIndexes<T>(nextValues: Array<T>, prevValues: Array<T>): Array<number> {
+  return nextValues
+    .map((_, index) => index)
+    .filter((index) => nextValues[index] !== prevValues[index]);
+}
+
+interface FlashTimerRef {
+  current: ReturnType<typeof setTimeout> | undefined;
+}
+
 export default function Poll() {
   const [history, setHistory] = createSignal<Array<PartySeries>>([]);
+  const [flashedSupport, setFlashedSupport] = createSignal<Array<number>>([]);
+  const [flashedSeats, setFlashedSeats] = createSignal<Array<number>>([]);
+  const flashTimer: FlashTimerRef = { current: undefined };
   // onSettled is a no-op during SSR, so the numbers only materialize in the
   // browser — the server and the first client render agree on the placeholder.
   onSettled(() => {
     setHistory(generatePartyHistory());
+  });
+  onCleanup(() => {
+    if (flashTimer.current !== undefined) clearTimeout(flashTimer.current);
   });
 
   const headline = createMemo(() =>
@@ -91,8 +107,29 @@ export default function Poll() {
   });
 
   const refresh = () => {
-    setHistory(generatePartyHistory());
+    const beforeShares = headline().map((share) => share.toFixed(1));
+    const beforeSeats = seats();
+    const next = generatePartyHistory();
+    const nextShares = next.map((entry) => (entry.points[entry.points.length - 1] ?? 0).toFixed(1));
+    const nextSeats = allocateSeats(
+      next.map((entry) => entry.points[entry.points.length - 1] ?? 0),
+      PARLIAMENT_SEATS,
+    );
+    setHistory(next);
+    if (flashTimer.current !== undefined) clearTimeout(flashTimer.current);
+    setFlashedSupport(changedIndexes(nextShares, beforeShares));
+    setFlashedSeats(changedIndexes(nextSeats, beforeSeats));
+    flashTimer.current = setTimeout(() => {
+      setFlashedSupport([]);
+      setFlashedSeats([]);
+    }, 1600);
   };
+
+  const supportCellClass = (index: number): string =>
+    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSupport().includes(index) ? "poll-flash bg-amber-200 dark:bg-amber-900/60" : ""}`;
+
+  const seatsCellClass = (index: number): string =>
+    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSeats().includes(index) ? "poll-flash bg-amber-200 dark:bg-amber-900/60" : ""}`;
 
   return (
     <PageLayout
@@ -130,7 +167,7 @@ export default function Poll() {
                     {(entry, index) => (
                       <tr class="border-b">
                         <td class="px-3 py-2">{entry.name}</td>
-                        <td class="px-3 py-2 text-right tabular-nums">
+                        <td class={supportCellClass(index())}>
                           {formatPoints(headline()[index()] ?? 0)}
                         </td>
                         <td class="px-3 py-2 text-right font-semibold">
@@ -172,7 +209,7 @@ export default function Poll() {
                     {(entry, index) => (
                       <tr class="border-b">
                         <td class="px-3 py-2">{entry.name}</td>
-                        <td class="px-3 py-2 text-right tabular-nums">{seats()[index()] ?? 0}</td>
+                        <td class={seatsCellClass(index())}>{seats()[index()] ?? 0}</td>
                         <td class="px-3 py-2 text-right font-semibold">
                           {formatChange(seatDeltas()[index()] ?? 0)}
                         </td>

--- a/apps/web/src/routes/poll.tsx
+++ b/apps/web/src/routes/poll.tsx
@@ -35,17 +35,54 @@ function formatChange(delta: number): string {
   return delta > 0 ? `↑${Math.abs(delta).toFixed(1)}` : `↓${Math.abs(delta).toFixed(1)}`;
 }
 
-function supportClause(name: string, share: number, delta: number): string {
-  if (Math.abs(delta) < 0.05) return `${name} is unchanged on ${formatPoints(share)}.`;
-  if (delta > 0)
-    return `${name} is up ${Math.abs(delta).toFixed(1)} points to ${formatPoints(share)}.`;
-  return `${name} is down ${Math.abs(delta).toFixed(1)} points to ${formatPoints(share)}.`;
+function supportVerb(delta: number): string {
+  if (Math.abs(delta) < 0.05) return "is unchanged on";
+  if (delta > 0) return `is up ${Math.abs(delta).toFixed(1)} points to`;
+  return `is down ${Math.abs(delta).toFixed(1)} points to`;
 }
 
-function seatClause(name: string, seats: number, delta: number): string {
-  if (delta === 0) return `${name} is unchanged on ${seats} seats.`;
-  if (delta > 0) return `${name} gains ${delta} to ${seats}.`;
-  return `${name} drops ${Math.abs(delta)} to ${seats}.`;
+export interface Methodology {
+  decided: number;
+  moe: number;
+  online: number;
+  phone: number;
+  refused: number;
+  sample: number;
+  undecided: number;
+}
+
+const EMPTY_METHODOLOGY: Methodology = {
+  decided: 0,
+  moe: 0,
+  online: 0,
+  phone: 0,
+  refused: 0,
+  sample: 0,
+  undecided: 0,
+};
+
+export function generateMethodology(): Methodology {
+  const sample = 980 + Math.floor(Math.random() * 41);
+  const phone = Math.round(sample * (0.65 + Math.random() * 0.1));
+  const online = sample - phone;
+  const undecided = Math.round((1.8 + Math.random() * 0.8) * 10) / 10;
+  const refused = Math.round((1 + Math.random() * 0.6) * 10) / 10;
+  const decided =
+    sample - Math.round((sample * undecided) / 100) - Math.round((sample * refused) / 100);
+  const moe = Math.round(1.96 * Math.sqrt(0.25 / sample) * 1000) / 10;
+  return { decided, moe, online, phone, refused, sample, undecided };
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-NZ");
+}
+
+const FLASH_ON = "poll-flash bg-amber-200 dark:bg-amber-900/60";
+
+function seatChange(delta: number): string {
+  if (delta === 0) return "no change";
+  if (delta > 0) return `up ${delta}`;
+  return `down ${Math.abs(delta)}`;
 }
 
 function changedIndexes<T>(nextValues: Array<T>, prevValues: Array<T>): Array<number> {
@@ -60,13 +97,16 @@ interface FlashTimerRef {
 
 export default function Poll() {
   const [history, setHistory] = createSignal<Array<PartySeries>>([]);
+  const [methodology, setMethodology] = createSignal<Methodology>(EMPTY_METHODOLOGY);
   const [flashedSupport, setFlashedSupport] = createSignal<Array<number>>([]);
   const [flashedSeats, setFlashedSeats] = createSignal<Array<number>>([]);
+  const [flashedMethod, setFlashedMethod] = createSignal<Array<keyof Methodology>>([]);
   const flashTimer: FlashTimerRef = { current: undefined };
   // onSettled is a no-op during SSR, so the numbers only materialize in the
   // browser — the server and the first client render agree on the placeholder.
   onSettled(() => {
     setHistory(generatePartyHistory());
+    setMethodology(generateMethodology());
   });
   onCleanup(() => {
     if (flashTimer.current !== undefined) clearTimeout(flashTimer.current);
@@ -109,27 +149,41 @@ export default function Poll() {
   const refresh = () => {
     const beforeShares = headline().map((share) => share.toFixed(1));
     const beforeSeats = seats();
+    const beforeMethod = methodology();
     const next = generatePartyHistory();
     const nextShares = next.map((entry) => (entry.points[entry.points.length - 1] ?? 0).toFixed(1));
     const nextSeats = allocateSeats(
       next.map((entry) => entry.points[entry.points.length - 1] ?? 0),
       PARLIAMENT_SEATS,
     );
+    const nextMethod = generateMethodology();
     setHistory(next);
+    setMethodology(nextMethod);
     if (flashTimer.current !== undefined) clearTimeout(flashTimer.current);
     setFlashedSupport(changedIndexes(nextShares, beforeShares));
     setFlashedSeats(changedIndexes(nextSeats, beforeSeats));
+    setFlashedMethod(
+      (Object.keys(nextMethod) as Array<keyof Methodology>).filter(
+        (key) => nextMethod[key] !== beforeMethod[key],
+      ),
+    );
     flashTimer.current = setTimeout(() => {
       setFlashedSupport([]);
       setFlashedSeats([]);
+      setFlashedMethod([]);
     }, 1600);
   };
 
   const supportCellClass = (index: number): string =>
-    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSupport().includes(index) ? "poll-flash bg-amber-200 dark:bg-amber-900/60" : ""}`;
+    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSupport().includes(index) ? FLASH_ON : ""}`;
 
   const seatsCellClass = (index: number): string =>
-    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSeats().includes(index) ? "poll-flash bg-amber-200 dark:bg-amber-900/60" : ""}`;
+    `px-3 py-2 text-right tabular-nums transition-colors duration-1000 ${flashedSeats().includes(index) ? FLASH_ON : ""}`;
+
+  const flashText = (flashed: boolean): string =>
+    `transition-colors duration-1000 ${flashed ? FLASH_ON : ""}`;
+
+  const methodFlash = (key: keyof Methodology): string => flashText(flashedMethod().includes(key));
 
   return (
     <PageLayout
@@ -182,7 +236,11 @@ export default function Poll() {
                 <For each={history()}>
                   {(entry, index) => (
                     <p>
-                      {supportClause(entry.name, headline()[index()] ?? 0, deltas()[index()] ?? 0)}
+                      {entry.name} {supportVerb(deltas()[index()] ?? 0)}{" "}
+                      <span class={flashText(flashedSupport().includes(index()))}>
+                        {formatPoints(headline()[index()] ?? 0)}
+                      </span>
+                      .
                     </p>
                   )}
                 </For>
@@ -222,7 +280,11 @@ export default function Poll() {
                 <For each={history()}>
                   {(entry, index) => (
                     <p>
-                      {seatClause(entry.name, seats()[index()] ?? 0, seatDeltas()[index()] ?? 0)}
+                      {entry.name} wins{" "}
+                      <span class={flashText(flashedSeats().includes(index()))}>
+                        {seats()[index()] ?? 0}
+                      </span>{" "}
+                      seats ({seatChange(seatDeltas()[index()] ?? 0)}).
                     </p>
                   )}
                 </For>
@@ -249,19 +311,29 @@ export default function Poll() {
               <p>
                 <em>
                   The poll was conducted by Doodoo Dynamics Market Research Ltd. It is a random poll
-                  of 1,000 adult New Zealanders and is weighted to the overall adult population. It
-                  was conducted by phone (landlines and mobile) and online between {HEADLINE_DATES},
-                  has a maximum margin of error of ±3.1% and 2.1% were undecided on the party vote
-                  question.
+                  of <span class={methodFlash("sample")}>{formatCount(methodology().sample)}</span>{" "}
+                  adult New Zealanders and is weighted to the overall adult population. It was
+                  conducted by phone (landlines and mobile) and online between {HEADLINE_DATES}, has
+                  a maximum margin of error of{" "}
+                  <span class={methodFlash("moe")}>±{methodology().moe.toFixed(1)}%</span> and{" "}
+                  <span class={methodFlash("undecided")}>
+                    {methodology().undecided.toFixed(1)}%
+                  </span>{" "}
+                  were undecided on the party vote question.
                 </em>
               </p>
               <h2>Notes</h2>
               <p>
                 The scientific poll was conducted by Doodoo Dynamics Market Research and
                 commissioned by nobody in particular. The target population is adults aged 18+ who
-                live in New Zealand and are eligible and likely to vote. 1,000 respondents agreed to
-                participate, 700 by phone and 300 by online panel. The number of decided voters on
-                the vote questions was 965.
+                live in New Zealand and are eligible and likely to vote.{" "}
+                <span class={methodFlash("sample")}>{formatCount(methodology().sample)}</span>{" "}
+                respondents agreed to participate,{" "}
+                <span class={methodFlash("phone")}>{formatCount(methodology().phone)}</span> by
+                phone and{" "}
+                <span class={methodFlash("online")}>{formatCount(methodology().online)}</span> by
+                online panel. The number of decided voters on the vote questions was{" "}
+                <span class={methodFlash("decided")}>{formatCount(methodology().decided)}</span>.
               </p>
               <p>
                 For seat projections it is assumed all current parliamentary parties will win at
@@ -270,8 +342,11 @@ export default function Poll() {
               </p>
               <p>
                 The results are weighted to reflect the overall voting adult population in terms of
-                gender, age, and area. Based on this sample of 1,000 respondents, the maximum
-                sampling error (for a result of 50%) is ±3.1%, at the 95% confidence level.
+                gender, age, and area. Based on this sample of{" "}
+                <span class={methodFlash("sample")}>{formatCount(methodology().sample)}</span>{" "}
+                respondents, the maximum sampling error (for a result of 50%) is{" "}
+                <span class={methodFlash("moe")}>±{methodology().moe.toFixed(1)}%</span>, at the 95%
+                confidence level.
               </p>
             </section>
             <Button type="button" variant="primary" onClick={refresh}>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "./tomui/badge": "./src/tomui/components/badge/badge.tsx",
     "./tomui/banner": "./src/tomui/components/banner/banner.tsx",
     "./tomui/banner-action": "./src/tomui/components/banner/banner-action.tsx",
+    "./tomui/bollinger": "./src/tomui/components/bollinger/bollinger.tsx",
     "./tomui/breadcrumbs": "./src/tomui/components/breadcrumbs/breadcrumbs.tsx",
     "./tomui/button": "./src/tomui/components/button/button.tsx",
     "./tomui/chart": "./src/tomui/components/chart/chart.tsx",

--- a/packages/ui/src/storybook/stories/web/TomuiBollinger.stories.tsx
+++ b/packages/ui/src/storybook/stories/web/TomuiBollinger.stories.tsx
@@ -1,0 +1,26 @@
+import preview from "#.storybook/preview";
+import { Bollinger } from "@tom/ui/tomui/bollinger";
+
+const meta = preview.meta({
+  title: "web/Bollinger",
+  component: Bollinger,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+});
+
+const series = [
+  { color: "#0A4DA6", label: "National", values: [31, 30, 32, 29, 31, 33, 30, 31] },
+  { color: "#D62027", label: "Labour", values: [28, 29, 27, 30, 28, 27, 29, 28] },
+];
+
+const labels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug"];
+
+export const Default = meta.story({
+  args: {
+    series,
+    labels,
+    caption: "Support over time, with five-poll Bollinger bands.",
+  },
+});

--- a/packages/ui/src/tomui/components/bollinger/bollinger.tsx
+++ b/packages/ui/src/tomui/components/bollinger/bollinger.tsx
@@ -1,0 +1,210 @@
+import { For, Show, createMemo, merge, omit } from "solid-js";
+import type { JSX } from "@solidjs/web";
+import { cn } from "../../utils/cn";
+
+export interface BollingerSeries {
+  color: string;
+  label: string;
+  values: Array<number>;
+}
+
+export interface BollingerBand {
+  lower: number;
+  mid: number;
+  upper: number;
+}
+
+export type BollingerProps = Omit<JSX.HTMLAttributes<HTMLDivElement>, "style"> & {
+  ariaLabel?: string;
+  caption?: string;
+  children?: JSX.Element;
+  class?: string;
+  deviations?: number;
+  labels?: Array<string>;
+  series?: Array<BollingerSeries>;
+  span?: number;
+  style?: JSX.CSSProperties;
+};
+
+export const TOMUI_BOLLINGER_DEFAULTS = {
+  deviations: 2,
+  span: 5,
+} as const;
+
+export function bollinger(
+  values: Array<number>,
+  span: number,
+  deviations: number,
+): Array<BollingerBand> {
+  return values.map((_, index) => {
+    const slice = values.slice(Math.max(0, index - span + 1), index + 1);
+    const mean = slice.reduce((sum, value) => sum + value, 0) / slice.length;
+    const variance = slice.reduce((sum, value) => sum + (value - mean) ** 2, 0) / slice.length;
+    const deviation = Math.sqrt(variance);
+    return {
+      lower: Math.max(0, mean - deviations * deviation),
+      mid: mean,
+      upper: mean + deviations * deviation,
+    };
+  });
+}
+
+const CHART_WIDTH = 640;
+const CHART_HEIGHT = 360;
+const MARGIN = { bottom: 40, left: 44, right: 8, top: 12 };
+
+function niceCeiling(value: number): number {
+  return Math.max(10, Math.ceil(value / 5) * 5);
+}
+
+export function Bollinger(props: BollingerProps) {
+  const merged = merge(TOMUI_BOLLINGER_DEFAULTS, props);
+  const rest = omit(
+    merged,
+    "ariaLabel",
+    "caption",
+    "children",
+    "class",
+    "deviations",
+    "labels",
+    "series",
+    "span",
+    "style",
+  );
+  const entries = () => merged.series ?? [];
+  const bands = createMemo(() =>
+    entries().map((entry) => bollinger(entry.values, merged.span, merged.deviations)),
+  );
+  const ceiling = createMemo(() => {
+    const top = bands()
+      .flat()
+      .reduce((best, band) => Math.max(best, band.upper), 0);
+    return niceCeiling(top);
+  });
+  const ticks = createMemo(() => {
+    const step = ceiling() > 30 ? 10 : 5;
+    const count = Math.floor(ceiling() / step);
+    return Array.from({ length: count + 1 }, (_, index) => (count - index) * step);
+  });
+  const plotWidth = CHART_WIDTH - MARGIN.left - MARGIN.right;
+  const plotHeight = CHART_HEIGHT - MARGIN.top - MARGIN.bottom;
+  const pointCount = () => Math.max(...entries().map((entry) => entry.values.length), 0);
+  const x = (index: number): number =>
+    MARGIN.left + (index / Math.max(1, pointCount() - 1)) * plotWidth;
+  const y = (value: number): number => MARGIN.top + plotHeight - (value / ceiling()) * plotHeight;
+  const bandPath = (band: Array<BollingerBand>): string => {
+    const upper = band.map((point, index) => `${x(index).toFixed(1)},${y(point.upper).toFixed(1)}`);
+    const lower = band
+      .map((point, index) => `${x(index).toFixed(1)},${y(point.lower).toFixed(1)}`)
+      .reverse();
+    return `M${upper.join(" L")} L${lower.join(" L")} Z`;
+  };
+  const midPath = (band: Array<BollingerBand>): string =>
+    `M${band.map((point, index) => `${x(index).toFixed(1)},${y(point.mid).toFixed(1)}`).join(" L")}`;
+  const labelIndexes = () =>
+    (merged.labels ?? [])
+      .map((_, index) => index)
+      .filter((index) => index % 2 === 0 || index === pointCount() - 1);
+
+  return (
+    <div
+      data-tomui-component="Bollinger"
+      class={cn("tomui-bollinger w-full", merged.class)}
+      style={merged.style}
+      {...rest}
+    >
+      <Show when={entries().length > 0}>
+        <figure>
+          <div aria-hidden="true">
+            <svg
+              viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+              class="h-auto w-full"
+              role="img"
+              aria-label={merged.ariaLabel ?? "Trend chart with Bollinger bands"}
+            >
+              <For each={ticks()}>
+                {(tick) => (
+                  <>
+                    <line
+                      x1={MARGIN.left}
+                      x2={CHART_WIDTH - MARGIN.right}
+                      y1={y(tick)}
+                      y2={y(tick)}
+                      stroke="currentColor"
+                      stroke-opacity="0.2"
+                      stroke-dasharray="4 3"
+                    />
+                    <text
+                      x={MARGIN.left - 6}
+                      y={y(tick) + 4}
+                      text-anchor="end"
+                      font-size="11"
+                      fill="currentColor"
+                    >
+                      {tick}%
+                    </text>
+                  </>
+                )}
+              </For>
+              <For each={entries()}>
+                {(entry, index) => (
+                  <>
+                    <path
+                      d={bandPath(bands()[index()] ?? [])}
+                      fill={entry.color}
+                      fill-opacity="0.15"
+                    />
+                    <path
+                      d={midPath(bands()[index()] ?? [])}
+                      fill="none"
+                      stroke={entry.color}
+                      stroke-width="2"
+                    />
+                    <Show when={(bands()[index()] ?? []).length > 0}>
+                      <circle
+                        cx={x(pointCount() - 1)}
+                        cy={y((bands()[index()] ?? [])[pointCount() - 1]?.mid ?? 0)}
+                        r="3"
+                        fill={entry.color}
+                      />
+                    </Show>
+                  </>
+                )}
+              </For>
+              <For each={labelIndexes()}>
+                {(index) => (
+                  <text
+                    x={x(index)}
+                    y={CHART_HEIGHT - 12}
+                    text-anchor="middle"
+                    font-size="11"
+                    fill="currentColor"
+                  >
+                    {(merged.labels ?? [])[index]}
+                  </text>
+                )}
+              </For>
+            </svg>
+            <div class="flex flex-wrap gap-x-4 gap-y-1 pt-2 text-xs">
+              <For each={entries()}>
+                {(entry) => (
+                  <span class="inline-flex items-center gap-1.5">
+                    <span
+                      class="inline-block h-2.5 w-2.5 rounded-sm"
+                      style={{ "background-color": entry.color }}
+                    />
+                    {entry.label}
+                  </span>
+                )}
+              </For>
+            </div>
+          </div>
+          <Show when={merged.caption}>
+            {(caption) => <figcaption class="pt-2 text-xs opacity-70">{caption()}</figcaption>}
+          </Show>
+        </figure>
+      </Show>
+      {merged.children}
+    </div>
+  );
+}

--- a/packages/ui/src/tomui/components/bollinger/bollinger.tsx
+++ b/packages/ui/src/tomui/components/bollinger/bollinger.tsx
@@ -31,7 +31,7 @@ export const TOMUI_BOLLINGER_DEFAULTS = {
   span: 5,
 } as const;
 
-export function bollinger(
+export function computeBollingerBands(
   values: Array<number>,
   span: number,
   deviations: number,
@@ -73,7 +73,7 @@ export function Bollinger(props: BollingerProps) {
   );
   const entries = () => merged.series ?? [];
   const bands = createMemo(() =>
-    entries().map((entry) => bollinger(entry.values, merged.span, merged.deviations)),
+    entries().map((entry) => computeBollingerBands(entry.values, merged.span, merged.deviations)),
   );
   const ceiling = createMemo(() => {
     const top = bands()
@@ -115,89 +115,92 @@ export function Bollinger(props: BollingerProps) {
     >
       <Show when={entries().length > 0}>
         <figure>
-          <div aria-hidden="true">
-            <svg
-              viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-              class="h-auto w-full"
-              role="img"
-              aria-label={merged.ariaLabel ?? "Trend chart with Bollinger bands"}
-            >
-              <For each={ticks()}>
-                {(tick) => (
-                  <>
-                    <line
-                      x1={MARGIN.left}
-                      x2={CHART_WIDTH - MARGIN.right}
-                      y1={y(tick)}
-                      y2={y(tick)}
-                      stroke="currentColor"
-                      stroke-opacity="0.2"
-                      stroke-dasharray="4 3"
-                    />
-                    <text
-                      x={MARGIN.left - 6}
-                      y={y(tick) + 4}
-                      text-anchor="end"
-                      font-size="11"
-                      fill="currentColor"
-                    >
-                      {tick}%
-                    </text>
-                  </>
-                )}
-              </For>
-              <For each={entries()}>
-                {(entry, index) => (
-                  <>
-                    <path
-                      d={bandPath(bands()[index()] ?? [])}
-                      fill={entry.color}
-                      fill-opacity="0.15"
-                    />
-                    <path
-                      d={midPath(bands()[index()] ?? [])}
-                      fill="none"
-                      stroke={entry.color}
-                      stroke-width="2"
-                    />
-                    <Show when={(bands()[index()] ?? []).length > 0}>
-                      <circle
-                        cx={x(pointCount() - 1)}
-                        cy={y((bands()[index()] ?? [])[pointCount() - 1]?.mid ?? 0)}
-                        r="3"
-                        fill={entry.color}
-                      />
-                    </Show>
-                  </>
-                )}
-              </For>
-              <For each={labelIndexes()}>
-                {(index) => (
+          <svg
+            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+            class="h-auto w-full"
+            role="img"
+            aria-label={merged.ariaLabel ?? "Trend chart with Bollinger bands"}
+          >
+            <For each={ticks()}>
+              {(tick) => (
+                <>
+                  <line
+                    x1={MARGIN.left}
+                    x2={CHART_WIDTH - MARGIN.right}
+                    y1={y(tick)}
+                    y2={y(tick)}
+                    stroke="currentColor"
+                    stroke-opacity="0.2"
+                    stroke-dasharray="4 3"
+                  />
                   <text
-                    x={x(index)}
-                    y={CHART_HEIGHT - 12}
-                    text-anchor="middle"
+                    x={MARGIN.left - 6}
+                    y={y(tick) + 4}
+                    text-anchor="end"
                     font-size="11"
                     fill="currentColor"
                   >
-                    {(merged.labels ?? [])[index]}
+                    {tick}%
                   </text>
-                )}
-              </For>
-            </svg>
-            <div class="flex flex-wrap gap-x-4 gap-y-1 pt-2 text-xs">
-              <For each={entries()}>
-                {(entry) => (
-                  <span class="inline-flex items-center gap-1.5">
-                    <span
-                      class="inline-block h-2.5 w-2.5 rounded-sm"
-                      style={{ "background-color": entry.color }}
+                </>
+              )}
+            </For>
+            <For each={entries()}>
+              {(entry, index) => (
+                <>
+                  <path
+                    d={bandPath(bands()[index()] ?? [])}
+                    fill={entry.color}
+                    fill-opacity="0.15"
+                  />
+                  <path
+                    d={midPath(bands()[index()] ?? [])}
+                    fill="none"
+                    stroke={entry.color}
+                    stroke-width="2"
+                  />
+                  <For each={entry.values}>
+                    {(value, point) => (
+                      <circle cx={x(point())} cy={y(value)} r="2" fill={entry.color} />
+                    )}
+                  </For>
+                  <Show when={(bands()[index()] ?? []).length > 0}>
+                    <circle
+                      cx={x(pointCount() - 1)}
+                      cy={y((bands()[index()] ?? [])[pointCount() - 1]?.mid ?? 0)}
+                      r="3"
+                      fill={entry.color}
                     />
-                    {entry.label}
-                  </span>
-                )}
-              </For>
-            </div>
+                  </Show>
+                </>
+              )}
+            </For>
+            <For each={labelIndexes()}>
+              {(index) => (
+                <text
+                  x={x(index)}
+                  y={CHART_HEIGHT - 12}
+                  text-anchor="middle"
+                  font-size="11"
+                  fill="currentColor"
+                >
+                  {(merged.labels ?? [])[index]}
+                </text>
+              )}
+            </For>
+          </svg>
+          <div class="flex flex-wrap gap-x-4 gap-y-1 pt-2 text-xs">
+            <For each={entries()}>
+              {(entry) => (
+                <span class="inline-flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-2.5 w-2.5 rounded-sm"
+                    style={{ "background-color": entry.color }}
+                  />
+                  {entry.label}
+                </span>
+              )}
+            </For>
           </div>
           <Show when={merged.caption}>
             {(caption) => <figcaption class="pt-2 text-xs opacity-70">{caption()}</figcaption>}


### PR DESCRIPTION
Adds a satirical /poll report page in the style of a serious pollster release: support table with changes, seat projection, bloc arithmetic, media summary statement, and methodology notes.

Trend bands render through a new generic Tomui Bollinger component (@tom/ui/tomui/bollinger), fed by a poll feature component (PollTrendChart). All numbers are random per visit and regenerate via Spin it again.

Live preview: https://dev-web.tom.so/poll

Checks: web tests 74 pass, web typecheck passes, oxlint clean, oxfmt clean. Note: packages/ui typecheck has a pre-existing link.tsx error, untouched by this change.