### PR TITLE
feat(web): public Are.na channel canvas route

### DIFF
--- a/apps/adapter/src/__tests__/arena-cache.test.ts
+++ b/apps/adapter/src/__tests__/arena-cache.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { app } from "../index";
+import { jsonResponse, requestWithEnv, testEnv } from "../test/helpers";
+
+const fetchMock = vi.fn();
+
+const mockArenaBody = <T>(body: T): void => {
+  fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(body)));
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const env = testEnv();
+
+const publicChannel = {
+  id: 1001,
+  type: "Channel",
+  slug: "philemon",
+  title: "Philemon",
+  description: null,
+  state: "available",
+  visibility: "public",
+  created_at: "2021-01-01T00:00:00.000Z",
+  updated_at: "2023-06-01T00:00:00.000Z",
+  metadata: null,
+  owner: null,
+  counts: { blocks: 0, channels: 0, contents: 0, collaborators: 0 },
+  collaborators: [],
+};
+
+const contentsBody = {
+  data: [],
+  meta: {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    per_page: 100,
+    total_pages: 0,
+    total_count: 0,
+    has_more_pages: false,
+  },
+};
+
+describe("arena public cache", () => {
+  it("marks channel contents responses cacheable", async () => {
+    mockArenaBody(contentsBody);
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/arena/channels/philemon/contents?per=100", env),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("max-age=600");
+  });
+
+  it("marks channel responses cacheable", async () => {
+    mockArenaBody(publicChannel);
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/arena/channels/philemon", env),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("max-age=600");
+  });
+
+  it("hides private channels behind not found", async () => {
+    mockArenaBody({ ...publicChannel, visibility: "private" });
+    const response = await app.fetch(requestWithEnv("http://localhost/arena/channels/secret", env));
+    expect(response.status).toBe(404);
+  });
+
+  it("strips private items from channel contents", async () => {
+    mockArenaBody({
+      ...contentsBody,
+      data: [
+        { id: 1, type: "Text", visibility: "public" },
+        { id: 2, type: "Text", visibility: "private" },
+        { id: 3, type: "Channel", visibility: "closed" },
+        { id: 4, type: "Channel", visibility: "private" },
+      ],
+    });
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/arena/channels/philemon/contents?per=100", env),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.map((item: { id: number }) => item.id)).toEqual([1, 3]);
+  });
+});

--- a/apps/adapter/src/integrations/arena/index.ts
+++ b/apps/adapter/src/integrations/arena/index.ts
@@ -15,6 +15,22 @@ import { paginationQuerySchema, searchQuerySchema, type PaginationQuery } from "
 
 const ChannelSlugParamsSchema = Schema.toStandardSchemaV1(Schema.Struct({ slug: Schema.String }));
 
+const PUBLIC_ARENA_CACHE_CONTROL =
+  "public, max-age=600, s-maxage=3600, stale-while-revalidate=86400";
+
+/**
+ * The canvas serves public channels with the authenticated client for the
+ * higher rate tier, so private items the token can see must stay filtered.
+ */
+const withoutPrivateItems = <
+  T extends { readonly data: ReadonlyArray<{ readonly visibility?: string }> },
+>(
+  response: T,
+): T => ({
+  ...response,
+  data: response.data.filter((item) => item.visibility !== "private"),
+});
+
 const IdOrSlugParamsSchema = Schema.toStandardSchemaV1(
   Schema.Struct({
     id: Schema.Union([Schema.NumberFromString, Schema.String]),
@@ -92,12 +108,27 @@ export const arenaIntegration = new Elysia({ name: "arena" })
   )
   .get(
     "/arena/channels/:slug",
-    ({ params, request }) => {
+    ({ params, request, set }) => {
+      set.headers["Cache-Control"] = PUBLIC_ARENA_CACHE_CONTROL;
       return runArena(
         request,
-        (client) => client.channel(params.slug).get(),
+        (client) =>
+          client
+            .channel(params.slug)
+            .get()
+            .pipe(
+              Effect.flatMap((channel) =>
+                channel.visibility === "private"
+                  ? Effect.fail(
+                      new HttpError({
+                        message: "Channel not found",
+                        status: HttpStatus.NotFound,
+                      }),
+                    )
+                  : Effect.succeed(channel),
+              ),
+            ),
         logContextFromRequest(request, "tom-adapter"),
-        "public",
       );
     },
     {
@@ -108,12 +139,16 @@ export const arenaIntegration = new Elysia({ name: "arena" })
   )
   .get(
     "/arena/channels/:slug/contents",
-    ({ params, query, request }) => {
+    ({ params, query, request, set }) => {
+      set.headers["Cache-Control"] = PUBLIC_ARENA_CACHE_CONTROL;
       return runArena(
         request,
-        (client) => client.channel(params.slug).contents(toPaginationAttributes(query)),
+        (client) =>
+          client
+            .channel(params.slug)
+            .contents(toPaginationAttributes(query))
+            .pipe(Effect.map(withoutPrivateItems)),
         logContextFromRequest(request, "tom-adapter"),
-        "public",
       );
     },
     {
@@ -124,7 +159,8 @@ export const arenaIntegration = new Elysia({ name: "arena" })
   )
   .get(
     "/arena/channels/:slug/thumb",
-    ({ params, request }) => {
+    ({ params, request, set }) => {
+      set.headers["Cache-Control"] = PUBLIC_ARENA_CACHE_CONTROL;
       return runArena(
         request,
         (client) => client.channel(params.slug).thumb(),

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,4 +1,6 @@
 import { QueryClientProvider } from "@tanstack/solid-query";
+import { useLocation } from "@solidjs/router";
+import { Show, createMemo } from "solid-js";
 import { Footer } from "@tom/ui/Footer";
 import { Nav } from "@tom/ui/Nav";
 import { ProgressBar } from "@tom/ui/ProgressBar";
@@ -10,14 +12,23 @@ import "./app.css";
 
 function RootLayout(props: { children: import("@solidjs/web").JSX.Element }) {
   useColorMode();
+  const location = useLocation();
+  const isCanvas = createMemo(() => location.pathname.startsWith("/canvas"));
   return (
-    <div class="min-h-screen flex flex-col">
-      <SkipLink />
-      <ProgressBar />
-      <Nav />
-      <div class="flex-1">{props.children}</div>
-      <Footer />
-    </div>
+    <Show
+      when={isCanvas()}
+      fallback={
+        <div class="min-h-screen flex flex-col">
+          <SkipLink />
+          <ProgressBar />
+          <Nav />
+          <div class="flex-1">{props.children}</div>
+          <Footer />
+        </div>
+      }
+    >
+      <div class="h-dvh w-full overflow-hidden">{props.children}</div>
+    </Show>
   );
 }
 

--- a/apps/web/src/components/Arena.tsx
+++ b/apps/web/src/components/Arena.tsx
@@ -20,7 +20,7 @@ const asBlock = <T extends ArenaBlock["type"]>(
 ): Extract<ArenaBlock, { type: T }> | null =>
   block.type === type ? (block as Extract<ArenaBlock, { type: T }>) : null;
 
-const formatFileSize = (bytes?: number | null): string => {
+export const formatFileSize = (bytes?: number | null): string => {
   if (!bytes) return "";
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -171,7 +171,7 @@ interface ArenaBlockItemProps {
   block: ArenaBlock;
 }
 
-function ArenaBlockItem(props: ArenaBlockItemProps) {
+export function ArenaBlockItem(props: ArenaBlockItemProps) {
   const block = () => props.block;
 
   return (

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -1,0 +1,421 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/solid-query";
+import { Effect } from "effect";
+import { For, Show, createEffect, createMemo, createSignal, onSettled } from "solid-js";
+import { isServer } from "@solidjs/web";
+import { Metadata } from "@tom/ui/Meta";
+import { Dialog } from "@tom/ui/tomui/dialog";
+import { Loader } from "@tom/ui/tomui/loader";
+import type { ArenaBlock, ArenaChannelContents } from "@tom/schemas/arena";
+import { fetchChannel, fetchChannelContentsPage } from "~/server/adapter";
+import { computeCanvasLayout } from "~/libs/canvas/layout";
+import { ArenaBlockItem } from "~/components/Arena";
+import { CanvasTile, ChannelTile, describeCanvasItem } from "./CanvasTile";
+
+const CANVAS_PAGE_SIZE = 100;
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 2.5;
+
+const clampScale = (value: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+
+export function CanvasChannel(props: { slug: string }) {
+  const slug = () => props.slug;
+  const [x, setX] = createSignal(0);
+  const [y, setY] = createSignal(0);
+  const [scale, setScale] = createSignal(1);
+  const [selected, setSelected] = createSignal<ArenaBlock | null>(null);
+  const camera = { x: 0, y: 0, scale: 1, centered: false };
+  const drag = {
+    active: false,
+    moved: false,
+    lastX: 0,
+    lastY: 0,
+    startX: 0,
+    startY: 0,
+    x: 0,
+    y: 0,
+  };
+  const sentinel = { el: null as HTMLDivElement | null };
+  let viewport: HTMLDivElement | undefined;
+
+  const channelQuery = useQuery(() => ({
+    queryKey: ["canvas-channel", slug()],
+    queryFn: () => fetchChannel(slug()),
+    enabled: slug().length > 0,
+    deferStream: true,
+  }));
+
+  const contentsQuery = useInfiniteQuery(() => ({
+    queryKey: ["canvas-contents", slug()],
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      fetchChannelContentsPage(slug(), pageParam, CANVAS_PAGE_SIZE),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.meta.has_more_pages) return undefined;
+      return lastPage.meta.next_page ?? lastPage.meta.current_page + 1;
+    },
+    enabled: slug().length > 0,
+  }));
+
+  const blocks = createMemo(
+    (): ReadonlyArray<ArenaChannelContents> =>
+      contentsQuery.data?.pages.flatMap((page) => page.data) ?? [],
+  );
+
+  const blockById = createMemo(() => new Map(blocks().map((block) => [String(block.id), block])));
+
+  const positioned = createMemo(() => {
+    const current = Effect.runSync(
+      computeCanvasLayout({ slug: slug(), items: blocks().map(describeCanvasItem) }),
+    );
+    return {
+      bounds: current.bounds,
+      tiles: current.tiles.map((tile) => ({
+        ...tile,
+        x: tile.x - current.bounds.minX,
+        y: tile.y - current.bounds.minY,
+      })),
+    };
+  });
+
+  const totalCount = createMemo(
+    () => contentsQuery.data?.pages[0]?.meta.total_count ?? blocks().length,
+  );
+
+  const pageTitle = createMemo(() => channelQuery.data?.title || slug());
+  const pageDescription = createMemo(
+    () => channelQuery.data?.description?.markdown?.slice(0, 160) ?? "",
+  );
+
+  const transform = createMemo(() => `translate(${x()}px, ${y()}px) scale(${scale()})`);
+
+  const syncCamera = (): void => {
+    setX(camera.x);
+    setY(camera.y);
+    setScale(camera.scale);
+  };
+
+  const centerCamera = (): void => {
+    if (!viewport || isServer) return;
+    const rect = viewport.getBoundingClientRect();
+    camera.x = rect.width / 2 - positioned().bounds.width / 2;
+    camera.y = rect.height / 2 - positioned().bounds.height / 2;
+    camera.scale = 1;
+    syncCamera();
+  };
+
+  const zoomAt = (clientX: number, clientY: number, factor: number): void => {
+    if (!viewport) return;
+    const next = clampScale(camera.scale * factor);
+    const rect = viewport.getBoundingClientRect();
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
+    camera.x = px - ((px - camera.x) / camera.scale) * next;
+    camera.y = py - ((py - camera.y) / camera.scale) * next;
+    camera.scale = next;
+    syncCamera();
+  };
+
+  const zoomCenter = (factor: number): void => {
+    if (!viewport) return;
+    const rect = viewport.getBoundingClientRect();
+    zoomAt(rect.left + rect.width / 2, rect.top + rect.height / 2, factor);
+  };
+
+  const openBlock = (block: ArenaBlock): void => {
+    if (drag.moved) return;
+    setSelected(block);
+  };
+
+  const onPointerDown = (event: PointerEvent): void => {
+    drag.active = true;
+    drag.moved = false;
+    drag.lastX = event.clientX;
+    drag.lastY = event.clientY;
+    drag.startX = event.clientX;
+    drag.startY = event.clientY;
+    drag.x = camera.x;
+    drag.y = camera.y;
+    viewport?.setPointerCapture(event.pointerId);
+  };
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (!drag.active) return;
+    const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
+    if (distance > 4) drag.moved = true;
+    drag.x += event.clientX - drag.lastX;
+    drag.y += event.clientY - drag.lastY;
+    drag.lastX = event.clientX;
+    drag.lastY = event.clientY;
+    camera.x = drag.x;
+    camera.y = drag.y;
+    syncCamera();
+  };
+
+  const endPointer = (): void => {
+    drag.active = false;
+  };
+
+  const observeSentinel = (element: HTMLDivElement): void => {
+    sentinel.el = element;
+  };
+
+  createEffect(
+    () => positioned().bounds.width,
+    (width) => {
+      if (width === 0 || camera.centered || !viewport || isServer) return;
+      if (blocks().length === 0) return;
+      centerCamera();
+      camera.centered = true;
+    },
+  );
+
+  createEffect(
+    () => contentsQuery.error,
+    (error) => {
+      if (error) {
+        void Effect.runFork(Effect.logWarning(`[canvas] contents failed for "${slug()}"`));
+      }
+    },
+  );
+
+  createEffect(
+    () => ({
+      pages: contentsQuery.data?.pages.length ?? 0,
+      more: contentsQuery.hasNextPage,
+    }),
+    () => {
+      const element = sentinel.el;
+      if (!element || isServer || !("IntersectionObserver" in globalThis)) return;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) void contentsQuery.fetchNextPage();
+        },
+        { rootMargin: "1200px" },
+      );
+      observer.observe(element);
+      return () => observer.disconnect();
+    },
+  );
+
+  onSettled(() => {
+    if (isServer || !viewport) return;
+    const element = viewport;
+    const onWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      zoomAt(event.clientX, event.clientY, Math.exp(-event.deltaY * 0.0015));
+    };
+    element.addEventListener("wheel", onWheel, { passive: false });
+    const onKey = (event: KeyboardEvent): void => {
+      if (selected() !== null) {
+        if (event.key === "Escape") setSelected(null);
+        return;
+      }
+      const step = 60 / camera.scale;
+      if (event.key === "ArrowLeft") {
+        camera.x += step;
+        syncCamera();
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        camera.x -= step;
+        syncCamera();
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        camera.y += step;
+        syncCamera();
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        camera.y -= step;
+        syncCamera();
+        return;
+      }
+      if (event.key === "+" || event.key === "=") {
+        zoomCenter(1.2);
+        return;
+      }
+      if (event.key === "-") {
+        zoomCenter(1 / 1.2);
+        return;
+      }
+      if (event.key === "0") {
+        centerCamera();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      element.removeEventListener("wheel", onWheel);
+      window.removeEventListener("keydown", onKey);
+    };
+  });
+
+  return (
+    <div class="relative h-full w-full overflow-hidden bg-neutral-100 dark:bg-neutral-950">
+      <Metadata
+        title={`Canvas ${pageTitle()}`}
+        metaType="description"
+        metaContent={pageDescription() || `Are.na channel ${slug()} as an open canvas.`}
+        canonical={`https://tom.so/canvas/${slug()}`}
+      />
+      <header class="absolute inset-x-0 top-0 z-20 flex items-center gap-2 border-b border-black/10 bg-white/90 px-3 py-2 backdrop-blur dark:border-white/10 dark:bg-neutral-900/90">
+        <a href="/" class="text-sm underline" aria-label="Back home">
+          Home
+        </a>
+        <div class="min-w-0 flex-1">
+          <h1 class="truncate text-sm font-medium">{pageTitle()}</h1>
+          <p class="text-[11px] opacity-60">
+            {blocks().length} of {totalCount()} blocks
+          </p>
+        </div>
+        <div class="flex items-center gap-1" role="toolbar" aria-label="Canvas controls">
+          <button
+            type="button"
+            class="rounded border border-black/10 px-2 py-1 text-sm"
+            aria-label="Zoom out"
+            onClick={() => zoomCenter(1 / 1.2)}
+          >
+            -
+          </button>
+          <button
+            type="button"
+            class="rounded border border-black/10 px-2 py-1 text-sm"
+            aria-label="Zoom in"
+            onClick={() => zoomCenter(1.2)}
+          >
+            +
+          </button>
+          <button
+            type="button"
+            class="rounded border border-black/10 px-2 py-1 text-sm"
+            onClick={centerCamera}
+          >
+            Reset
+          </button>
+        </div>
+        <a
+          href={`https://are.na/tom/${slug()}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs underline"
+        >
+          Source
+        </a>
+      </header>
+      <Show
+        when={!contentsQuery.isLoading}
+        fallback={
+          <div class="absolute inset-0 top-14 flex items-center justify-center">
+            <Loader />
+          </div>
+        }
+      >
+        <Show
+          when={!contentsQuery.error}
+          fallback={
+            <div class="absolute inset-0 top-14 flex flex-col items-center justify-center gap-3 p-6 text-center">
+              <p class="text-sm">This channel cannot load.</p>
+              <button
+                type="button"
+                class="rounded border border-black/10 px-3 py-1 text-sm underline"
+                onClick={() => void contentsQuery.refetch()}
+              >
+                Retry
+              </button>
+            </div>
+          }
+        >
+          <Show
+            when={blocks().length > 0}
+            fallback={
+              <div class="absolute inset-0 top-14 flex items-center justify-center p-6 text-center">
+                <p class="text-sm">This channel holds no blocks.</p>
+              </div>
+            }
+          >
+            <div
+              ref={(element) => {
+                viewport = element;
+              }}
+              class="absolute inset-x-0 bottom-0 top-14 touch-none select-none overflow-hidden"
+              onPointerDown={onPointerDown}
+              onPointerMove={onPointerMove}
+              onPointerUp={endPointer}
+              onPointerCancel={endPointer}
+            >
+              <div
+                class="absolute left-0 top-0 will-change-transform"
+                style={{
+                  width: `${positioned().bounds.width}px`,
+                  height: `${positioned().bounds.height}px`,
+                  transform: transform(),
+                }}
+              >
+                <For each={positioned().tiles}>
+                  {(tile) => {
+                    const found = blockById().get(tile.id);
+                    if (!found) return null;
+                    if (!("base_type" in found)) {
+                      return <ChannelTile slug={found.slug} title={found.title} layout={tile} />;
+                    }
+                    return <CanvasTile item={found} layout={tile} onOpen={openBlock} />;
+                  }}
+                </For>
+                <div
+                  ref={observeSentinel}
+                  class="absolute h-1 w-1"
+                  style={{
+                    left: `${positioned().bounds.width / 2}px`,
+                    top: `${positioned().bounds.height - 4}px`,
+                  }}
+                />
+              </div>
+            </div>
+            <div class="absolute inset-x-0 bottom-0 z-20 flex justify-center pb-3">
+              <Show when={contentsQuery.hasNextPage}>
+                <button
+                  type="button"
+                  class="rounded-full border border-black/10 bg-white/90 px-4 py-1 text-xs shadow backdrop-blur dark:bg-neutral-900/90"
+                  onClick={() => void contentsQuery.fetchNextPage()}
+                >
+                  <Show
+                    when={contentsQuery.isFetchingNextPage}
+                    fallback={`Load more (${blocks().length} of ${totalCount()})`}
+                  >
+                    Loading more
+                  </Show>
+                </button>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </Show>
+      <Dialog.Root
+        open={selected() !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      >
+        <Dialog size="xl" class="max-h-[85vh] overflow-auto p-6">
+          <Show when={selected()}>
+            {(block) => (
+              <>
+                <Dialog.Title class="pr-8 text-lg font-semibold">
+                  {block().title || `${block().type} block`}
+                </Dialog.Title>
+                <div class="mt-4">
+                  <ArenaBlockItem block={block()} />
+                </div>
+                <div class="mt-4 flex justify-end">
+                  <Dialog.Close class="rounded border border-black/10 px-3 py-1 text-sm">
+                    Close
+                  </Dialog.Close>
+                </div>
+              </>
+            )}
+          </Show>
+        </Dialog>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/solid-query";
 import { Effect } from "effect";
-import { For, Show, createEffect, createMemo, createSignal, onSettled } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, onSettled } from "solid-js";
 import { isServer } from "@solidjs/web";
 import { Metadata } from "@tom/ui/Meta";
 import { Button, buttonVariants } from "@tom/ui/tomui/button";
@@ -15,6 +15,9 @@ import { CanvasTile, ChannelTile, describeCanvasItem } from "./CanvasTile";
 const CANVAS_PAGE_SIZE = 100;
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 2.5;
+const PAGE_FETCH_GAP_MS = 800;
+const PAGE_RETRY_COUNT = 5;
+const PAGE_RETRY_MAX_DELAY_MS = 10000;
 
 const clampScale = (value: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
 
@@ -29,6 +32,7 @@ export function CanvasChannel(props: { slug: string }) {
   const [y, setY] = createSignal(0);
   const [scale, setScale] = createSignal(1);
   const [selected, setSelected] = createSignal<ArenaBlock | null>(null);
+  const [sentinelVisible, setSentinelVisible] = createSignal(false);
   const camera = { x: 0, y: 0, scale: 1, centered: false };
   const drag = {
     active: false,
@@ -43,6 +47,7 @@ export function CanvasChannel(props: { slug: string }) {
   const pointers = new Map<number, PointerPoint>();
   const pinch = { active: false, distance: 0, midX: 0, midY: 0 };
   const sentinel = { el: null as HTMLDivElement | null };
+  const pager = { lastFetch: 0, timer: null as ReturnType<typeof setTimeout> | null };
   let viewport: HTMLDivElement | undefined;
 
   const channelQuery = useQuery(() => ({
@@ -62,6 +67,8 @@ export function CanvasChannel(props: { slug: string }) {
       return lastPage.meta.next_page ?? lastPage.meta.current_page + 1;
     },
     enabled: slug().length > 0,
+    retry: PAGE_RETRY_COUNT,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, PAGE_RETRY_MAX_DELAY_MS),
   }));
 
   const blocks = createMemo(
@@ -145,7 +152,7 @@ export function CanvasChannel(props: { slug: string }) {
 
   const onPointerDown = (event: PointerEvent): void => {
     pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-    viewport?.setPointerCapture?.(event.pointerId);
+    if (event.pointerType === "mouse") viewport?.setPointerCapture?.(event.pointerId);
     if (pointers.size === 2) {
       drag.active = false;
       pinch.active = true;
@@ -244,12 +251,33 @@ export function CanvasChannel(props: { slug: string }) {
       if (!element || isServer || !("IntersectionObserver" in globalThis)) return;
       const observer = new IntersectionObserver(
         (entries) => {
-          if (entries[0]?.isIntersecting) void contentsQuery.fetchNextPage();
+          setSentinelVisible(entries[0]?.isIntersecting === true);
         },
         { rootMargin: "1200px" },
       );
       observer.observe(element);
       return () => observer.disconnect();
+    },
+  );
+
+  createEffect(
+    () => ({
+      visible: sentinelVisible(),
+      pages: contentsQuery.data?.pages.length ?? 0,
+      more: contentsQuery.hasNextPage,
+      fetching: contentsQuery.isFetching,
+    }),
+    (state) => {
+      onCleanup(() => {
+        if (pager.timer) clearTimeout(pager.timer);
+        pager.timer = null;
+      });
+      if (!state.visible || !state.more || state.fetching) return;
+      const wait = Math.max(0, PAGE_FETCH_GAP_MS - (Date.now() - pager.lastFetch));
+      pager.timer = setTimeout(() => {
+        pager.lastFetch = Date.now();
+        void contentsQuery.fetchNextPage();
+      }, wait);
     },
   );
 
@@ -261,6 +289,11 @@ export function CanvasChannel(props: { slug: string }) {
       zoomAt(event.clientX, event.clientY, Math.exp(-event.deltaY * 0.0015));
     };
     element.addEventListener("wheel", onWheel, { passive: false });
+    const stopGesture = (event: Event): void => {
+      event.preventDefault();
+    };
+    document.addEventListener("gesturestart", stopGesture);
+    document.addEventListener("gesturechange", stopGesture);
     const onKey = (event: KeyboardEvent): void => {
       if (selected() !== null) {
         if (event.key === "Escape") setSelected(null);
@@ -302,6 +335,8 @@ export function CanvasChannel(props: { slug: string }) {
     window.addEventListener("keydown", onKey);
     return () => {
       element.removeEventListener("wheel", onWheel);
+      document.removeEventListener("gesturestart", stopGesture);
+      document.removeEventListener("gesturechange", stopGesture);
       window.removeEventListener("keydown", onKey);
     };
   });
@@ -323,63 +358,63 @@ export function CanvasChannel(props: { slug: string }) {
         }
       >
         <Show
-          when={!contentsQuery.error}
+          when={blocks().length === 0 && contentsQuery.error !== null}
           fallback={
-            <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center">
-              <p class="text-sm">This channel cannot load.</p>
-              <Button variant="secondary" onClick={() => void contentsQuery.refetch()}>
-                Retry
-              </Button>
-            </div>
-          }
-        >
-          <Show
-            when={blocks().length > 0}
-            fallback={
-              <div class="absolute inset-0 flex items-center justify-center p-6 text-center">
-                <p class="text-sm">This channel holds no blocks.</p>
-              </div>
-            }
-          >
-            <div
-              ref={(element) => {
-                viewport = element;
-              }}
-              class="absolute inset-0 touch-none overflow-hidden select-none"
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={endPointer}
-              onPointerCancel={endPointer}
+            <Show
+              when={blocks().length > 0}
+              fallback={
+                <div class="absolute inset-0 flex items-center justify-center p-6 text-center">
+                  <p class="text-sm">This channel holds no blocks.</p>
+                </div>
+              }
             >
               <div
-                class="absolute left-0 top-0 will-change-transform"
-                style={{
-                  width: `${positioned().bounds.width}px`,
-                  height: `${positioned().bounds.height}px`,
-                  transform: transform(),
+                ref={(element) => {
+                  viewport = element;
                 }}
+                class="absolute inset-0 touch-none overflow-hidden select-none"
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={endPointer}
+                onPointerCancel={endPointer}
               >
-                <For each={positioned().tiles}>
-                  {(tile) => {
-                    const found = blockById().get(tile.id);
-                    if (!found) return null;
-                    if (!("base_type" in found)) {
-                      return <ChannelTile slug={found.slug} title={found.title} layout={tile} />;
-                    }
-                    return <CanvasTile item={found} layout={tile} onOpen={openBlock} />;
-                  }}
-                </For>
                 <div
-                  ref={observeSentinel}
-                  class="absolute h-1 w-1"
+                  class="absolute left-0 top-0 will-change-transform"
                   style={{
-                    left: `${positioned().bounds.width / 2}px`,
-                    top: `${positioned().bounds.height - 4}px`,
+                    width: `${positioned().bounds.width}px`,
+                    height: `${positioned().bounds.height}px`,
+                    transform: transform(),
                   }}
-                />
+                >
+                  <For each={positioned().tiles}>
+                    {(tile) => {
+                      const found = blockById().get(tile.id);
+                      if (!found) return null;
+                      if (!("base_type" in found)) {
+                        return <ChannelTile slug={found.slug} title={found.title} layout={tile} />;
+                      }
+                      return <CanvasTile item={found} layout={tile} onOpen={openBlock} />;
+                    }}
+                  </For>
+                  <div
+                    ref={observeSentinel}
+                    class="absolute h-1 w-1"
+                    style={{
+                      left: `${positioned().bounds.width / 2}px`,
+                      top: `${positioned().bounds.height - 4}px`,
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          </Show>
+            </Show>
+          }
+        >
+          <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center">
+            <p class="text-sm">This channel cannot load.</p>
+            <Button variant="secondary" onClick={() => void contentsQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
         </Show>
       </Show>
       <Dialog.Root

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -15,9 +15,12 @@ import { CanvasTile, ChannelTile, describeCanvasItem } from "./CanvasTile";
 const CANVAS_PAGE_SIZE = 100;
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 2.5;
+// Premium tier allows 300 requests per minute; backoff covers lower tiers.
 const PAGE_FETCH_GAP_MS = 800;
 const PAGE_RETRY_COUNT = 5;
 const PAGE_RETRY_MAX_DELAY_MS = 10000;
+const CANVAS_STALE_MS = 10 * 60 * 1000;
+const CANVAS_GC_MS = 60 * 60 * 1000;
 
 const clampScale = (value: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
 
@@ -47,7 +50,11 @@ export function CanvasChannel(props: { slug: string }) {
   const pointers = new Map<number, PointerPoint>();
   const pinch = { active: false, distance: 0, midX: 0, midY: 0 };
   const sentinel = { el: null as HTMLDivElement | null };
-  const pager = { lastFetch: 0, timer: null as ReturnType<typeof setTimeout> | null };
+  const pager = {
+    lastFetch: 0,
+    timer: null as ReturnType<typeof setTimeout> | null,
+    inView: false,
+  };
   let viewport: HTMLDivElement | undefined;
 
   const channelQuery = useQuery(() => ({
@@ -55,6 +62,8 @@ export function CanvasChannel(props: { slug: string }) {
     queryFn: () => fetchChannel(slug()),
     enabled: slug().length > 0,
     deferStream: true,
+    staleTime: CANVAS_STALE_MS,
+    gcTime: CANVAS_GC_MS,
   }));
 
   const contentsQuery = useInfiniteQuery(() => ({
@@ -69,6 +78,8 @@ export function CanvasChannel(props: { slug: string }) {
     enabled: slug().length > 0,
     retry: PAGE_RETRY_COUNT,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, PAGE_RETRY_MAX_DELAY_MS),
+    staleTime: CANVAS_STALE_MS,
+    gcTime: CANVAS_GC_MS,
   }));
 
   const blocks = createMemo(
@@ -251,7 +262,8 @@ export function CanvasChannel(props: { slug: string }) {
       if (!element || isServer || !("IntersectionObserver" in globalThis)) return;
       const observer = new IntersectionObserver(
         (entries) => {
-          setSentinelVisible(entries[0]?.isIntersecting === true);
+          pager.inView = entries[0]?.isIntersecting === true;
+          setSentinelVisible(pager.inView && document.visibilityState === "visible");
         },
         { rootMargin: "1200px" },
       );
@@ -276,7 +288,7 @@ export function CanvasChannel(props: { slug: string }) {
       const wait = Math.max(0, PAGE_FETCH_GAP_MS - (Date.now() - pager.lastFetch));
       pager.timer = setTimeout(() => {
         pager.lastFetch = Date.now();
-        void contentsQuery.fetchNextPage();
+        if (document.visibilityState === "visible") void contentsQuery.fetchNextPage();
       }, wait);
     },
   );
@@ -294,6 +306,10 @@ export function CanvasChannel(props: { slug: string }) {
     };
     document.addEventListener("gesturestart", stopGesture);
     document.addEventListener("gesturechange", stopGesture);
+    const onVisibility = (): void => {
+      setSentinelVisible(pager.inView && document.visibilityState === "visible");
+    };
+    document.addEventListener("visibilitychange", onVisibility);
     const onKey = (event: KeyboardEvent): void => {
       if (selected() !== null) {
         if (event.key === "Escape") setSelected(null);
@@ -337,6 +353,7 @@ export function CanvasChannel(props: { slug: string }) {
       element.removeEventListener("wheel", onWheel);
       document.removeEventListener("gesturestart", stopGesture);
       document.removeEventListener("gesturechange", stopGesture);
+      document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("keydown", onKey);
     };
   });

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -187,7 +187,9 @@ export function CanvasChannel(props: { slug: string }) {
 
   const onPointerMove = (event: PointerEvent): void => {
     if (!pointers.has(event.pointerId)) return;
-    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    const moves = event.getCoalescedEvents?.() ?? [];
+    const move = moves[moves.length - 1] ?? event;
+    pointers.set(event.pointerId, { x: move.clientX, y: move.clientY });
     if (pinch.active && pointers.size >= 2) {
       const distance = pointerDistance();
       const mid = pointerMidpoint();
@@ -201,12 +203,12 @@ export function CanvasChannel(props: { slug: string }) {
       return;
     }
     if (!drag.active) return;
-    const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
+    const distance = Math.hypot(move.clientX - drag.startX, move.clientY - drag.startY);
     if (distance > 4) drag.moved = true;
-    drag.x += event.clientX - drag.lastX;
-    drag.y += event.clientY - drag.lastY;
-    drag.lastX = event.clientX;
-    drag.lastY = event.clientY;
+    drag.x += move.clientX - drag.lastX;
+    drag.y += move.clientY - drag.lastY;
+    drag.lastX = move.clientX;
+    drag.lastY = move.clientY;
     camera.x = drag.x;
     camera.y = drag.y;
     syncCamera();
@@ -394,6 +396,7 @@ export function CanvasChannel(props: { slug: string }) {
                 onPointerMove={onPointerMove}
                 onPointerUp={endPointer}
                 onPointerCancel={endPointer}
+                onContextMenu={(event) => event.preventDefault()}
               >
                 <div
                   class="absolute left-0 top-0 will-change-transform"

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -8,13 +8,15 @@ import { Dialog } from "@tom/ui/tomui/dialog";
 import { Loader } from "@tom/ui/tomui/loader";
 import type { ArenaBlock, ArenaChannelContents } from "@tom/schemas/arena";
 import { fetchChannel, fetchChannelContentsPage } from "~/server/adapter";
-import { computeCanvasLayout } from "~/libs/canvas/layout";
+import { computeCanvasLayout, tileIntersectsView } from "~/libs/canvas/layout";
+import type { WorldView } from "~/libs/canvas/layout";
 import { ArenaBlockItem } from "~/components/Arena";
-import { CanvasTile, ChannelTile, describeCanvasItem } from "./CanvasTile";
+import { CanvasTile, ChannelTile, CulledTile, describeCanvasItem } from "./CanvasTile";
 
 const CANVAS_PAGE_SIZE = 100;
-const MIN_SCALE = 0.25;
 const MAX_SCALE = 2.5;
+const DETAIL_SCALE = 0.55;
+const MIN_SCALE_FLOOR = 0.12;
 // Premium tier allows 300 requests per minute; backoff covers lower tiers.
 const PAGE_FETCH_GAP_MS = 800;
 const PAGE_RETRY_COUNT = 5;
@@ -22,7 +24,10 @@ const PAGE_RETRY_MAX_DELAY_MS = 10000;
 const CANVAS_STALE_MS = 10 * 60 * 1000;
 const CANVAS_GC_MS = 60 * 60 * 1000;
 
-const clampScale = (value: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+interface ViewportSize {
+  readonly width: number;
+  readonly height: number;
+}
 
 interface PointerPoint {
   readonly x: number;
@@ -36,6 +41,7 @@ export function CanvasChannel(props: { slug: string }) {
   const [scale, setScale] = createSignal(1);
   const [selected, setSelected] = createSignal<ArenaBlock | null>(null);
   const [sentinelVisible, setSentinelVisible] = createSignal(false);
+  const [viewportSize, setViewportSize] = createSignal<ViewportSize>({ width: 0, height: 0 });
   const camera = { x: 0, y: 0, scale: 1, centered: false };
   const drag = {
     active: false,
@@ -109,6 +115,33 @@ export function CanvasChannel(props: { slug: string }) {
 
   const transform = createMemo(() => `translate(${x()}px, ${y()}px) scale(${scale()})`);
 
+  const minZoom = createMemo(() => {
+    const bounds = positioned().bounds;
+    const size = viewportSize();
+    if (bounds.width === 0 || size.width === 0) return MIN_SCALE_FLOOR;
+    const fit = Math.min(size.width / bounds.width, size.height / bounds.height);
+    return Math.max(MIN_SCALE_FLOOR, Math.min(fit, 0.5));
+  });
+
+  const clampZoom = (value: number): number => Math.min(MAX_SCALE, Math.max(minZoom(), value));
+
+  const detailVisible = createMemo(() => scale() >= DETAIL_SCALE);
+
+  const visibleWorld = createMemo((): WorldView => {
+    const zoom = scale();
+    const size = viewportSize();
+    if (size.width === 0 && size.height === 0) {
+      return { minX: -Infinity, minY: -Infinity, maxX: Infinity, maxY: Infinity };
+    }
+    const margin = Math.max(size.width, size.height) / Math.max(zoom, MIN_SCALE_FLOOR);
+    return {
+      minX: -x() / zoom - margin,
+      minY: -y() / zoom - margin,
+      maxX: (-x() + size.width) / zoom + margin,
+      maxY: (-y() + size.height) / zoom + margin,
+    };
+  });
+
   const syncCamera = (): void => {
     setX(camera.x);
     setY(camera.y);
@@ -126,7 +159,7 @@ export function CanvasChannel(props: { slug: string }) {
 
   const zoomAt = (clientX: number, clientY: number, factor: number): void => {
     if (!viewport) return;
-    const next = clampScale(camera.scale * factor);
+    const next = clampZoom(camera.scale * factor);
     const rect = viewport.getBoundingClientRect();
     const px = clientX - rect.left;
     const py = clientY - rect.top;
@@ -303,6 +336,11 @@ export function CanvasChannel(props: { slug: string }) {
       zoomAt(event.clientX, event.clientY, Math.exp(-event.deltaY * 0.0015));
     };
     element.addEventListener("wheel", onWheel, { passive: false });
+    const measure = (): void => {
+      setViewportSize({ width: element.clientWidth, height: element.clientHeight });
+    };
+    measure();
+    window.addEventListener("resize", measure);
     const stopGesture = (event: Event): void => {
       event.preventDefault();
     };
@@ -356,6 +394,7 @@ export function CanvasChannel(props: { slug: string }) {
       document.removeEventListener("gesturestart", stopGesture);
       document.removeEventListener("gesturechange", stopGesture);
       document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("resize", measure);
       window.removeEventListener("keydown", onKey);
     };
   });
@@ -391,7 +430,7 @@ export function CanvasChannel(props: { slug: string }) {
                 ref={(element) => {
                   viewport = element;
                 }}
-                class="absolute inset-0 touch-none overflow-hidden select-none"
+                class="absolute inset-0 touch-none overflow-hidden bg-[radial-gradient(circle,rgb(0_0_0/0.14)_1px,transparent_1px)] bg-[size:28px_28px] select-none dark:bg-[radial-gradient(circle,rgb(255_255_255/0.14)_1px,transparent_1px)]"
                 onPointerDown={onPointerDown}
                 onPointerMove={onPointerMove}
                 onPointerUp={endPointer}
@@ -410,10 +449,24 @@ export function CanvasChannel(props: { slug: string }) {
                     {(tile) => {
                       const found = blockById().get(tile.id);
                       if (!found) return null;
+                      const inView = tileIntersectsView(tile, visibleWorld());
                       if (!("base_type" in found)) {
-                        return <ChannelTile slug={found.slug} title={found.title} layout={tile} />;
+                        return (
+                          <CulledTile layout={tile} visible={inView}>
+                            <ChannelTile slug={found.slug} title={found.title} layout={tile} />
+                          </CulledTile>
+                        );
                       }
-                      return <CanvasTile item={found} layout={tile} onOpen={openBlock} />;
+                      return (
+                        <CulledTile layout={tile} visible={inView}>
+                          <CanvasTile
+                            item={found}
+                            layout={tile}
+                            detail={detailVisible()}
+                            onOpen={openBlock}
+                          />
+                        </CulledTile>
+                      );
                     }}
                   </For>
                   <div

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { For, Show, createEffect, createMemo, createSignal, onSettled } from "solid-js";
 import { isServer } from "@solidjs/web";
 import { Metadata } from "@tom/ui/Meta";
+import { Button, buttonVariants } from "@tom/ui/tomui/button";
 import { Dialog } from "@tom/ui/tomui/dialog";
 import { Loader } from "@tom/ui/tomui/loader";
 import type { ArenaBlock, ArenaChannelContents } from "@tom/schemas/arena";
@@ -16,6 +17,11 @@ const MIN_SCALE = 0.25;
 const MAX_SCALE = 2.5;
 
 const clampScale = (value: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+
+interface PointerPoint {
+  readonly x: number;
+  readonly y: number;
+}
 
 export function CanvasChannel(props: { slug: string }) {
   const slug = () => props.slug;
@@ -34,6 +40,8 @@ export function CanvasChannel(props: { slug: string }) {
     x: 0,
     y: 0,
   };
+  const pointers = new Map<number, PointerPoint>();
+  const pinch = { active: false, distance: 0, midX: 0, midY: 0 };
   const sentinel = { el: null as HTMLDivElement | null };
   let viewport: HTMLDivElement | undefined;
 
@@ -76,11 +84,6 @@ export function CanvasChannel(props: { slug: string }) {
       })),
     };
   });
-
-  const totalCount = createMemo(
-    () => contentsQuery.data?.pages[0]?.meta.total_count ?? blocks().length,
-  );
-
   const pageTitle = createMemo(() => channelQuery.data?.title || slug());
   const pageDescription = createMemo(
     () => channelQuery.data?.description?.markdown?.slice(0, 160) ?? "",
@@ -126,7 +129,34 @@ export function CanvasChannel(props: { slug: string }) {
     setSelected(block);
   };
 
+  const pointerMidpoint = (): PointerPoint => {
+    const points = [...pointers.values()];
+    const first = points[0] ?? { x: 0, y: 0 };
+    const second = points[1] ?? first;
+    return { x: (first.x + second.x) / 2, y: (first.y + second.y) / 2 };
+  };
+
+  const pointerDistance = (): number => {
+    const points = [...pointers.values()];
+    const first = points[0] ?? { x: 0, y: 0 };
+    const second = points[1] ?? first;
+    return Math.hypot(first.x - second.x, first.y - second.y);
+  };
+
   const onPointerDown = (event: PointerEvent): void => {
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    viewport?.setPointerCapture?.(event.pointerId);
+    if (pointers.size === 2) {
+      drag.active = false;
+      pinch.active = true;
+      drag.moved = true;
+      pinch.distance = pointerDistance();
+      const mid = pointerMidpoint();
+      pinch.midX = mid.x;
+      pinch.midY = mid.y;
+      return;
+    }
+    if (pointers.size > 2) return;
     drag.active = true;
     drag.moved = false;
     drag.lastX = event.clientX;
@@ -135,10 +165,23 @@ export function CanvasChannel(props: { slug: string }) {
     drag.startY = event.clientY;
     drag.x = camera.x;
     drag.y = camera.y;
-    viewport?.setPointerCapture(event.pointerId);
   };
 
   const onPointerMove = (event: PointerEvent): void => {
+    if (!pointers.has(event.pointerId)) return;
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    if (pinch.active && pointers.size >= 2) {
+      const distance = pointerDistance();
+      const mid = pointerMidpoint();
+      if (pinch.distance > 0) zoomAt(mid.x, mid.y, distance / pinch.distance);
+      camera.x += mid.x - pinch.midX;
+      camera.y += mid.y - pinch.midY;
+      syncCamera();
+      pinch.distance = distance;
+      pinch.midX = mid.x;
+      pinch.midY = mid.y;
+      return;
+    }
     if (!drag.active) return;
     const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
     if (distance > 4) drag.moved = true;
@@ -151,8 +194,21 @@ export function CanvasChannel(props: { slug: string }) {
     syncCamera();
   };
 
-  const endPointer = (): void => {
-    drag.active = false;
+  const endPointer = (event: PointerEvent): void => {
+    pointers.delete(event.pointerId);
+    if (pointers.size < 2) pinch.active = false;
+    if (pointers.size === 1) {
+      const remaining = [...pointers.values()][0] ?? { x: 0, y: 0 };
+      drag.active = true;
+      drag.lastX = remaining.x;
+      drag.lastY = remaining.y;
+      drag.startX = remaining.x;
+      drag.startY = remaining.y;
+      drag.x = camera.x;
+      drag.y = camera.y;
+      return;
+    }
+    if (pointers.size === 0) drag.active = false;
   };
 
   const observeSentinel = (element: HTMLDivElement): void => {
@@ -258,54 +314,10 @@ export function CanvasChannel(props: { slug: string }) {
         metaContent={pageDescription() || `Are.na channel ${slug()} as an open canvas.`}
         canonical={`https://tom.so/canvas/${slug()}`}
       />
-      <header class="absolute inset-x-0 top-0 z-20 flex items-center gap-2 border-b border-black/10 bg-white/90 px-3 py-2 backdrop-blur dark:border-white/10 dark:bg-neutral-900/90">
-        <a href="/" class="text-sm underline" aria-label="Back home">
-          Home
-        </a>
-        <div class="min-w-0 flex-1">
-          <h1 class="truncate text-sm font-medium">{pageTitle()}</h1>
-          <p class="text-[11px] opacity-60">
-            {blocks().length} of {totalCount()} blocks
-          </p>
-        </div>
-        <div class="flex items-center gap-1" role="toolbar" aria-label="Canvas controls">
-          <button
-            type="button"
-            class="rounded border border-black/10 px-2 py-1 text-sm"
-            aria-label="Zoom out"
-            onClick={() => zoomCenter(1 / 1.2)}
-          >
-            -
-          </button>
-          <button
-            type="button"
-            class="rounded border border-black/10 px-2 py-1 text-sm"
-            aria-label="Zoom in"
-            onClick={() => zoomCenter(1.2)}
-          >
-            +
-          </button>
-          <button
-            type="button"
-            class="rounded border border-black/10 px-2 py-1 text-sm"
-            onClick={centerCamera}
-          >
-            Reset
-          </button>
-        </div>
-        <a
-          href={`https://are.na/tom/${slug()}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-xs underline"
-        >
-          Source
-        </a>
-      </header>
       <Show
         when={!contentsQuery.isLoading}
         fallback={
-          <div class="absolute inset-0 top-14 flex items-center justify-center">
+          <div class="absolute inset-0 flex items-center justify-center">
             <Loader />
           </div>
         }
@@ -313,22 +325,18 @@ export function CanvasChannel(props: { slug: string }) {
         <Show
           when={!contentsQuery.error}
           fallback={
-            <div class="absolute inset-0 top-14 flex flex-col items-center justify-center gap-3 p-6 text-center">
+            <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center">
               <p class="text-sm">This channel cannot load.</p>
-              <button
-                type="button"
-                class="rounded border border-black/10 px-3 py-1 text-sm underline"
-                onClick={() => void contentsQuery.refetch()}
-              >
+              <Button variant="secondary" onClick={() => void contentsQuery.refetch()}>
                 Retry
-              </button>
+              </Button>
             </div>
           }
         >
           <Show
             when={blocks().length > 0}
             fallback={
-              <div class="absolute inset-0 top-14 flex items-center justify-center p-6 text-center">
+              <div class="absolute inset-0 flex items-center justify-center p-6 text-center">
                 <p class="text-sm">This channel holds no blocks.</p>
               </div>
             }
@@ -337,7 +345,7 @@ export function CanvasChannel(props: { slug: string }) {
               ref={(element) => {
                 viewport = element;
               }}
-              class="absolute inset-x-0 bottom-0 top-14 touch-none select-none overflow-hidden"
+              class="absolute inset-0 touch-none overflow-hidden select-none"
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
               onPointerUp={endPointer}
@@ -371,22 +379,6 @@ export function CanvasChannel(props: { slug: string }) {
                 />
               </div>
             </div>
-            <div class="absolute inset-x-0 bottom-0 z-20 flex justify-center pb-3">
-              <Show when={contentsQuery.hasNextPage}>
-                <button
-                  type="button"
-                  class="rounded-full border border-black/10 bg-white/90 px-4 py-1 text-xs shadow backdrop-blur dark:bg-neutral-900/90"
-                  onClick={() => void contentsQuery.fetchNextPage()}
-                >
-                  <Show
-                    when={contentsQuery.isFetchingNextPage}
-                    fallback={`Load more (${blocks().length} of ${totalCount()})`}
-                  >
-                    Loading more
-                  </Show>
-                </button>
-              </Show>
-            </div>
           </Show>
         </Show>
       </Show>
@@ -407,7 +399,7 @@ export function CanvasChannel(props: { slug: string }) {
                   <ArenaBlockItem block={block()} />
                 </div>
                 <div class="mt-4 flex justify-end">
-                  <Dialog.Close class="rounded border border-black/10 px-3 py-1 text-sm">
+                  <Dialog.Close class={buttonVariants({ variant: "secondary" })}>
                     Close
                   </Dialog.Close>
                 </div>

--- a/apps/web/src/components/Canvas/CanvasChannel.tsx
+++ b/apps/web/src/components/Canvas/CanvasChannel.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/solid-query";
 import { Effect } from "effect";
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, onSettled } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import { isServer } from "@solidjs/web";
 import { Metadata } from "@tom/ui/Meta";
 import { Button, buttonVariants } from "@tom/ui/tomui/button";
@@ -61,7 +61,7 @@ export function CanvasChannel(props: { slug: string }) {
     timer: null as ReturnType<typeof setTimeout> | null,
     inView: false,
   };
-  let viewport: HTMLDivElement | undefined;
+  const [viewportEl, setViewportEl] = createSignal<HTMLDivElement | null>(null);
 
   const channelQuery = useQuery(() => ({
     queryKey: ["canvas-channel", slug()],
@@ -149,8 +149,9 @@ export function CanvasChannel(props: { slug: string }) {
   };
 
   const centerCamera = (): void => {
-    if (!viewport || isServer) return;
-    const rect = viewport.getBoundingClientRect();
+    const element = viewportEl();
+    if (!element || isServer) return;
+    const rect = element.getBoundingClientRect();
     camera.x = rect.width / 2 - positioned().bounds.width / 2;
     camera.y = rect.height / 2 - positioned().bounds.height / 2;
     camera.scale = 1;
@@ -158,9 +159,10 @@ export function CanvasChannel(props: { slug: string }) {
   };
 
   const zoomAt = (clientX: number, clientY: number, factor: number): void => {
-    if (!viewport) return;
+    const element = viewportEl();
+    if (!element) return;
     const next = clampZoom(camera.scale * factor);
-    const rect = viewport.getBoundingClientRect();
+    const rect = element.getBoundingClientRect();
     const px = clientX - rect.left;
     const py = clientY - rect.top;
     camera.x = px - ((px - camera.x) / camera.scale) * next;
@@ -170,8 +172,9 @@ export function CanvasChannel(props: { slug: string }) {
   };
 
   const zoomCenter = (factor: number): void => {
-    if (!viewport) return;
-    const rect = viewport.getBoundingClientRect();
+    const element = viewportEl();
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
     zoomAt(rect.left + rect.width / 2, rect.top + rect.height / 2, factor);
   };
 
@@ -196,7 +199,7 @@ export function CanvasChannel(props: { slug: string }) {
 
   const onPointerDown = (event: PointerEvent): void => {
     pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-    if (event.pointerType === "mouse") viewport?.setPointerCapture?.(event.pointerId);
+    if (event.pointerType === "mouse") viewportEl()?.setPointerCapture?.(event.pointerId);
     if (pointers.size === 2) {
       drag.active = false;
       pinch.active = true;
@@ -271,7 +274,7 @@ export function CanvasChannel(props: { slug: string }) {
   createEffect(
     () => positioned().bounds.width,
     (width) => {
-      if (width === 0 || camera.centered || !viewport || isServer) return;
+      if (width === 0 || camera.centered || !viewportEl() || isServer) return;
       if (blocks().length === 0) return;
       centerCamera();
       camera.centered = true;
@@ -303,7 +306,7 @@ export function CanvasChannel(props: { slug: string }) {
         { rootMargin: "1200px" },
       );
       observer.observe(element);
-      return () => observer.disconnect();
+      onCleanup(() => observer.disconnect());
     },
   );
 
@@ -328,76 +331,78 @@ export function CanvasChannel(props: { slug: string }) {
     },
   );
 
-  onSettled(() => {
-    if (isServer || !viewport) return;
-    const element = viewport;
-    const onWheel = (event: WheelEvent): void => {
-      event.preventDefault();
-      zoomAt(event.clientX, event.clientY, Math.exp(-event.deltaY * 0.0015));
-    };
-    element.addEventListener("wheel", onWheel, { passive: false });
-    const measure = (): void => {
-      setViewportSize({ width: element.clientWidth, height: element.clientHeight });
-    };
-    measure();
-    window.addEventListener("resize", measure);
-    const stopGesture = (event: Event): void => {
-      event.preventDefault();
-    };
-    document.addEventListener("gesturestart", stopGesture);
-    document.addEventListener("gesturechange", stopGesture);
-    const onVisibility = (): void => {
-      setSentinelVisible(pager.inView && document.visibilityState === "visible");
-    };
-    document.addEventListener("visibilitychange", onVisibility);
-    const onKey = (event: KeyboardEvent): void => {
-      if (selected() !== null) {
-        if (event.key === "Escape") setSelected(null);
-        return;
-      }
-      const step = 60 / camera.scale;
-      if (event.key === "ArrowLeft") {
-        camera.x += step;
-        syncCamera();
-        return;
-      }
-      if (event.key === "ArrowRight") {
-        camera.x -= step;
-        syncCamera();
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        camera.y += step;
-        syncCamera();
-        return;
-      }
-      if (event.key === "ArrowDown") {
-        camera.y -= step;
-        syncCamera();
-        return;
-      }
-      if (event.key === "+" || event.key === "=") {
-        zoomCenter(1.2);
-        return;
-      }
-      if (event.key === "-") {
-        zoomCenter(1 / 1.2);
-        return;
-      }
-      if (event.key === "0") {
-        centerCamera();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => {
-      element.removeEventListener("wheel", onWheel);
-      document.removeEventListener("gesturestart", stopGesture);
-      document.removeEventListener("gesturechange", stopGesture);
-      document.removeEventListener("visibilitychange", onVisibility);
-      window.removeEventListener("resize", measure);
-      window.removeEventListener("keydown", onKey);
-    };
-  });
+  createEffect(
+    () => viewportEl(),
+    (element) => {
+      if (isServer || !element) return;
+      const onWheel = (event: WheelEvent): void => {
+        event.preventDefault();
+        zoomAt(event.clientX, event.clientY, Math.exp(-event.deltaY * 0.0015));
+      };
+      element.addEventListener("wheel", onWheel, { passive: false });
+      const measure = (): void => {
+        setViewportSize({ width: element.clientWidth, height: element.clientHeight });
+      };
+      measure();
+      window.addEventListener("resize", measure);
+      const stopGesture = (event: Event): void => {
+        event.preventDefault();
+      };
+      document.addEventListener("gesturestart", stopGesture);
+      document.addEventListener("gesturechange", stopGesture);
+      const onVisibility = (): void => {
+        setSentinelVisible(pager.inView && document.visibilityState === "visible");
+      };
+      document.addEventListener("visibilitychange", onVisibility);
+      const onKey = (event: KeyboardEvent): void => {
+        if (selected() !== null) {
+          if (event.key === "Escape") setSelected(null);
+          return;
+        }
+        const step = 60 / camera.scale;
+        if (event.key === "ArrowLeft") {
+          camera.x += step;
+          syncCamera();
+          return;
+        }
+        if (event.key === "ArrowRight") {
+          camera.x -= step;
+          syncCamera();
+          return;
+        }
+        if (event.key === "ArrowUp") {
+          camera.y += step;
+          syncCamera();
+          return;
+        }
+        if (event.key === "ArrowDown") {
+          camera.y -= step;
+          syncCamera();
+          return;
+        }
+        if (event.key === "+" || event.key === "=") {
+          zoomCenter(1.2);
+          return;
+        }
+        if (event.key === "-") {
+          zoomCenter(1 / 1.2);
+          return;
+        }
+        if (event.key === "0") {
+          centerCamera();
+        }
+      };
+      window.addEventListener("keydown", onKey);
+      onCleanup(() => {
+        element.removeEventListener("wheel", onWheel);
+        document.removeEventListener("gesturestart", stopGesture);
+        document.removeEventListener("gesturechange", stopGesture);
+        document.removeEventListener("visibilitychange", onVisibility);
+        window.removeEventListener("resize", measure);
+        window.removeEventListener("keydown", onKey);
+      });
+    },
+  );
 
   return (
     <div class="relative h-full w-full overflow-hidden bg-neutral-100 dark:bg-neutral-950">
@@ -428,7 +433,7 @@ export function CanvasChannel(props: { slug: string }) {
             >
               <div
                 ref={(element) => {
-                  viewport = element;
+                  setViewportEl(element);
                 }}
                 class="absolute inset-0 touch-none overflow-hidden bg-[radial-gradient(circle,rgb(0_0_0/0.14)_1px,transparent_1px)] bg-[size:28px_28px] select-none dark:bg-[radial-gradient(circle,rgb(255_255_255/0.14)_1px,transparent_1px)]"
                 onPointerDown={onPointerDown}

--- a/apps/web/src/components/Canvas/CanvasTile.tsx
+++ b/apps/web/src/components/Canvas/CanvasTile.tsx
@@ -52,6 +52,29 @@ export interface TileFrame {
   readonly label: string;
 }
 
+export interface TileThumb {
+  readonly src: string;
+  readonly srcset: string | undefined;
+}
+
+interface TileImageVersion {
+  readonly src?: string;
+  readonly src_2x?: string;
+}
+
+interface TileImage {
+  readonly small?: TileImageVersion | null;
+  readonly medium?: TileImageVersion | null;
+}
+
+/** Smallest usable thumbnail; null when the block carries no image pixels. */
+export const tileThumb = (image: TileImage | null | undefined): TileThumb | null => {
+  const src = image?.small?.src ?? image?.medium?.src;
+  if (!src) return null;
+  const retina = image?.small?.src_2x ?? image?.medium?.src;
+  return { src, srcset: retina && retina !== src ? `${src} 1x, ${retina} 2x` : undefined };
+};
+
 const tileFrame = (layout: CanvasTileLayout, label: string): TileFrame => ({
   label,
   style: {
@@ -150,6 +173,7 @@ function ImageTileBody(props: { block: Extract<ArenaBlock, { type: "Image" }> })
   const block = () => props.block;
   const [loaded, setLoaded] = createSignal(false);
   const placeholder = createMemo(() => Effect.runSync(decodeBlurhash(block().image?.blurhash)));
+  const thumb = createMemo(() => tileThumb(block().image));
   return (
     <div class="relative h-full w-full bg-gray-100 dark:bg-neutral-800">
       <Show when={placeholder() && !loaded()}>
@@ -160,19 +184,19 @@ function ImageTileBody(props: { block: Extract<ArenaBlock, { type: "Image" }> })
           class="absolute inset-0 h-full w-full object-cover blur-sm"
         />
       </Show>
-      <img
-        src={block().image?.medium.src}
-        srcset={
-          block().image?.medium.src_2x
-            ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
-            : undefined
-        }
-        alt={block().image?.alt_text || block().title || ""}
-        class={`h-full w-full object-cover ${placeholder() && !loaded() ? "opacity-0" : ""}`}
-        onLoad={() => setLoaded(true)}
-        loading="lazy"
-        decoding="async"
-      />
+      <Show when={thumb()} fallback={<p class="p-3 text-xs">{block().title || "Image"}</p>}>
+        {(image) => (
+          <img
+            src={image().src}
+            srcset={image().srcset}
+            alt={block().image?.alt_text || block().title || ""}
+            class={`h-full w-full object-cover ${placeholder() && !loaded() ? "opacity-0" : ""}`}
+            onLoad={() => setLoaded(true)}
+            loading="lazy"
+            decoding="async"
+          />
+        )}
+      </Show>
     </div>
   );
 }
@@ -195,6 +219,7 @@ function TextTileBody(props: { block: Extract<ArenaBlock, { type: "Text" }> }) {
 
 function LinkTileBody(props: { block: Extract<ArenaBlock, { type: "Link" }> }) {
   const block = () => props.block;
+  const thumb = createMemo(() => tileThumb(block().image));
   const host = createMemo(() =>
     Effect.runSync(
       canvasLinkHost(block().source?.url ?? "").pipe(Effect.catch(() => Effect.succeed(""))),
@@ -202,22 +227,20 @@ function LinkTileBody(props: { block: Extract<ArenaBlock, { type: "Link" }> }) {
   );
   return (
     <div class="flex h-full w-full flex-col bg-white dark:bg-neutral-900">
-      <Show when={block().image}>
-        <div class="relative min-h-0 flex-1 bg-gray-100 dark:bg-neutral-800">
-          <img
-            src={block().image?.medium.src}
-            srcset={
-              block().image?.medium.src_2x
-                ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
-                : undefined
-            }
-            alt=""
-            aria-hidden="true"
-            class="absolute inset-0 h-full w-full object-cover"
-            loading="lazy"
-            decoding="async"
-          />
-        </div>
+      <Show when={thumb()}>
+        {(image) => (
+          <div class="relative min-h-0 flex-1 bg-gray-100 dark:bg-neutral-800">
+            <img
+              src={image().src}
+              srcset={image().srcset}
+              alt=""
+              aria-hidden="true"
+              class="absolute inset-0 h-full w-full object-cover"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+        )}
       </Show>
       <div class="p-2">
         <p class="truncate text-xs font-medium">
@@ -243,6 +266,7 @@ function AttachmentTileBody(props: { block: Extract<ArenaBlock, { type: "Attachm
   const background = createMemo(() =>
     Effect.runSync(colorHashForTitle(displayName() || `file-${block().id}`)),
   );
+  const thumb = createMemo(() => tileThumb(block().image));
   return (
     <Show
       when={isAudio() || isVideo()}
@@ -251,15 +275,18 @@ function AttachmentTileBody(props: { block: Extract<ArenaBlock, { type: "Attachm
           class="flex h-full w-full flex-col justify-between p-3"
           style={{ "background-color": background() }}
         >
-          <Show when={block().image}>
-            <img
-              src={block().image?.medium.src}
-              alt=""
-              aria-hidden="true"
-              class="mb-2 max-h-2/3 w-full flex-1 object-cover"
-              loading="lazy"
-              decoding="async"
-            />
+          <Show when={thumb()}>
+            {(image) => (
+              <img
+                src={image().src}
+                srcset={image().srcset}
+                alt=""
+                aria-hidden="true"
+                class="mb-2 max-h-2/3 w-full flex-1 object-cover"
+                loading="lazy"
+                decoding="async"
+              />
+            )}
           </Show>
           <div>
             <p class="break-words text-xs font-medium">{displayName()}</p>
@@ -298,29 +325,28 @@ function AttachmentTileBody(props: { block: Extract<ArenaBlock, { type: "Attachm
 
 function EmbedTileBody(props: { block: Extract<ArenaBlock, { type: "Embed" }> }) {
   const block = () => props.block;
+  const thumb = createMemo(() => tileThumb(block().image));
   return (
     <div class="relative h-full w-full bg-black">
       <Show
-        when={block().image}
+        when={thumb()}
         fallback={
           <div class="flex h-full w-full items-center justify-center p-3">
             <p class="text-center text-xs text-white">{block().title || "Embed"}</p>
           </div>
         }
       >
-        <img
-          src={block().image?.medium.src}
-          srcset={
-            block().image?.medium.src_2x
-              ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
-              : undefined
-          }
-          alt=""
-          aria-hidden="true"
-          class="absolute inset-0 h-full w-full object-cover"
-          loading="lazy"
-          decoding="async"
-        />
+        {(image) => (
+          <img
+            src={image().src}
+            srcset={image().srcset}
+            alt=""
+            aria-hidden="true"
+            class="absolute inset-0 h-full w-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        )}
       </Show>
       <div class="absolute inset-0 flex items-center justify-center">
         <div

--- a/apps/web/src/components/Canvas/CanvasTile.tsx
+++ b/apps/web/src/components/Canvas/CanvasTile.tsx
@@ -91,15 +91,22 @@ const tileFrame = (layout: CanvasTileLayout, label: string): TileFrame => ({
 interface CanvasTileProps {
   item: ArenaChannelContents;
   layout: CanvasTileLayout;
+  detail: boolean;
   onOpen: (block: ArenaBlock) => void;
 }
 
 export function CanvasTile(props: CanvasTileProps) {
   const item = () => props.item;
   const layout = () => props.layout;
+  const detail = () => props.detail;
   return (
     <Show when={"base_type" in item()}>
-      <BlockTile block={item() as ArenaBlock} layout={layout()} onOpen={props.onOpen} />
+      <BlockTile
+        block={item() as ArenaBlock}
+        layout={layout()}
+        detail={detail()}
+        onOpen={props.onOpen}
+      />
     </Show>
   );
 }
@@ -107,14 +114,19 @@ export function CanvasTile(props: CanvasTileProps) {
 interface BlockTileProps {
   block: ArenaBlock;
   layout: CanvasTileLayout;
+  detail: boolean;
   onOpen: (block: ArenaBlock) => void;
 }
 
 function BlockTile(props: BlockTileProps) {
   const block = () => props.block;
   const layout = () => props.layout;
+  const detail = () => props.detail;
   const frame = createMemo(() =>
     tileFrame(layout(), block().title || `${block().type} ${block().id}`),
+  );
+  const flatColor = createMemo(() =>
+    Effect.runSync(colorHashForTitle(block().title || `${block().type}-${block().id}`)),
   );
   const open = (): void => props.onOpen(block());
   const onKeyDown = (event: KeyboardEvent): void => {
@@ -132,17 +144,52 @@ function BlockTile(props: BlockTileProps) {
       onClick={open}
       onKeyDown={onKeyDown}
     >
-      <Show when={asBlock(block(), "Image")}>{(image) => <ImageTileBody block={image()} />}</Show>
-      <Show when={asBlock(block(), "Text")}>{(text) => <TextTileBody block={text()} />}</Show>
-      <Show when={asBlock(block(), "Link")}>{(link) => <LinkTileBody block={link()} />}</Show>
-      <Show when={asBlock(block(), "Attachment")}>
-        {(attachment) => <AttachmentTileBody block={attachment()} />}
-      </Show>
-      <Show when={asBlock(block(), "Embed")}>{(embed) => <EmbedTileBody block={embed()} />}</Show>
-      <Show when={block().type === "PendingBlock"}>
-        <PendingTileBody title={block().title} />
+      <Show
+        when={detail()}
+        fallback={<div class="h-full w-full" style={{ "background-color": flatColor() }} />}
+      >
+        <Show when={asBlock(block(), "Image")}>{(image) => <ImageTileBody block={image()} />}</Show>
+        <Show when={asBlock(block(), "Text")}>{(text) => <TextTileBody block={text()} />}</Show>
+        <Show when={asBlock(block(), "Link")}>{(link) => <LinkTileBody block={link()} />}</Show>
+        <Show when={asBlock(block(), "Attachment")}>
+          {(attachment) => <AttachmentTileBody block={attachment()} />}
+        </Show>
+        <Show when={asBlock(block(), "Embed")}>{(embed) => <EmbedTileBody block={embed()} />}</Show>
+        <Show when={block().type === "PendingBlock"}>
+          <PendingTileBody title={block().title} />
+        </Show>
       </Show>
     </Button>
+  );
+}
+
+export interface CulledTileProps {
+  layout: CanvasTileLayout;
+  visible: boolean;
+  children?: JSX.Element;
+}
+
+/** Offscreen tiles stay mounted as bare boxes so paint cost tracks the viewport. */
+export function CulledTile(props: CulledTileProps) {
+  const layout = () => props.layout;
+  return (
+    <Show
+      when={props.visible}
+      fallback={
+        <div
+          aria-hidden="true"
+          class="absolute"
+          style={{
+            left: `${layout().x}px`,
+            top: `${layout().y}px`,
+            width: `${layout().width}px`,
+            height: `${layout().height}px`,
+          }}
+        />
+      }
+    >
+      {props.children}
+    </Show>
   );
 }
 

--- a/apps/web/src/components/Canvas/CanvasTile.tsx
+++ b/apps/web/src/components/Canvas/CanvasTile.tsx
@@ -1,0 +1,354 @@
+import { Effect } from "effect";
+import { Show, createMemo, createSignal } from "solid-js";
+import type { JSX } from "@solidjs/web";
+import type { ArenaBlock, ArenaChannelContents } from "@tom/schemas/arena";
+import { decodeBlurhash } from "~/libs/utils/blurhash";
+import { canvasLinkHost, colorHashForTitle } from "~/libs/canvas/layout";
+import type { CanvasLayoutItem, CanvasTileLayout } from "~/libs/canvas/layout";
+import { formatFileSize } from "~/components/Arena";
+
+export const describeCanvasItem = (item: ArenaChannelContents): CanvasLayoutItem => {
+  if (!("base_type" in item)) {
+    return { id: String(item.id), kind: "Channel", ratio: null };
+  }
+  const block = item as ArenaBlock;
+  const image =
+    block.type === "Image"
+      ? block.image
+      : block.type === "Link" || block.type === "Attachment" || block.type === "Embed"
+        ? (block.image ?? null)
+        : null;
+  return { id: String(block.id), kind: block.type, ratio: ratioFor(image) };
+};
+
+const ratioFor = (
+  image:
+    | {
+        readonly aspect_ratio?: number | null;
+        readonly width?: number | null;
+        readonly height?: number | null;
+      }
+    | null
+    | undefined,
+): number | null => {
+  if (image?.aspect_ratio) return image.aspect_ratio;
+  if (image?.width && image?.height) return image.width / image.height;
+  return null;
+};
+
+const asBlock = <T extends ArenaBlock["type"]>(
+  block: ArenaBlock,
+  type: T,
+): Extract<ArenaBlock, { type: T }> | null =>
+  block.type === type ? (block as Extract<ArenaBlock, { type: T }>) : null;
+
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "ogg", "m4a", "aac", "flac", "opus"]);
+
+const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "m4v", "mpg4"]);
+
+export interface TileFrame {
+  readonly style: JSX.CSSProperties;
+  readonly label: string;
+}
+
+const tileFrame = (layout: CanvasTileLayout, label: string): TileFrame => ({
+  label,
+  style: {
+    left: `${layout.x}px`,
+    top: `${layout.y}px`,
+    width: `${layout.width}px`,
+    height: `${layout.height}px`,
+    transform: `rotate(${layout.rotate}deg)`,
+    "content-visibility": "auto",
+    "contain-intrinsic-size": "300px 240px",
+  },
+});
+
+interface CanvasTileProps {
+  item: ArenaChannelContents;
+  layout: CanvasTileLayout;
+  onOpen: (block: ArenaBlock) => void;
+}
+
+export function CanvasTile(props: CanvasTileProps) {
+  const item = () => props.item;
+  const layout = () => props.layout;
+  return (
+    <Show when={"base_type" in item()}>
+      <BlockTile block={item() as ArenaBlock} layout={layout()} onOpen={props.onOpen} />
+    </Show>
+  );
+}
+
+interface BlockTileProps {
+  block: ArenaBlock;
+  layout: CanvasTileLayout;
+  onOpen: (block: ArenaBlock) => void;
+}
+
+function BlockTile(props: BlockTileProps) {
+  const block = () => props.block;
+  const layout = () => props.layout;
+  const frame = createMemo(() =>
+    tileFrame(layout(), block().title || `${block().type} ${block().id}`),
+  );
+  const open = (): void => props.onOpen(block());
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      open();
+    }
+  };
+  return (
+    <div
+      role="button"
+      tabindex="0"
+      aria-label={frame().label}
+      class="absolute cursor-pointer select-none overflow-hidden rounded-xl border border-black/10 bg-white shadow-md transition-shadow hover:shadow-xl dark:border-white/10 dark:bg-neutral-900"
+      style={frame().style}
+      onClick={open}
+      onKeyDown={onKeyDown}
+    >
+      <Show when={asBlock(block(), "Image")}>{(image) => <ImageTileBody block={image()} />}</Show>
+      <Show when={asBlock(block(), "Text")}>{(text) => <TextTileBody block={text()} />}</Show>
+      <Show when={asBlock(block(), "Link")}>{(link) => <LinkTileBody block={link()} />}</Show>
+      <Show when={asBlock(block(), "Attachment")}>
+        {(attachment) => <AttachmentTileBody block={attachment()} />}
+      </Show>
+      <Show when={asBlock(block(), "Embed")}>{(embed) => <EmbedTileBody block={embed()} />}</Show>
+      <Show when={block().type === "PendingBlock"}>
+        <PendingTileBody title={block().title} />
+      </Show>
+    </div>
+  );
+}
+
+interface ChannelTileProps {
+  slug: string;
+  title: string;
+  layout: CanvasTileLayout;
+}
+
+export function ChannelTile(props: ChannelTileProps) {
+  const layout = () => props.layout;
+  const frame = createMemo(() => tileFrame(layout(), props.title));
+  return (
+    <a
+      href={`/canvas/${props.slug}`}
+      aria-label={`Open canvas ${props.title}`}
+      class="absolute block select-none overflow-hidden rounded-xl border border-dashed border-black/20 bg-neutral-50 p-3 shadow-sm transition-shadow hover:shadow-xl dark:border-white/20 dark:bg-neutral-900"
+      style={frame().style}
+    >
+      <p class="text-xs uppercase tracking-wide opacity-60">Channel</p>
+      <p class="mt-1 text-sm font-medium leading-snug">{props.title}</p>
+      <p class="mt-2 text-xs underline">Open canvas</p>
+    </a>
+  );
+}
+
+function ImageTileBody(props: { block: Extract<ArenaBlock, { type: "Image" }> }) {
+  const block = () => props.block;
+  const [loaded, setLoaded] = createSignal(false);
+  const placeholder = createMemo(() => Effect.runSync(decodeBlurhash(block().image?.blurhash)));
+  return (
+    <div class="relative h-full w-full bg-gray-100 dark:bg-neutral-800">
+      <Show when={placeholder() && !loaded()}>
+        <img
+          src={placeholder()!}
+          alt=""
+          aria-hidden="true"
+          class="absolute inset-0 h-full w-full object-cover blur-sm"
+        />
+      </Show>
+      <img
+        src={block().image?.medium.src}
+        srcset={
+          block().image?.medium.src_2x
+            ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
+            : undefined
+        }
+        alt={block().image?.alt_text || block().title || ""}
+        class={`h-full w-full object-cover ${placeholder() && !loaded() ? "opacity-0" : ""}`}
+        onLoad={() => setLoaded(true)}
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
+  );
+}
+
+function TextTileBody(props: { block: Extract<ArenaBlock, { type: "Text" }> }) {
+  const block = () => props.block;
+  const background = createMemo(() =>
+    Effect.runSync(colorHashForTitle(block().title || `text-${block().id}`)),
+  );
+  const excerpt = createMemo(() => (block().content?.markdown ?? "").slice(0, 280));
+  return (
+    <div class="h-full w-full overflow-hidden p-3" style={{ "background-color": background() }}>
+      <Show when={block().title}>
+        <p class="text-sm font-medium leading-snug">{block().title}</p>
+      </Show>
+      <p class="mt-1 line-clamp-6 text-xs leading-relaxed">{excerpt()}</p>
+    </div>
+  );
+}
+
+function LinkTileBody(props: { block: Extract<ArenaBlock, { type: "Link" }> }) {
+  const block = () => props.block;
+  const host = createMemo(() =>
+    Effect.runSync(
+      canvasLinkHost(block().source?.url ?? "").pipe(Effect.catch(() => Effect.succeed(""))),
+    ),
+  );
+  return (
+    <div class="flex h-full w-full flex-col bg-white dark:bg-neutral-900">
+      <Show when={block().image}>
+        <div class="relative min-h-0 flex-1 bg-gray-100 dark:bg-neutral-800">
+          <img
+            src={block().image?.medium.src}
+            srcset={
+              block().image?.medium.src_2x
+                ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
+                : undefined
+            }
+            alt=""
+            aria-hidden="true"
+            class="absolute inset-0 h-full w-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        </div>
+      </Show>
+      <div class="p-2">
+        <p class="truncate text-xs font-medium">
+          {block().title || block().source?.title || host()}
+        </p>
+        <Show when={host()}>
+          <p class="truncate text-[11px] opacity-60">{host()}</p>
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+function AttachmentTileBody(props: { block: Extract<ArenaBlock, { type: "Attachment" }> }) {
+  const block = () => props.block;
+  const attachment = () => block().attachment;
+  const extension = () => (attachment()?.file_extension || "").toLowerCase();
+  const contentType = () => attachment()?.content_type || "";
+  const fileUrl = () => attachment()?.url || "";
+  const displayName = () => block().title || attachment()?.filename || "";
+  const isAudio = () => AUDIO_EXTENSIONS.has(extension()) || contentType().startsWith("audio/");
+  const isVideo = () => VIDEO_EXTENSIONS.has(extension()) || contentType().startsWith("video/");
+  const background = createMemo(() =>
+    Effect.runSync(colorHashForTitle(displayName() || `file-${block().id}`)),
+  );
+  return (
+    <Show
+      when={isAudio() || isVideo()}
+      fallback={
+        <div
+          class="flex h-full w-full flex-col justify-between p-3"
+          style={{ "background-color": background() }}
+        >
+          <Show when={block().image}>
+            <img
+              src={block().image?.medium.src}
+              alt=""
+              aria-hidden="true"
+              class="mb-2 max-h-2/3 w-full flex-1 object-cover"
+              loading="lazy"
+              decoding="async"
+            />
+          </Show>
+          <div>
+            <p class="break-words text-xs font-medium">{displayName()}</p>
+            <p class="text-[11px] opacity-60">{formatFileSize(attachment()?.file_size)}</p>
+          </div>
+        </div>
+      }
+    >
+      <Show when={isAudio()}>
+        <div
+          class="flex h-full w-full flex-col justify-center gap-2 p-3"
+          style={{ "background-color": background() }}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          <p class="truncate text-xs font-medium">{displayName()}</p>
+          <audio src={fileUrl()} controls preload="none" class="w-full">
+            Your browser does not support the audio element.
+          </audio>
+        </div>
+      </Show>
+      <Show when={isVideo()}>
+        <div
+          class="h-full w-full bg-black"
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          <video src={fileUrl()} controls preload="metadata" class="h-full w-full">
+            Your browser does not support the video element.
+          </video>
+        </div>
+      </Show>
+    </Show>
+  );
+}
+
+function EmbedTileBody(props: { block: Extract<ArenaBlock, { type: "Embed" }> }) {
+  const block = () => props.block;
+  return (
+    <div class="relative h-full w-full bg-black">
+      <Show
+        when={block().image}
+        fallback={
+          <div class="flex h-full w-full items-center justify-center p-3">
+            <p class="text-center text-xs text-white">{block().title || "Embed"}</p>
+          </div>
+        }
+      >
+        <img
+          src={block().image?.medium.src}
+          srcset={
+            block().image?.medium.src_2x
+              ? `${block().image?.medium.src} 1x, ${block().image?.medium.src_2x} 2x`
+              : undefined
+          }
+          alt=""
+          aria-hidden="true"
+          class="absolute inset-0 h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+        />
+      </Show>
+      <div class="absolute inset-0 flex items-center justify-center">
+        <div
+          class="flex h-12 w-12 items-center justify-center rounded-full bg-black/60 text-white"
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </div>
+      </div>
+      <Show when={block().title}>
+        <p class="absolute inset-x-0 bottom-0 truncate bg-black/60 p-1 text-[11px] text-white">
+          {block().title}
+        </p>
+      </Show>
+    </div>
+  );
+}
+
+function PendingTileBody(props: { title?: string | null | undefined }) {
+  const background = createMemo(() => Effect.runSync(colorHashForTitle(props.title || "pending")));
+  return (
+    <div
+      class="flex h-full w-full items-center justify-center p-3"
+      style={{ "background-color": background() }}
+    >
+      <p class="text-center text-xs">{props.title || "Processing block"}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/Canvas/CanvasTile.tsx
+++ b/apps/web/src/components/Canvas/CanvasTile.tsx
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { Show, createMemo, createSignal } from "solid-js";
 import type { JSX } from "@solidjs/web";
+import { Button } from "@tom/ui/tomui/button";
 import type { ArenaBlock, ArenaChannelContents } from "@tom/schemas/arena";
 import { decodeBlurhash } from "~/libs/utils/blurhash";
 import { canvasLinkHost, colorHashForTitle } from "~/libs/canvas/layout";
@@ -100,11 +101,10 @@ function BlockTile(props: BlockTileProps) {
     }
   };
   return (
-    <div
-      role="button"
-      tabindex="0"
+    <Button
+      variant="ghost"
       aria-label={frame().label}
-      class="absolute cursor-pointer select-none overflow-hidden rounded-xl border border-black/10 bg-white shadow-md transition-shadow hover:shadow-xl dark:border-white/10 dark:bg-neutral-900"
+      class="absolute cursor-pointer overflow-hidden rounded-none border border-black/10 bg-white px-0 font-normal shadow-md transition-shadow hover:shadow-xl dark:border-white/10 dark:bg-neutral-900"
       style={frame().style}
       onClick={open}
       onKeyDown={onKeyDown}
@@ -119,7 +119,7 @@ function BlockTile(props: BlockTileProps) {
       <Show when={block().type === "PendingBlock"}>
         <PendingTileBody title={block().title} />
       </Show>
-    </div>
+    </Button>
   );
 }
 
@@ -136,10 +136,10 @@ export function ChannelTile(props: ChannelTileProps) {
     <a
       href={`/canvas/${props.slug}`}
       aria-label={`Open canvas ${props.title}`}
-      class="absolute block select-none overflow-hidden rounded-xl border border-dashed border-black/20 bg-neutral-50 p-3 shadow-sm transition-shadow hover:shadow-xl dark:border-white/20 dark:bg-neutral-900"
+      class="absolute block select-none overflow-hidden rounded-none border border-dashed border-black/20 bg-neutral-50 p-3 shadow-sm transition-shadow hover:shadow-xl dark:border-white/20 dark:bg-neutral-900"
       style={frame().style}
     >
-      <p class="text-xs uppercase tracking-wide opacity-60">Channel</p>
+      <p class="text-xs tracking-wide opacity-60">Channel</p>
       <p class="mt-1 text-sm font-medium leading-snug">{props.title}</p>
       <p class="mt-2 text-xs underline">Open canvas</p>
     </a>

--- a/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
+++ b/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { QueryClientProvider } from "@tanstack/solid-query";
 import { CanvasChannel } from "~/components/Canvas/CanvasChannel";
@@ -67,6 +67,10 @@ beforeEach(() => {
   mockedFetchChannel.mockResolvedValue({ title: "Philemon", slug: "philemon" });
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("CanvasChannel", () => {
   it("scatters every block of the channel on the canvas", async () => {
     mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
@@ -109,5 +113,18 @@ describe("CanvasChannel", () => {
     renderCanvas();
 
     await waitFor(() => expect(screen.getByText("This channel holds no blocks.")).toBeTruthy());
+  });
+
+  it("shows the error state only when no block loads", async () => {
+    vi.useFakeTimers();
+    try {
+      mockedFetchContentsPage.mockRejectedValue(new Error("too many requests"));
+      renderCanvas();
+
+      await vi.advanceTimersByTimeAsync(40000);
+      expect(screen.getByText("This channel cannot load.")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
+++ b/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
@@ -85,6 +85,22 @@ describe("CanvasChannel", () => {
     expect(screen.queryByRole("banner")).toBeNull();
   });
 
+  it("zooms with the wheel once tiles mount", async () => {
+    mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
+    renderCanvas();
+
+    await waitFor(() => expect(screen.getByAltText("The Psychology of CG Jung")).toBeTruthy());
+    const viewport = document.querySelector(".touch-none") as HTMLElement;
+    viewport.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: -500, clientX: 100, clientY: 100, bubbles: true }),
+    );
+
+    await waitFor(() => {
+      const inner = viewport.firstElementChild as HTMLElement;
+      expect(inner.style.transform).toContain("scale(2.117");
+    });
+  });
+
   it("pinch zooms the canvas around the touch midpoint", async () => {
     mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
     renderCanvas();

--- a/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
+++ b/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
@@ -20,6 +20,10 @@ const imageBlock = {
   base_type: "Block",
   title: "The Psychology of CG Jung",
   image: {
+    small: {
+      src: "https://images.are.na/image-small.jpg",
+      src_2x: "https://images.are.na/image-small-2x.jpg",
+    },
     medium: {
       src: "https://images.are.na/image-medium.jpg",
       src_2x: "https://images.are.na/image-medium-2x.jpg",
@@ -106,6 +110,16 @@ describe("CanvasChannel", () => {
 
     await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
     expect(screen.getAllByText("Hello from the canvas")).toHaveLength(2);
+  });
+
+  it("renders a title fallback when an image block carries no versions", async () => {
+    mockedFetchContentsPage.mockResolvedValue(
+      pageFor([{ ...imageBlock, image: undefined, title: "Versionless image" }]),
+    );
+    renderCanvas();
+
+    await waitFor(() => expect(screen.getByText("Versionless image")).toBeTruthy());
+    expect(screen.queryByRole("img", { name: "Versionless image" })).toBeNull();
   });
 
   it("shows an empty state when the channel holds no blocks", async () => {

--- a/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
+++ b/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
@@ -74,7 +74,23 @@ describe("CanvasChannel", () => {
 
     await waitFor(() => expect(screen.getByAltText("The Psychology of CG Jung")).toBeTruthy());
     expect(screen.getByText("A note")).toBeTruthy();
-    expect(screen.getByText("2 of 2 blocks")).toBeTruthy();
+    expect(screen.queryByRole("banner")).toBeNull();
+  });
+
+  it("pinch zooms the canvas around the touch midpoint", async () => {
+    mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
+    renderCanvas();
+
+    await waitFor(() => expect(screen.getByAltText("The Psychology of CG Jung")).toBeTruthy());
+    const viewport = document.querySelector(".touch-none") as HTMLElement;
+    fireEvent.pointerDown(viewport, { pointerId: 1, clientX: 100, clientY: 100 });
+    fireEvent.pointerDown(viewport, { pointerId: 2, clientX: 200, clientY: 100 });
+    fireEvent.pointerMove(viewport, { pointerId: 2, clientX: 260, clientY: 100 });
+
+    await waitFor(() => {
+      const inner = viewport.firstElementChild as HTMLElement;
+      expect(inner.style.transform).toContain("scale(1.6)");
+    });
   });
 
   it("opens the block detail dialog on tile click", async () => {

--- a/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
+++ b/apps/web/src/components/Canvas/__tests__/CanvasChannel.test.tsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { QueryClientProvider } from "@tanstack/solid-query";
+import { CanvasChannel } from "~/components/Canvas/CanvasChannel";
+import { queryClient } from "~/libs/query-client";
+
+vi.mock("~/server/adapter", () => ({
+  fetchChannel: vi.fn(),
+  fetchChannelContentsPage: vi.fn(),
+}));
+
+import { fetchChannel, fetchChannelContentsPage } from "~/server/adapter";
+
+const mockedFetchChannel = fetchChannel as Mock;
+const mockedFetchContentsPage = fetchChannelContentsPage as Mock;
+
+const imageBlock = {
+  id: 6932930,
+  type: "Image",
+  base_type: "Block",
+  title: "The Psychology of CG Jung",
+  image: {
+    medium: {
+      src: "https://images.are.na/image-medium.jpg",
+      src_2x: "https://images.are.na/image-medium-2x.jpg",
+    },
+  },
+};
+
+const textBlock = {
+  id: 3001,
+  type: "Text",
+  base_type: "Block",
+  title: "A note",
+  content: {
+    markdown: "Hello from the canvas",
+    html: "<p>Hello from the canvas</p>",
+    plain: "Hello from the canvas",
+  },
+};
+
+const pageFor = (data: ReadonlyArray<unknown>) => ({
+  data,
+  meta: {
+    current_page: 1,
+    next_page: null,
+    per_page: 100,
+    total_pages: 1,
+    total_count: data.length,
+    has_more_pages: false,
+  },
+});
+
+const renderCanvas = () =>
+  render(() => (
+    <QueryClientProvider client={queryClient}>
+      <div class="h-dvh">
+        <CanvasChannel slug="philemon" />
+      </div>
+    </QueryClientProvider>
+  ));
+
+beforeEach(() => {
+  queryClient.clear();
+  mockedFetchChannel.mockReset();
+  mockedFetchContentsPage.mockReset();
+  mockedFetchChannel.mockResolvedValue({ title: "Philemon", slug: "philemon" });
+});
+
+describe("CanvasChannel", () => {
+  it("scatters every block of the channel on the canvas", async () => {
+    mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
+    renderCanvas();
+
+    await waitFor(() => expect(screen.getByAltText("The Psychology of CG Jung")).toBeTruthy());
+    expect(screen.getByText("A note")).toBeTruthy();
+    expect(screen.getByText("2 of 2 blocks")).toBeTruthy();
+  });
+
+  it("opens the block detail dialog on tile click", async () => {
+    mockedFetchContentsPage.mockResolvedValue(pageFor([imageBlock, textBlock]));
+    renderCanvas();
+
+    const tile = await screen.findByRole("button", { name: "A note" });
+    fireEvent.click(tile);
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+    expect(screen.getAllByText("Hello from the canvas")).toHaveLength(2);
+  });
+
+  it("shows an empty state when the channel holds no blocks", async () => {
+    mockedFetchContentsPage.mockResolvedValue(pageFor([]));
+    renderCanvas();
+
+    await waitFor(() => expect(screen.getByText("This channel holds no blocks.")).toBeTruthy());
+  });
+});

--- a/apps/web/src/libs/canvas/__tests__/layout.test.ts
+++ b/apps/web/src/libs/canvas/__tests__/layout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { colorHashForTitle, computeCanvasLayout } from "~/libs/canvas/layout";
+
+const runLayout = (slug: string, count: number) =>
+  Effect.runSync(
+    computeCanvasLayout({
+      slug,
+      items: Array.from({ length: count }, (_, index) => ({
+        id: String(index + 1),
+        kind: index % 2 === 0 ? ("Image" as const) : ("Text" as const),
+        ratio: null,
+      })),
+    }),
+  );
+
+describe("computeCanvasLayout", () => {
+  it("returns one tile per item", () => {
+    const layout = runLayout("philemon", 5);
+    expect(layout.tiles).toHaveLength(5);
+  });
+
+  it("returns an empty layout for an empty channel", () => {
+    const layout = runLayout("philemon", 0);
+    expect(layout.tiles).toEqual([]);
+  });
+
+  it("keeps the layout stable for one slug", () => {
+    expect(runLayout("philemon", 8)).toEqual(runLayout("philemon", 8));
+  });
+
+  it("scatters tiles across a bounds box holding every tile", () => {
+    const layout = runLayout("philemon", 12);
+    for (const tile of layout.tiles) {
+      expect(tile.x).toBeGreaterThanOrEqual(layout.bounds.minX);
+      expect(tile.y).toBeGreaterThanOrEqual(layout.bounds.minY);
+      expect(tile.x + tile.width).toBeLessThanOrEqual(layout.bounds.minX + layout.bounds.width);
+      expect(tile.y + tile.height).toBeLessThanOrEqual(layout.bounds.minY + layout.bounds.height);
+    }
+    const origins = new Set(layout.tiles.map((tile) => `${tile.x},${tile.y}`));
+    expect(origins.size).toBe(layout.tiles.length);
+  });
+});
+
+describe("colorHashForTitle", () => {
+  it("returns a stable color per title", () => {
+    const first = Effect.runSync(colorHashForTitle("A note"));
+    expect(first).toContain("hsl(");
+    expect(Effect.runSync(colorHashForTitle("A note"))).toBe(first);
+  });
+});

--- a/apps/web/src/libs/canvas/__tests__/layout.test.ts
+++ b/apps/web/src/libs/canvas/__tests__/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Effect } from "effect";
-import { colorHashForTitle, computeCanvasLayout } from "~/libs/canvas/layout";
+import { colorHashForTitle, computeCanvasLayout, tileIntersectsView } from "~/libs/canvas/layout";
 
 const runLayout = (slug: string, count: number) =>
   Effect.runSync(
@@ -54,6 +54,16 @@ describe("computeCanvasLayout", () => {
     }
     const origins = new Set(layout.tiles.map((tile) => `${tile.x},${tile.y}`));
     expect(origins.size).toBe(layout.tiles.length);
+  });
+});
+
+describe("tileIntersectsView", () => {
+  const view = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+  it("keeps touching tiles and drops the rest", () => {
+    expect(tileIntersectsView({ x: 10, y: 10, width: 20, height: 20 }, view)).toBe(true);
+    expect(tileIntersectsView({ x: 90, y: 90, width: 40, height: 40 }, view)).toBe(true);
+    expect(tileIntersectsView({ x: 200, y: 200, width: 20, height: 20 }, view)).toBe(false);
+    expect(tileIntersectsView({ x: 100, y: 0, width: 20, height: 20 }, view)).toBe(false);
   });
 });
 

--- a/apps/web/src/libs/canvas/__tests__/layout.test.ts
+++ b/apps/web/src/libs/canvas/__tests__/layout.test.ts
@@ -29,7 +29,22 @@ describe("computeCanvasLayout", () => {
     expect(runLayout("philemon", 8)).toEqual(runLayout("philemon", 8));
   });
 
-  it("scatters tiles across a bounds box holding every tile", () => {
+  it("packs tiles without overlap", () => {
+    [1, 7, 40, 200].forEach((count) => {
+      const layout = runLayout("philemon", count);
+      layout.tiles.forEach((first, a) => {
+        layout.tiles.slice(a + 1).forEach((second) => {
+          const separated =
+            first.x + first.width <= second.x ||
+            second.x + second.width <= first.x ||
+            first.y + first.height <= second.y ||
+            second.y + second.height <= first.y;
+          expect(separated).toBe(true);
+        });
+      });
+    });
+  });
+  it("holds every tile inside the bounds box", () => {
     const layout = runLayout("philemon", 12);
     for (const tile of layout.tiles) {
       expect(tile.x).toBeGreaterThanOrEqual(layout.bounds.minX);

--- a/apps/web/src/libs/canvas/layout.ts
+++ b/apps/web/src/libs/canvas/layout.ts
@@ -41,8 +41,9 @@ export interface TileSize {
   readonly height: number;
 }
 
-const GOLDEN_ANGLE = 2.399963;
 const CANVAS_PADDING = 400;
+const MASONRY_GUTTER = 40;
+const MASONRY_JITTER = 10;
 
 const hashSeed = (text: string): number => {
   const state = { value: 2166136261 };
@@ -110,20 +111,39 @@ const buildCanvasLayout = (input: {
   }
   const rand = createRandom(hashSeed(slug));
   const count = items.length;
-  const spread = 340 * Math.sqrt(count) + 400;
-  const seedAngle = rand() * Math.PI * 2;
+  const sizes = items.map((item) => tileSize(item.kind, item.ratio, rand));
+  const columns = Math.max(1, Math.round(Math.sqrt(count)));
+  const columnOf = (index: number): number => index % columns;
+  const columnWidths = sizes.reduce(
+    (widths, size, index) => {
+      const column = columnOf(index);
+      widths[column] = Math.max(widths[column] ?? 0, size.width);
+      return widths;
+    },
+    Array.from({ length: columns }, () => 0),
+  );
+  const columnX = columnWidths.reduce((offsets, _width, column) => {
+    offsets.push(
+      (offsets[column - 1] ?? -MASONRY_GUTTER) + (columnWidths[column - 1] ?? 0) + MASONRY_GUTTER,
+    );
+    return offsets;
+  }, [] as Array<number>);
+  const columnY = Array.from({ length: columns }, () => 0);
+  const jitter = (): number => Math.round((rand() * 2 - 1) * MASONRY_JITTER);
   const tiles = items.map((item, index): CanvasTileLayout => {
-    const size = tileSize(item.kind, item.ratio, rand);
-    const angle = index * GOLDEN_ANGLE + seedAngle;
-    const radius = spread * Math.sqrt((index + 0.3 + rand() * 0.7) / count);
-    return {
+    const size = sizes[index] ?? { width: 280, height: 200 };
+    const column = columnOf(index);
+    const width = columnWidths[column] ?? size.width;
+    const tile: CanvasTileLayout = {
       id: item.id,
       width: size.width,
       height: size.height,
-      x: Math.round(radius * Math.cos(angle) - size.width / 2),
-      y: Math.round(radius * Math.sin(angle) * 0.75 - size.height / 2),
-      rotate: Math.round((rand() * 5 - 2.5) * 10) / 10,
+      x: (columnX[column] ?? 0) + Math.round((width - size.width) / 2) + jitter(),
+      y: (columnY[column] ?? 0) + jitter(),
+      rotate: Math.round((rand() * 4 - 2) * 10) / 10,
     };
+    columnY[column] = (columnY[column] ?? 0) + size.height + MASONRY_GUTTER;
+    return tile;
   });
   const bounds = tiles.reduce(
     (acc, tile) => ({

--- a/apps/web/src/libs/canvas/layout.ts
+++ b/apps/web/src/libs/canvas/layout.ts
@@ -31,6 +31,27 @@ export interface CanvasBounds {
   readonly height: number;
 }
 
+export interface WorldView {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+export interface TileRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Whiteboard culling: only tiles touching the view (plus overscan) paint. */
+export const tileIntersectsView = (tile: TileRect, view: WorldView): boolean =>
+  tile.x < view.maxX &&
+  tile.x + tile.width > view.minX &&
+  tile.y < view.maxY &&
+  tile.y + tile.height > view.minY;
+
 export interface CanvasLayout {
   readonly tiles: ReadonlyArray<CanvasTileLayout>;
   readonly bounds: CanvasBounds;

--- a/apps/web/src/libs/canvas/layout.ts
+++ b/apps/web/src/libs/canvas/layout.ts
@@ -1,0 +1,155 @@
+import { Effect } from "effect";
+
+export type CanvasTileKind =
+  | "Attachment"
+  | "Channel"
+  | "Embed"
+  | "Image"
+  | "Link"
+  | "PendingBlock"
+  | "Text";
+
+export interface CanvasLayoutItem {
+  readonly id: string;
+  readonly kind: CanvasTileKind;
+  readonly ratio: number | null;
+}
+
+export interface CanvasTileLayout {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly rotate: number;
+}
+
+export interface CanvasBounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface CanvasLayout {
+  readonly tiles: ReadonlyArray<CanvasTileLayout>;
+  readonly bounds: CanvasBounds;
+}
+
+export interface TileSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+const GOLDEN_ANGLE = 2.399963;
+const CANVAS_PADDING = 400;
+
+const hashSeed = (text: string): number => {
+  const state = { value: 2166136261 };
+  for (const char of text) {
+    state.value ^= char.charCodeAt(0);
+    state.value = Math.imul(state.value, 16777619);
+  }
+  return state.value >>> 0;
+};
+
+const createRandom = (seed: number): (() => number) => {
+  const state = { value: seed >>> 0 };
+  return () => {
+    state.value = (state.value + 0x6d2b79f5) >>> 0;
+    const mixed = Math.imul(state.value ^ (state.value >>> 15), 1 | state.value);
+    const output = (mixed + Math.imul(mixed ^ (mixed >>> 7), 61 | mixed)) ^ mixed;
+    return ((output ^ (output >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const tileSize = (kind: CanvasTileKind, ratio: number | null, rand: () => number): TileSize => {
+  const jitter = (base: number, spread: number): number => Math.round(base + rand() * spread);
+  switch (kind) {
+    case "Image": {
+      const width = jitter(300, 120);
+      const height = ratio && ratio > 0 ? width / ratio : jitter(220, 160);
+      return { width, height: Math.round(clamp(height, 180, 480)) };
+    }
+    case "Text":
+      return { width: jitter(260, 80), height: jitter(160, 80) };
+    case "Link":
+      return { width: jitter(280, 80), height: jitter(240, 60) };
+    case "Attachment":
+      return { width: jitter(300, 80), height: jitter(160, 140) };
+    case "Embed":
+      return { width: jitter(320, 80), height: jitter(240, 80) };
+    case "Channel":
+      return { width: 280, height: 200 };
+    case "PendingBlock":
+      return { width: 260, height: 200 };
+  }
+};
+
+export const computeCanvasLayout = (input: {
+  slug: string;
+  items: ReadonlyArray<CanvasLayoutItem>;
+}): Effect.Effect<CanvasLayout> =>
+  Effect.suspend(() => Effect.succeed(buildCanvasLayout(input))).pipe(
+    Effect.withSpan("canvas.layout"),
+  );
+
+const buildCanvasLayout = (input: {
+  slug: string;
+  items: ReadonlyArray<CanvasLayoutItem>;
+}): CanvasLayout => {
+  const { slug, items } = input;
+  if (items.length === 0) {
+    return {
+      tiles: [],
+      bounds: { minX: 0, minY: 0, width: 0, height: 0 },
+    };
+  }
+  const rand = createRandom(hashSeed(slug));
+  const count = items.length;
+  const spread = 340 * Math.sqrt(count) + 400;
+  const seedAngle = rand() * Math.PI * 2;
+  const tiles = items.map((item, index): CanvasTileLayout => {
+    const size = tileSize(item.kind, item.ratio, rand);
+    const angle = index * GOLDEN_ANGLE + seedAngle;
+    const radius = spread * Math.sqrt((index + 0.3 + rand() * 0.7) / count);
+    return {
+      id: item.id,
+      width: size.width,
+      height: size.height,
+      x: Math.round(radius * Math.cos(angle) - size.width / 2),
+      y: Math.round(radius * Math.sin(angle) * 0.75 - size.height / 2),
+      rotate: Math.round((rand() * 5 - 2.5) * 10) / 10,
+    };
+  });
+  const bounds = tiles.reduce(
+    (acc, tile) => ({
+      minX: Math.min(acc.minX, tile.x),
+      minY: Math.min(acc.minY, tile.y),
+      maxX: Math.max(acc.maxX, tile.x + tile.width),
+      maxY: Math.max(acc.maxY, tile.y + tile.height),
+    }),
+    { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+  );
+  return {
+    tiles,
+    bounds: {
+      minX: bounds.minX - CANVAS_PADDING,
+      minY: bounds.minY - CANVAS_PADDING,
+      width: bounds.maxX - bounds.minX + CANVAS_PADDING * 2,
+      height: bounds.maxY - bounds.minY + CANVAS_PADDING * 2,
+    },
+  };
+};
+
+export const colorHashForTitle = (title: string): Effect.Effect<string> =>
+  Effect.succeed(`hsl(${hashSeed(title) % 360} 45% 90%)`).pipe(Effect.withSpan("canvas.colorHash"));
+
+export const canvasLinkHost = (url: string): Effect.Effect<string, Error> =>
+  Effect.try(() => {
+    if (!url) return "";
+    return new URL(url).host.replace(/^www\./, "");
+  }).pipe(Effect.withSpan("canvas.linkHost"));

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,9 +1,16 @@
 import { createRouter } from "@solidjs/router";
 import { getQueryClient } from "~/libs/query-client";
-import { fetchPostBySlug, fetchPosts, fetchWorks, fetchWorkBySlug } from "~/server/adapter";
+import {
+  fetchChannel,
+  fetchPostBySlug,
+  fetchPosts,
+  fetchWorks,
+  fetchWorkBySlug,
+} from "~/server/adapter";
 import NotFound from "~/routes/[...404]";
 import About from "~/routes/about";
 import Accessibility from "~/routes/accessibility";
+import CanvasPage from "~/routes/canvas/[slug]";
 import Guestbook, { fetchEntries } from "~/routes/guestbook";
 import Home from "~/routes/index";
 import PostPage from "~/routes/posts/[slug]";
@@ -90,6 +97,20 @@ export const Router = createRouter({
     { path: "/products", component: Products },
     { path: "/purchase/:productId", component: Purchase },
     { path: "/worktable", component: Worktable },
+    {
+      path: "/canvas/:slug",
+      component: CanvasPage,
+      preload: ({ params }) => {
+        if (params.slug) {
+          getQueryClient()
+            .prefetchQuery({
+              queryKey: ["canvas-channel", params.slug],
+              queryFn: () => fetchChannel(params.slug as string),
+            })
+            .catch(ignoredPrefetchError);
+        }
+      },
+    },
     { path: "*404", component: NotFound },
   ],
 });

--- a/apps/web/src/routes/canvas/[slug].tsx
+++ b/apps/web/src/routes/canvas/[slug].tsx
@@ -1,0 +1,18 @@
+import { useParams } from "@solidjs/router";
+import { httpHeader } from "@solidjs/web";
+import { createMemo } from "solid-js";
+import { CanvasChannel } from "~/components/Canvas/CanvasChannel";
+
+export default function CanvasPage() {
+  const params = useParams();
+  const slug = createMemo(() => params.slug ?? "");
+
+  httpHeader("Cache-Control", "public, max-age=600, s-maxage=3600, stale-while-revalidate=86400");
+  httpHeader("CDN-Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
+
+  return (
+    <div class="h-dvh w-full overflow-hidden">
+      <CanvasChannel slug={slug()} />
+    </div>
+  );
+}

--- a/apps/web/src/server/adapter.ts
+++ b/apps/web/src/server/adapter.ts
@@ -28,8 +28,18 @@ export function createCustomer(input: { email: string; name?: string; externalId
   return runAdapterRequest(() => callAdapter().polar.customers.post(input));
 }
 
+export function fetchChannel(slug: string) {
+  return runAdapterRequest(() => callAdapter().arena.channels({ slug }).get());
+}
+
 export function fetchChannelContents(slug: string, per: number) {
   return runAdapterRequest(() =>
     callAdapter().arena.channels({ slug }).contents.get({ query: { per } }),
+  );
+}
+
+export function fetchChannelContentsPage(slug: string, page: number, per: number) {
+  return runAdapterRequest(() =>
+    callAdapter().arena.channels({ slug }).contents.get({ query: { page, per } }),
   );
 }


### PR DESCRIPTION
Adds a full-screen canvas view at /canvas/:slug for public Are.na channels.

- Seeded scatter layout (stable per slug) via Effect with spans
- Custom pan/zoom transform layer, no PageLayout, shell chrome hidden on /canvas/*
- Lazy tiles for all block types with blurhash placeholders and title color hashes
- TomUI dialog detail per block; channel tiles link to nested canvases
- Paged infinite contents with edge prefetch and manual load-more

Checks: typecheck, lint, format, 76 web tests (9 new), production build.