### PR TITLE
perf(cms): cold-start posts/work indexes and detail pages

### DIFF
--- a/apps/adapter/src/__tests__/cms.test.ts
+++ b/apps/adapter/src/__tests__/cms.test.ts
@@ -62,6 +62,27 @@ describe("cms integration", () => {
       expect(await response.json()).toEqual(listBody);
     });
 
+    it("marks anonymous reads cacheable at the edge", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts?page=1&pageSize=5", env),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toContain("public");
+      expect(response.headers.get("Cache-Control")).toContain("s-maxage=300");
+    });
+
+    it("never caches session reads", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts?page=1&pageSize=5", env, {
+          headers: { cookie: "better-auth.session_token=abc" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    });
+
     it("forwards the category filter to the API", async () => {
       fetchMock.mockResolvedValue(jsonResponse(listBody));
       const response = await app.fetch(
@@ -105,6 +126,15 @@ describe("cms integration", () => {
         instance: "http://localhost/content/posts/missing",
       });
     });
+
+    it("never caches error responses at the edge", async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ title: "Not found" }, 404));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts/missing", env),
+      );
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Cache-Control") ?? "").not.toContain("public");
+    });
   });
 
   describe("GET /content/works", () => {
@@ -114,6 +144,68 @@ describe("cms integration", () => {
       expect(response.status).toBe(200);
       expect(fetchMock).toHaveBeenCalledWith(
         "http://localhost:8787/works?page=1&pageSize=10",
+        expect.anything(),
+      );
+    });
+
+    it("rejects the category filter instead of ignoring it", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      for (const path of [
+        "/content/works?category=essays",
+        "/content/works/summary?category=essays",
+      ]) {
+        fetchMock.mockClear();
+        const response = await app.fetch(requestWithEnv(`http://localhost${path}`, env));
+        expect(response.status).toBe(400);
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("GET /content/posts/summary", () => {
+    it("proxies pagination to the API summaries endpoint, not the slug route", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts/summary?page=1&pageSize=5", env),
+      );
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://localhost:8787/posts/summary?page=1&pageSize=5",
+        expect.anything(),
+      );
+      expect(await response.json()).toEqual(listBody);
+    });
+
+    it("marks anonymous summary reads cacheable at the edge", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts/summary", env),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toContain("public");
+    });
+
+    it("never caches summary session reads", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts/summary", env, {
+          headers: { cookie: "better-auth.session_token=abc" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    });
+  });
+
+  describe("GET /content/works/summary", () => {
+    it("proxies to the API work summaries endpoint, not the slug route", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/works/summary", env),
+      );
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://localhost:8787/works/summary?page=1&pageSize=10",
         expect.anything(),
       );
     });
@@ -175,6 +267,30 @@ describe("cms integration", () => {
       fetchMock.mockResolvedValue(jsonResponse(post));
       await app.fetch(
         requestWithEnv("http://localhost/content/posts/hello-world", env, {
+          headers: { cookie: "better-auth.session_token=abc" },
+        }),
+      );
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init.headers).get("cookie")).toBe("better-auth.session_token=abc");
+    });
+
+    it("forwards the bearer credential and never caches bearer reads", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/content/posts?page=1&pageSize=5", env, {
+          headers: { authorization: "Bearer test-token" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init.headers).get("authorization")).toBe("Bearer test-token");
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    });
+
+    it("forwards the session cookie on feed reads", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(listBody));
+      await app.fetch(
+        requestWithEnv("http://localhost/content/feed?limit=2", env, {
           headers: { cookie: "better-auth.session_token=abc" },
         }),
       );

--- a/apps/adapter/src/integrations/cms/index.ts
+++ b/apps/adapter/src/integrations/cms/index.ts
@@ -1,8 +1,15 @@
 import { Elysia } from "elysia";
 import { Effect, Schema } from "effect";
-import { CmsSlug, type CmsPost, type TiptapBlock, type TiptapDoc } from "@tom/schemas/cms";
+import {
+  CmsSlug,
+  type ArenaRef,
+  type CmsPost,
+  type TiptapBlock,
+  type TiptapDoc,
+} from "@tom/schemas/cms";
 import { INTERNAL_TOKEN_HEADER } from "@tom/constants/headers";
 import { HttpStatus, isErrorStatus } from "@tom/constants/http";
+import { hasSessionCredential } from "@tom/utils/services/session";
 import { readCloudflareEnv } from "@tom/utils/services/config";
 import { getRequestEnv, logContextFromRequest } from "@tom/utils/services/worker";
 import type { LogContext } from "@tom/utils/services/logging";
@@ -67,6 +74,54 @@ const cmsApi = async (request: Request) => {
 };
 
 const SessionBodySchema = Schema.Struct({ session: Schema.Unknown });
+
+/**
+ * Edge TTLs for anonymous CMS reads: a minute fresh at the edge, five in a
+ * shared cache, a day of stale-while-revalidate. Content edits are rare and
+ * readers tolerate slight staleness; session reads (drafts) never store.
+ */
+const PUBLIC_CMS_CACHE = "public, max-age=60, s-maxage=300, stale-while-revalidate=86400";
+const PRIVATE_NO_STORE = "private, no-store";
+
+/** List page sizes mirror the index pages that consume them. */
+const POSTS_PAGE_SIZE = 5;
+const WORKS_PAGE_SIZE = 10;
+
+/**
+ * Edge-cache public CMS reads. Anonymous responses are identical for every
+ * reader (published only), so they cache at the edge with
+ * stale-while-revalidate; session requests carry drafts and never store.
+ * Only anonymous responses ever populate the cache, so an admin preview
+ * may read stale-published but an anonymous reader can never see drafts.
+ * Called only after a successful proxy — error responses never store.
+ */
+const setCmsCache = (request: Request, set: { headers: Record<string, string | number> }): void => {
+  if (hasSessionCredential(request)) {
+    set.headers["Cache-Control"] = PRIVATE_NO_STORE;
+    return;
+  }
+  set.headers["Cache-Control"] = PUBLIC_CMS_CACHE;
+  set.headers["CDN-Cache-Control"] = PUBLIC_CMS_CACHE;
+};
+
+type CmsApi = Awaited<ReturnType<typeof cmsApi>>["api"];
+
+/**
+ * Proxy a public CMS read, then mark it cacheable. The cache headers go on
+ * after the upstream succeeds so 404/500 problem responses never store at
+ * the edge (a fresh slug would 404 for the whole s-maxage otherwise).
+ */
+const proxyCachedCms = async <T>(
+  request: Request,
+  set: { headers: Record<string, string | number> },
+  resource: string,
+  call: (api: CmsApi) => TreatyCall<T>,
+): Promise<T> => {
+  const { api, context } = await cmsApi(request);
+  const data = await proxyCms(call(api), resource, context);
+  setCmsCache(request, set);
+  return data;
+};
 
 /**
  * Session gate for CMS writes. The browser session cookie rides the
@@ -281,11 +336,6 @@ const toFeedDoc = (post: CmsPost) => ({
   content: post.html,
 });
 
-export type ArenaRef = {
-  readonly slug: string;
-  readonly title?: string;
-};
-
 /** Arena channel references embedded in a Tiptap document, in order. */
 export const extractArenaRefs = (doc: TiptapDoc): Array<ArenaRef> => {
   const refs: Array<ArenaRef> = [];
@@ -310,14 +360,24 @@ const PostQuerySchema = Schema.Struct({
   pageSize: Schema.optional(Schema.NumberFromString),
   status: Schema.optional(Schema.Literals(["all", "draft", "published"])),
   category: Schema.optional(CmsSlug),
+  excludeCategory: Schema.optional(CmsSlug),
 });
 
 type PostQuery = typeof PostQuerySchema.Type;
 
-/** Forward the browser session cookie so the API can unlock drafts. */
-const sessionHeaders = (request: Request): { cookie?: string } => {
+/**
+ * Forward the session credential so the API can unlock drafts. Cookie and
+ * bearer both ride the hop — the API's hasSessionCredential keys off the
+ * same pair, so a bearer-authed admin never reads published-only data that
+ * the edge then caches as public.
+ */
+const sessionHeaders = (request: Request) => {
+  const headers: Record<string, string> = {};
   const cookie = request.headers.get("cookie");
-  return cookie === null ? {} : { cookie };
+  if (cookie !== null) headers["cookie"] = cookie;
+  const authorization = request.headers.get("authorization");
+  if (authorization !== null) headers["authorization"] = authorization;
+  return headers;
 };
 
 const statusQuery = (query: PostQuery): { status?: "all" | "draft" | "published" } =>
@@ -325,6 +385,22 @@ const statusQuery = (query: PostQuery): { status?: "all" | "draft" | "published"
 
 const categoryQuery = (query: PostQuery): { category?: string } =>
   query.category === undefined ? {} : { category: query.category };
+
+const excludeCategoryQuery = (query: PostQuery): { excludeCategory?: string } =>
+  query.excludeCategory === undefined ? {} : { excludeCategory: query.excludeCategory };
+
+/**
+ * Works have no categories: fail closed instead of 200ing an unfiltered
+ * list the caller believes is filtered. The API enforces the same gate.
+ */
+const rejectWorkCategory = (query: PostQuery): void => {
+  if (query.category !== undefined || query.excludeCategory !== undefined) {
+    throw new AdapterError({
+      status: HttpStatus.BadRequest,
+      message: "Category filter not supported for works",
+    });
+  }
+};
 
 const postQuerySchema = Schema.toStandardSchemaV1(PostQuerySchema);
 
@@ -343,35 +419,53 @@ const MediaParamsSchema = Schema.toStandardSchemaV1(Schema.Struct({ id: Schema.S
 export const cmsIntegration = new Elysia({ name: "cms" })
   .get(
     "/content/posts",
-    async ({ query, request }) => {
-      const { api, context } = await cmsApi(request);
-      return proxyCms(
+    async ({ query, request, set }) =>
+      proxyCachedCms(request, set, "posts", (api) =>
         api.posts.get({
           query: {
             page: query.page ?? 1,
-            pageSize: query.pageSize ?? 5,
+            pageSize: query.pageSize ?? POSTS_PAGE_SIZE,
             ...statusQuery(query),
             ...categoryQuery(query),
+            ...excludeCategoryQuery(query),
           },
           headers: sessionHeaders(request),
         }),
-        "posts",
-        context,
-      );
-    },
+      ),
     {
       query: postQuerySchema,
       detail: { description: "List posts (drafts need a session)", tags: ["cms"] },
     },
   )
   .get(
+    // Static before dynamic: "/content/posts/summary" must not read as a slug.
+    "/content/posts/summary",
+    async ({ query, request, set }) =>
+      proxyCachedCms(request, set, "post summaries", (api) =>
+        api.posts.summary.get({
+          query: {
+            page: query.page ?? 1,
+            pageSize: query.pageSize ?? POSTS_PAGE_SIZE,
+            ...statusQuery(query),
+            ...categoryQuery(query),
+            ...excludeCategoryQuery(query),
+          },
+          headers: sessionHeaders(request),
+        }),
+      ),
+    {
+      query: postQuerySchema,
+      detail: {
+        description: "List post summaries, no body (drafts need a session)",
+        tags: ["cms"],
+      },
+    },
+  )
+  .get(
     "/content/posts/:slug",
-    async ({ params, request }) => {
-      const { api, context } = await cmsApi(request);
-      const post = await proxyCms(
+    async ({ params, request, set }) => {
+      const post = await proxyCachedCms(request, set, "post", (api) =>
         api.posts({ slug: params.slug }).get({ headers: sessionHeaders(request) }),
-        "post",
-        context,
       );
       return { ...post, arenaBlocks: extractArenaRefs(post.content) };
     },
@@ -382,15 +476,17 @@ export const cmsIntegration = new Elysia({ name: "cms" })
   )
   .get(
     "/content/works",
-    async ({ query, request }) => {
-      const { api, context } = await cmsApi(request);
-      return proxyCms(
+    async ({ query, request, set }) => {
+      rejectWorkCategory(query);
+      return proxyCachedCms(request, set, "works", (api) =>
         api.works.get({
-          query: { page: query.page ?? 1, pageSize: query.pageSize ?? 10, ...statusQuery(query) },
+          query: {
+            page: query.page ?? 1,
+            pageSize: query.pageSize ?? WORKS_PAGE_SIZE,
+            ...statusQuery(query),
+          },
           headers: sessionHeaders(request),
         }),
-        "works",
-        context,
       );
     },
     {
@@ -399,13 +495,34 @@ export const cmsIntegration = new Elysia({ name: "cms" })
     },
   )
   .get(
+    // Static before dynamic: "/content/works/summary" must not read as a slug.
+    "/content/works/summary",
+    async ({ query, request, set }) => {
+      rejectWorkCategory(query);
+      return proxyCachedCms(request, set, "work summaries", (api) =>
+        api.works.summary.get({
+          query: {
+            page: query.page ?? 1,
+            pageSize: query.pageSize ?? WORKS_PAGE_SIZE,
+            ...statusQuery(query),
+          },
+          headers: sessionHeaders(request),
+        }),
+      );
+    },
+    {
+      query: postQuerySchema,
+      detail: {
+        description: "List work summaries, no body (drafts need a session)",
+        tags: ["cms"],
+      },
+    },
+  )
+  .get(
     "/content/works/:slug",
-    async ({ params, request }) => {
-      const { api, context } = await cmsApi(request);
-      const work = await proxyCms(
+    async ({ params, request, set }) => {
+      const work = await proxyCachedCms(request, set, "work", (api) =>
         api.works({ slug: params.slug }).get({ headers: sessionHeaders(request) }),
-        "work",
-        context,
       );
       return { ...work, arenaBlocks: extractArenaRefs(work.content) };
     },
@@ -416,20 +533,16 @@ export const cmsIntegration = new Elysia({ name: "cms" })
   )
   .get(
     "/content/categories",
-    async ({ request }) => {
-      const { api, context } = await cmsApi(request);
-      return proxyCms(api.categories.get(), "categories", context);
-    },
+    async ({ request, set }) =>
+      proxyCachedCms(request, set, "categories", (api) => api.categories.get()),
     {
       detail: { description: "List categories", tags: ["cms"] },
     },
   )
   .get(
     "/content/media/:id",
-    async ({ params, request }) => {
-      const { api, context } = await cmsApi(request);
-      return proxyCms(api.media({ id: params.id }).get(), "media", context);
-    },
+    async ({ params, request, set }) =>
+      proxyCachedCms(request, set, "media", (api) => api.media({ id: params.id }).get()),
     {
       params: MediaParamsSchema,
       detail: { description: "Get media metadata by id", tags: ["cms"] },
@@ -469,12 +582,12 @@ export const cmsIntegration = new Elysia({ name: "cms" })
   )
   .get(
     "/content/feed",
-    async ({ query, request }) => {
-      const { api, context } = await cmsApi(request);
-      const posts = await proxyCms(
-        api.posts.get({ query: { page: 1, pageSize: query.limit ?? 20 } }),
-        "feed",
-        context,
+    async ({ query, request, set }) => {
+      const posts = await proxyCachedCms(request, set, "feed", (api) =>
+        api.posts.get({
+          query: { page: 1, pageSize: query.limit ?? 20 },
+          headers: sessionHeaders(request),
+        }),
       );
       return { docs: posts.docs.map(toFeedDoc) };
     },

--- a/apps/api/src/__tests__/cms-admin.test.ts
+++ b/apps/api/src/__tests__/cms-admin.test.ts
@@ -154,9 +154,44 @@ describe("cms admin reads", () => {
       expect(((await response.json()) as { totalDocs: number }).totalDocs).toBe(1);
     });
 
+    it("skips the session lookup without a session credential", async () => {
+      const response = await app.fetch(requestWithEnv("http://localhost/posts", authEnv(seed)));
+      expect(response.status).toBe(200);
+      expect(vi.mocked(requireSession)).not.toHaveBeenCalled();
+    });
+
+    it("skips the session lookup on every read without a credential", async () => {
+      for (const path of [
+        "/posts/summary",
+        "/works",
+        "/works/summary",
+        "/posts/hello-world",
+        "/works/hyperjam",
+      ]) {
+        vi.mocked(requireSession).mockClear();
+        const response = await app.fetch(requestWithEnv(`http://localhost${path}`, authEnv(seed)));
+        expect(response.status).toBe(200);
+        expect(vi.mocked(requireSession)).not.toHaveBeenCalled();
+      }
+    });
+
+    it("checks the session on bearer credentials", async () => {
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/posts", authEnv(seed), {
+          headers: { authorization: "Bearer test-token" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(vi.mocked(requireSession)).toHaveBeenCalled();
+    });
+
     it("lists everything for admins by default", async () => {
       vi.mocked(requireSession).mockReturnValue(adminSession());
-      const response = await app.fetch(requestWithEnv("http://localhost/posts", authEnv(seed)));
+      const response = await app.fetch(
+        requestWithEnv("http://localhost/posts", authEnv(seed), {
+          headers: { cookie: "better-auth.session_token=test" },
+        }),
+      );
       expect(response.status).toBe(200);
       expect(((await response.json()) as { totalDocs: number }).totalDocs).toBe(2);
     });
@@ -164,7 +199,9 @@ describe("cms admin reads", () => {
     it("filters drafts for admins on request", async () => {
       vi.mocked(requireSession).mockReturnValue(adminSession());
       const response = await app.fetch(
-        requestWithEnv("http://localhost/posts?status=draft", authEnv(seed)),
+        requestWithEnv("http://localhost/posts?status=draft", authEnv(seed), {
+          headers: { cookie: "better-auth.session_token=test" },
+        }),
       );
       expect(response.status).toBe(200);
       const body = (await response.json()) as { docs: Array<{ slug: string }> };
@@ -183,7 +220,9 @@ describe("cms admin reads", () => {
     it("shows drafts to admins", async () => {
       vi.mocked(requireSession).mockReturnValue(adminSession());
       const response = await app.fetch(
-        requestWithEnv("http://localhost/posts/draft-post", authEnv(seed)),
+        requestWithEnv("http://localhost/posts/draft-post", authEnv(seed), {
+          headers: { cookie: "better-auth.session_token=test" },
+        }),
       );
       expect(response.status).toBe(200);
       expect(((await response.json()) as { slug: string }).slug).toBe("draft-post");

--- a/apps/api/src/__tests__/cms-reserved-slug.test.ts
+++ b/apps/api/src/__tests__/cms-reserved-slug.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { Effect, Schema } from "effect";
+import type { CmsD1Binding, CmsD1Statement } from "@tom/utils/services/config";
+import { CmsSlug } from "@tom/schemas/cms";
+import type { CmsPostInput, CmsWorkInput, TiptapDoc } from "@tom/schemas/cms";
+import { createPost, createWork, updatePost, updateWork } from "../services/cms";
+
+/**
+ * The guard fires before any database touch, so the binding only needs to
+ * satisfy the type — a write reaching it returns empty rows (and would
+ * fail with 404, not 400).
+ */
+const inertStatement: CmsD1Statement = {
+  bind: () => inertStatement,
+  first: async () => null,
+  all: async () => ({ results: [] }),
+  run: async () => ({ success: true }),
+};
+
+const inertDb: CmsD1Binding = {
+  prepare: () => inertStatement,
+  batch: () => Promise.resolve([]),
+  exec: () => Promise.resolve({}),
+};
+
+const content: TiptapDoc = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "Hello" }] }],
+};
+
+/** The shadowed slug, branded through the same schema production uses. */
+const reservedSlug = Effect.runSync(Schema.decodeUnknownEffect(CmsSlug)("summary"));
+
+const meta = { title: null, description: null, image: null };
+
+const postInput = (slug: typeof reservedSlug): CmsPostInput => ({
+  slug,
+  title: "Title",
+  summary: null,
+  content,
+  status: "draft",
+  publishedAt: null,
+  heroMediaId: null,
+  categoryIds: [],
+  meta,
+});
+
+const workInput = (slug: typeof reservedSlug): CmsWorkInput => ({
+  slug,
+  title: "Title",
+  summary: null,
+  content,
+  status: "draft",
+  publishedAt: null,
+  heroMediaId: null,
+  meta,
+});
+
+describe("reserved slugs", () => {
+  it("rejects summary on post create", async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(createPost(inertDb, postInput(reservedSlug), "actor", "http://localhost:8788")),
+    );
+    expect(failure.status).toBe(400);
+  });
+
+  it("rejects summary on post update", async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        updatePost(
+          inertDb,
+          reservedSlug,
+          postInput(reservedSlug),
+          "actor",
+          "http://localhost:8788",
+        ),
+      ),
+    );
+    expect(failure.status).toBe(400);
+  });
+
+  it("rejects summary on work create", async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(createWork(inertDb, workInput(reservedSlug), "actor", "http://localhost:8788")),
+    );
+    expect(failure.status).toBe(400);
+  });
+
+  it("rejects summary on work update", async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        updateWork(
+          inertDb,
+          reservedSlug,
+          workInput(reservedSlug),
+          "actor",
+          "http://localhost:8788",
+        ),
+      ),
+    );
+    expect(failure.status).toBe(400);
+  });
+});

--- a/apps/api/src/__tests__/cms-summary-shape.test.ts
+++ b/apps/api/src/__tests__/cms-summary-shape.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { Schema, SchemaAST } from "effect";
+import {
+  CmsPostSchema,
+  CmsPostSummarySchema,
+  CmsWorkSchema,
+  CmsWorkSummarySchema,
+} from "@tom/schemas/cms";
+
+/**
+ * Summary schemas are hand-kept subsets (Effect 4 has no Schema.omit), so
+ * pin the key parity: summary keys must equal full keys minus the body.
+ * Add a field to CmsPostSchema and this tells you to mirror it in
+ * CmsPostSummarySchema (and POST_SUMMARY_COLUMNS, derived from the same
+ * list, picks it up structurally).
+ */
+const structKeys = (schema: Schema.Schema<unknown>): Array<string> => {
+  const ast = schema.ast;
+  if (!SchemaAST.isObjects(ast)) throw new Error("expected a struct schema");
+  return ast.propertySignatures.map((signature) => String(signature.name)).sort();
+};
+
+const BODY_KEYS = ["content", "html"];
+
+describe("cms summary shapes", () => {
+  it("matches CmsPostSchema minus the body", () => {
+    const full = structKeys(CmsPostSchema).filter((key) => !BODY_KEYS.includes(key));
+    expect(structKeys(CmsPostSummarySchema)).toEqual(full);
+  });
+
+  it("matches CmsWorkSchema minus the body", () => {
+    const full = structKeys(CmsWorkSchema).filter((key) => !BODY_KEYS.includes(key));
+    expect(structKeys(CmsWorkSummarySchema)).toEqual(full);
+  });
+});

--- a/apps/api/src/__tests__/cms.test.ts
+++ b/apps/api/src/__tests__/cms.test.ts
@@ -98,24 +98,42 @@ const scopeByCategory = (
   sql: string,
   values: ReadonlyArray<string | number | null>,
 ): Array<Row> => {
-  if (!sql.includes("c.slug = ?")) return [...posts];
-  const slug = values[2] ?? null;
-  if (slug === null) return [...posts];
-  return posts.filter((row) => postCategories(seed, String(row["id"])).includes(String(slug)));
+  const includeMatch = sql.includes("AND EXISTS (SELECT 1 FROM post_categories");
+  const excludeMatch = sql.includes("NOT EXISTS (SELECT 1 FROM post_categories");
+  if (!includeMatch && !excludeMatch) return [...posts];
+  let scoped = [...posts];
+  let position = 2;
+  if (includeMatch) {
+    const slug = values[position++] ?? null;
+    if (slug !== null) {
+      scoped = scoped.filter((row) =>
+        postCategories(seed, String(row["id"])).includes(String(slug)),
+      );
+    }
+  }
+  if (excludeMatch) {
+    const slug = values[position] ?? null;
+    if (slug !== null) {
+      scoped = scoped.filter(
+        (row) => !postCategories(seed, String(row["id"])).includes(String(slug)),
+      );
+    }
+  }
+  return scoped;
 };
 
-/** Page bounds from bound values; positions shift with a category filter. */
+/** Page bounds from bound values; category filters shift the positions. */
 type PageBounds = {
   readonly limit: number;
   readonly offset: number;
 };
 
 const pageBounds = (sql: string, values: ReadonlyArray<string | number | null>): PageBounds => {
-  if (sql.includes("c.slug = ?")) {
-    return { limit: Number(values[3] ?? 10), offset: Number(values[4] ?? 0) };
-  }
-  if (values.length > 2) return { limit: Number(values[2]), offset: Number(values[3]) };
-  return { limit: Number(values[0] ?? 10), offset: Number(values[1] ?? 0) };
+  void sql;
+  return {
+    limit: Number(values[values.length - 2] ?? 10),
+    offset: Number(values[values.length - 1] ?? 0),
+  };
 };
 
 const runQuery = async <T>(
@@ -344,6 +362,102 @@ describe("cms routes", () => {
     expect(list.status).toBe(200);
     const listBody = (await list.json()) as { docs: Array<{ slug: string }> };
     expect(listBody.docs.map((doc) => doc.slug)).toEqual(["atelier", "hyperjam"]);
+  });
+
+  it("lists post summaries without the body", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts/summary?page=1&pageSize=10", seedEnv(fullSeed)),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      docs: Array<{
+        slug: string;
+        title: string;
+        updatedAt: string;
+        categories: Array<{ slug: string }>;
+      }>;
+      totalDocs: number;
+      totalPages: number;
+    };
+    expect(body.totalDocs).toBe(2);
+    expect(body.totalPages).toBe(1);
+    expect(body.docs.map((doc) => doc.slug)).toEqual(["hello-world", "second-post"]);
+    for (const doc of body.docs) {
+      expect("html" in doc).toBe(false);
+      expect("content" in doc).toBe(false);
+    }
+    expect(body.docs[0]?.categories.map((category) => category.slug)).toEqual(["essays"]);
+  });
+
+  it("lists work summaries without the body", async () => {
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/works/summary", seedEnv(fullSeed)),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      docs: Array<{ slug: string; title: string }>;
+      totalDocs: number;
+    };
+    expect(body.totalDocs).toBe(2);
+    expect(body.docs.map((doc) => doc.slug)).toEqual(["atelier", "hyperjam"]);
+    for (const doc of body.docs) {
+      expect("html" in doc).toBe(false);
+      expect("content" in doc).toBe(false);
+    }
+  });
+
+  it("ignores the status filter on summaries for anonymous readers", async () => {
+    for (const path of ["/posts/summary?status=all", "/works/summary?status=all"]) {
+      const response = await app.fetch(
+        requestWithEnv(`http://localhost${path}`, seedEnv(fullSeed)),
+      );
+      expect(response.status).toBe(200);
+      expect(((await response.json()) as { totalDocs: number }).totalDocs).toBe(2);
+    }
+  });
+
+  it("rejects the category filter on works lists", async () => {
+    for (const path of ["/works?category=essays", "/works/summary?category=essays"]) {
+      const response = await app.fetch(
+        requestWithEnv(`http://localhost${path}`, seedEnv(fullSeed)),
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it("excludes one category server-side without skewing totals", async () => {
+    const seed: Seed = {
+      ...fullSeed,
+      categories: [...fullSeed.categories, { id: "cat-2", slug: "pages", title: "Pages" }],
+      links: [...fullSeed.links, { postId: "post-2", categoryId: "cat-2" }],
+    };
+    for (const path of ["/posts?excludeCategory=pages", "/posts/summary?excludeCategory=pages"]) {
+      const response = await app.fetch(requestWithEnv(`http://localhost${path}`, seedEnv(seed)));
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        docs: Array<{ slug: string }>;
+        totalDocs: number;
+      };
+      expect(body.docs.map((doc) => doc.slug)).toEqual(["hello-world"]);
+      expect(body.totalDocs).toBe(1);
+    }
+  });
+
+  it("serves the summary list even when a post takes the reserved slug", async () => {
+    const seed: Seed = {
+      ...fullSeed,
+      posts: [...fullSeed.posts, postRow({ id: "post-9", slug: "summary", title: "Summary" })],
+    };
+    const response = await app.fetch(
+      requestWithEnv("http://localhost/posts/summary?page=1&pageSize=10", seedEnv(seed)),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      docs: Array<{ slug: string }>;
+      totalDocs: number;
+    };
+    expect(body.totalDocs).toBe(3);
+    expect(body.docs.map((doc) => doc.slug)).toContain("summary");
   });
 
   it("returns a work by slug", async () => {

--- a/apps/api/src/routes/cms.ts
+++ b/apps/api/src/routes/cms.ts
@@ -1,10 +1,11 @@
 import { Elysia } from "elysia";
 import { Effect, Schema } from "effect";
 import { CmsPagingSchema } from "@tom/schemas/cms";
-import type { CmsPaging } from "@tom/schemas/cms";
+import type { CmsListResponse, CmsPaging, CmsStatusFilter } from "@tom/schemas/cms";
 import { CmsError } from "@tom/types/errors";
 import { HttpStatus } from "@tom/constants/http";
 import type { CmsD1Binding, CmsR2Binding, CloudflareEnv } from "@tom/utils/services/config";
+import { hasSessionCredential } from "@tom/utils/services/session";
 import { getRequestEnv, logContextFromRequest, runEffect } from "@tom/utils/services/worker";
 import { toOpenApiSchema } from "../openapi";
 import { createAuthFromEnv, requireSession } from "../services/auth";
@@ -14,7 +15,9 @@ import {
   getPostBySlug,
   getWorkBySlug,
   listCategories,
+  listPostSummaries,
   listPosts,
+  listWorkSummaries,
   listWorks,
 } from "../services/cms";
 
@@ -140,14 +143,19 @@ const putFileCache = (url: string, response: Response): Effect.Effect<void, neve
 /**
  * Best-effort admin check for reads: a live session unlocks drafts,
  * anything else falls back to published-only. Never fails, so anonymous
- * readers never see auth errors.
+ * readers never see auth errors. Fast-path: without a session credential
+ * (see hasSessionCredential) there is no session to load, so skip auth
+ * init and the D1 lookup entirely — public reads stay at 2-3 D1 queries
+ * instead of 3-4.
  */
-const optionalSession = (request: Request, env: CloudflareEnv): Effect.Effect<boolean, never> =>
-  createAuthFromEnv(env).pipe(
+const optionalSession = (request: Request, env: CloudflareEnv): Effect.Effect<boolean, never> => {
+  if (!hasSessionCredential(request)) return Effect.succeed(false);
+  return createAuthFromEnv(env).pipe(
     Effect.flatMap((auth) => requireSession(auth, request.headers)),
     Effect.as(true),
     Effect.orElseSucceed(() => false),
   );
+};
 
 /** Run a CMS effect with request logging. CmsError failures reject and the
  * worker onError hook maps them to RFC 9457 problem responses, so route
@@ -155,27 +163,65 @@ const optionalSession = (request: Request, env: CloudflareEnv): Effect.Effect<bo
 const runCms = <A>(effect: Effect.Effect<A, CmsError>, request: Request): Promise<A> =>
   runEffect(effect, logContextFromRequest(request, "tom-api"));
 
+/**
+ * Shared list pipeline: storage gate, paging decode, admin check, then the
+ * service list fn. Works have no categories, so their routes reject the
+ * filter instead of silently ignoring it.
+ */
+const runListQuery = <T, Q>(
+  request: Request,
+  query: Q,
+  operation: string,
+  allowCategory: boolean,
+  list: (
+    db: CmsD1Binding,
+    paging: CmsPaging,
+    status: CmsStatusFilter,
+  ) => Effect.Effect<CmsListResponse<T>, CmsError>,
+): Promise<CmsListResponse<T>> => {
+  const env = getRequestEnv(request);
+  return runCms(
+    requireCmsD1(env).pipe(
+      Effect.flatMap((db) =>
+        Effect.flatMap(decodePagingQuery(query, operation), (paging) =>
+          !allowCategory && (paging.category !== undefined || paging.excludeCategory !== undefined)
+            ? Effect.fail(
+                new CmsError({
+                  message: "Category filter not supported for works",
+                  status: HttpStatus.BadRequest,
+                  operation,
+                }),
+              )
+            : Effect.flatMap(optionalSession(request, env), (isAdmin) =>
+                list(db, paging, isAdmin ? (paging.status ?? "all") : "published"),
+              ),
+        ),
+      ),
+    ),
+    request,
+  );
+};
+
 export const cmsRoutes = new Elysia({ name: "cms" })
   .get(
     "/posts",
-    ({ query, request }) => {
-      const env = getRequestEnv(request);
-      return runCms(
-        requireCmsD1(env).pipe(
-          Effect.flatMap((db) =>
-            Effect.flatMap(decodePagingQuery(query, "list_posts"), (paging) =>
-              Effect.flatMap(optionalSession(request, env), (isAdmin) =>
-                listPosts(db, paging, isAdmin ? (paging.status ?? "all") : "published"),
-              ),
-            ),
-          ),
-        ),
-        request,
-      );
-    },
+    ({ query, request }) => runListQuery(request, query, "list_posts", true, listPosts),
     {
       query: cmsListQuerySchema,
       detail: { description: "List posts (drafts need a session)", tags: ["cms"] },
+    },
+  )
+  .get(
+    // Static before dynamic: "/posts/summary" must not read as a slug.
+    "/posts/summary",
+    ({ query, request }) =>
+      runListQuery(request, query, "list_post_summaries", true, listPostSummaries),
+    {
+      query: cmsListQuerySchema,
+      detail: {
+        description: "List post summaries, no body (drafts need a session)",
+        tags: ["cms"],
+      },
     },
   )
   .get(
@@ -202,24 +248,23 @@ export const cmsRoutes = new Elysia({ name: "cms" })
   )
   .get(
     "/works",
-    ({ query, request }) => {
-      const env = getRequestEnv(request);
-      return runCms(
-        requireCmsD1(env).pipe(
-          Effect.flatMap((db) =>
-            Effect.flatMap(decodePagingQuery(query, "list_works"), (paging) =>
-              Effect.flatMap(optionalSession(request, env), (isAdmin) =>
-                listWorks(db, paging, isAdmin ? (paging.status ?? "all") : "published"),
-              ),
-            ),
-          ),
-        ),
-        request,
-      );
-    },
+    ({ query, request }) => runListQuery(request, query, "list_works", false, listWorks),
     {
       query: cmsListQuerySchema,
       detail: { description: "List works (drafts need a session)", tags: ["cms"] },
+    },
+  )
+  .get(
+    // Static before dynamic: "/works/summary" must not read as a slug.
+    "/works/summary",
+    ({ query, request }) =>
+      runListQuery(request, query, "list_work_summaries", false, listWorkSummaries),
+    {
+      query: cmsListQuerySchema,
+      detail: {
+        description: "List work summaries, no body (drafts need a session)",
+        tags: ["cms"],
+      },
     },
   )
   .get(

--- a/apps/api/src/services/cms.ts
+++ b/apps/api/src/services/cms.ts
@@ -7,9 +7,11 @@ import {
   CmsMediaUsageRefSchema,
   CmsPostInputSchema,
   CmsPostSchema,
+  CmsPostSummarySchema,
   CmsRevisionMetaSchema,
   CmsWorkInputSchema,
   CmsWorkSchema,
+  CmsWorkSummarySchema,
 } from "@tom/schemas/cms";
 import type {
   CmsCategory,
@@ -20,12 +22,14 @@ import type {
   CmsPaging,
   CmsPost,
   CmsPostInput,
+  CmsPostSummary,
   CmsRevisionEntity,
   CmsRevisionMeta,
   CmsRevisionSnapshot,
   CmsStatusFilter,
   CmsWork,
   CmsWorkInput,
+  CmsWorkSummary,
   TiptapDoc,
 } from "@tom/schemas/cms";
 import { CmsError } from "@tom/types/errors";
@@ -51,6 +55,23 @@ type PostRow = {
 };
 
 type WorkRow = PostRow;
+
+type PostSummaryRow = {
+  readonly id: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string | null;
+  readonly status: string;
+  readonly published_at: string | null;
+  readonly hero_media_id: string | null;
+  readonly meta_title: string | null;
+  readonly meta_description: string | null;
+  readonly meta_image: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+type WorkSummaryRow = PostSummaryRow;
 
 type MediaRow = {
   readonly id: string;
@@ -82,10 +103,47 @@ type RevisionRow = {
 /** Revisions kept per document; older snapshots prune on write. */
 const MAX_REVISIONS = 20;
 
-const POST_COLUMNS =
-  "p.id, p.slug, p.title, p.summary, p.content_json, p.html, p.status, " +
-  "p.published_at, p.hero_media_id, p.meta_title, p.meta_description, " +
-  "p.meta_image, p.created_at, p.updated_at";
+const POST_COLUMN_LIST = [
+  "p.id",
+  "p.slug",
+  "p.title",
+  "p.summary",
+  "p.content_json",
+  "p.html",
+  "p.status",
+  "p.published_at",
+  "p.hero_media_id",
+  "p.meta_title",
+  "p.meta_description",
+  "p.meta_image",
+  "p.created_at",
+  "p.updated_at",
+];
+
+const POST_COLUMNS = POST_COLUMN_LIST.join(", ");
+
+/**
+ * List columns: everything except the heavy body (content_json, html).
+ * Derived from POST_COLUMNS so a new column cannot silently miss the
+ * summary selects (a missing column 500s the summary decode instead).
+ */
+const POST_SUMMARY_COLUMNS = POST_COLUMN_LIST.filter(
+  (column) => column !== "p.content_json" && column !== "p.html",
+).join(", ");
+
+/** Slugs shadowed by static API routes; single reads for them are unreachable. */
+const RESERVED_SLUGS = ["summary"];
+
+const rejectReservedSlug = (slug: string, operation: string): Effect.Effect<void, CmsError> =>
+  RESERVED_SLUGS.includes(slug)
+    ? Effect.fail(
+        new CmsError({
+          message: `Slug reserved: ${slug}`,
+          status: HttpStatus.BadRequest,
+          operation,
+        }),
+      )
+    : Effect.void;
 
 const queryAll = <T>(
   db: CmsD1Binding,
@@ -142,29 +200,34 @@ const parseContentJson = (json: string, operation: string): Effect.Effect<Tiptap
     ),
   );
 
+/** Fields shared by full and summary rows: everything except the body. */
+const baseFields = (row: PostSummaryRow) => ({
+  id: row.id,
+  slug: row.slug,
+  title: row.title,
+  summary: row.summary,
+  status: row.status,
+  publishedAt: row.published_at,
+  heroMediaId: row.hero_media_id,
+  meta: {
+    title: row.meta_title,
+    description: row.meta_description,
+    image: row.meta_image,
+  },
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
 const toPost = Effect.fn("CmsService.toPost")(function* (
   row: PostRow,
   categories: ReadonlyArray<CmsCategory>,
 ) {
   const content = yield* parseContentJson(row.content_json, "decode_post");
   return yield* Schema.decodeUnknownEffect(CmsPostSchema)({
-    id: row.id,
-    slug: row.slug,
-    title: row.title,
-    summary: row.summary,
+    ...baseFields(row),
     content,
     html: row.html,
-    status: row.status,
-    publishedAt: row.published_at,
-    heroMediaId: row.hero_media_id,
     categories,
-    meta: {
-      title: row.meta_title,
-      description: row.meta_description,
-      image: row.meta_image,
-    },
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
   }).pipe(
     Effect.mapError(
       (cause) =>
@@ -181,22 +244,9 @@ const toPost = Effect.fn("CmsService.toPost")(function* (
 const toWork = Effect.fn("CmsService.toWork")(function* (row: WorkRow) {
   const content = yield* parseContentJson(row.content_json, "decode_work");
   return yield* Schema.decodeUnknownEffect(CmsWorkSchema)({
-    id: row.id,
-    slug: row.slug,
-    title: row.title,
-    summary: row.summary,
+    ...baseFields(row),
     content,
     html: row.html,
-    status: row.status,
-    publishedAt: row.published_at,
-    heroMediaId: row.hero_media_id,
-    meta: {
-      title: row.meta_title,
-      description: row.meta_description,
-      image: row.meta_image,
-    },
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
   }).pipe(
     Effect.mapError(
       (cause) =>
@@ -204,6 +254,44 @@ const toWork = Effect.fn("CmsService.toWork")(function* (row: WorkRow) {
           message: "Invalid CMS work row",
           status: HttpStatus.InternalServerError,
           operation: "decode_work",
+          cause,
+        }),
+    ),
+  );
+});
+
+/** Slim post row: no Tiptap parse, no HTML — the body never leaves D1. */
+const toPostSummary = Effect.fn("CmsService.toPostSummary")(function* (
+  row: PostSummaryRow,
+  categories: ReadonlyArray<CmsCategory>,
+) {
+  return yield* Schema.decodeUnknownEffect(CmsPostSummarySchema)({
+    ...baseFields(row),
+    categories,
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CmsError({
+          message: "Invalid CMS post row",
+          status: HttpStatus.InternalServerError,
+          operation: "decode_post_summary",
+          cause,
+        }),
+    ),
+  );
+});
+
+/** Slim work row: no Tiptap parse, no HTML. */
+const toWorkSummary = Effect.fn("CmsService.toWorkSummary")(function* (row: WorkSummaryRow) {
+  return yield* Schema.decodeUnknownEffect(CmsWorkSummarySchema)({
+    ...baseFields(row),
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CmsError({
+          message: "Invalid CMS work row",
+          status: HttpStatus.InternalServerError,
+          operation: "decode_work_summary",
           cause,
         }),
     ),
@@ -324,38 +412,66 @@ const normalizePaging = (
   return Effect.succeed({ limit, current, offset: (current - 1) * limit });
 };
 
+/**
+ * Category scoping for post lists, shared by full and summary selects so
+ * the two cannot diverge. `category` keeps only linked posts;
+ * `excludeCategory` drops one category (Sophie hides its reserved pages
+ * without skewing totals, which a client-side filter would).
+ */
+const postListFilters = (paging: CmsPaging) => {
+  const category = paging.category ?? null;
+  const excluded = paging.excludeCategory ?? null;
+  const includeFilter =
+    category === null
+      ? ""
+      : "AND EXISTS (SELECT 1 FROM post_categories pc " +
+        "JOIN categories c ON c.id = pc.category_id " +
+        "WHERE pc.post_id = p.id AND c.slug = ?) ";
+  const includeCountFilter =
+    category === null
+      ? ""
+      : " AND EXISTS (SELECT 1 FROM post_categories pc " +
+        "JOIN categories c ON c.id = pc.category_id " +
+        "WHERE pc.post_id = posts.id AND c.slug = ?)";
+  const excludeFilter =
+    excluded === null
+      ? ""
+      : "AND NOT EXISTS (SELECT 1 FROM post_categories pc " +
+        "JOIN categories c ON c.id = pc.category_id " +
+        "WHERE pc.post_id = p.id AND c.slug = ?) ";
+  const excludeCountFilter =
+    excluded === null
+      ? ""
+      : " AND NOT EXISTS (SELECT 1 FROM post_categories pc " +
+        "JOIN categories c ON c.id = pc.category_id " +
+        "WHERE pc.post_id = posts.id AND c.slug = ?)";
+  return {
+    rowFilter: includeFilter + excludeFilter,
+    countFilter: includeCountFilter + excludeCountFilter,
+    params: [...(category === null ? [] : [category]), ...(excluded === null ? [] : [excluded])],
+  };
+};
+
 export const listPosts = Effect.fn("CmsService.listPosts")(function* (
   db: CmsD1Binding,
   paging: CmsPaging,
   status: CmsStatusFilter,
 ) {
   const { limit, current, offset } = yield* normalizePaging(paging, "list_posts");
-  const category = paging.category ?? null;
-  const filter =
-    category === null
-      ? ""
-      : "AND EXISTS (SELECT 1 FROM post_categories pc " +
-        "JOIN categories c ON c.id = pc.category_id " +
-        "WHERE pc.post_id = p.id AND c.slug = ?) ";
-  const categoryParams = category === null ? [] : [category];
+  const { rowFilter, countFilter, params } = postListFilters(paging);
   const [rows, countRow] = yield* Effect.all([
     queryAll<PostRow>(
       db,
       `SELECT ${POST_COLUMNS} FROM posts p WHERE (? = 'all' OR p.status = ?) ` +
-        filter +
+        rowFilter +
         "ORDER BY p.published_at DESC LIMIT ? OFFSET ?",
-      [status, status, ...categoryParams, limit, offset],
+      [status, status, ...params, limit, offset],
       "list_posts",
     ),
     queryFirst<{ total: number }>(
       db,
-      "SELECT COUNT(*) AS total FROM posts WHERE (? = 'all' OR status = ?)" +
-        (category === null
-          ? ""
-          : " AND EXISTS (SELECT 1 FROM post_categories pc " +
-            "JOIN categories c ON c.id = pc.category_id " +
-            "WHERE pc.post_id = posts.id AND c.slug = ?)"),
-      category === null ? [status, status] : [status, status, category],
+      "SELECT COUNT(*) AS total FROM posts WHERE (? = 'all' OR status = ?)" + countFilter,
+      [status, status, ...params],
       "count_posts",
     ),
   ]);
@@ -366,6 +482,44 @@ export const listPosts = Effect.fn("CmsService.listPosts")(function* (
     "list_posts",
   );
   const docs = yield* Effect.forEach(rows, (row) => toPost(row, grouped[row.id] ?? []));
+  return toListResponse(docs, total, current, limit);
+});
+
+/**
+ * Slim post list for indexes and sitemaps: selects no body columns and
+ * skips the Tiptap parse, so list payloads stay small. Full reads (single
+ * post, feed, editor) keep listPosts.
+ */
+export const listPostSummaries = Effect.fn("CmsService.listPostSummaries")(function* (
+  db: CmsD1Binding,
+  paging: CmsPaging,
+  status: CmsStatusFilter,
+) {
+  const { limit, current, offset } = yield* normalizePaging(paging, "list_post_summaries");
+  const { rowFilter, countFilter, params } = postListFilters(paging);
+  const [rows, countRow] = yield* Effect.all([
+    queryAll<PostSummaryRow>(
+      db,
+      `SELECT ${POST_SUMMARY_COLUMNS} FROM posts p WHERE (? = 'all' OR p.status = ?) ` +
+        rowFilter +
+        "ORDER BY p.published_at DESC LIMIT ? OFFSET ?",
+      [status, status, ...params, limit, offset],
+      "list_post_summaries",
+    ),
+    queryFirst<{ total: number }>(
+      db,
+      "SELECT COUNT(*) AS total FROM posts WHERE (? = 'all' OR status = ?)" + countFilter,
+      [status, status, ...params],
+      "count_post_summaries",
+    ),
+  ]);
+  const total = countRow?.total ?? 0;
+  const grouped = yield* categoriesForPosts(
+    db,
+    rows.map((row) => row.id),
+    "list_post_summaries",
+  );
+  const docs = yield* Effect.forEach(rows, (row) => toPostSummary(row, grouped[row.id] ?? []));
   return toListResponse(docs, total, current, limit);
 });
 
@@ -414,6 +568,36 @@ export const listWorks = Effect.fn("CmsService.listWorks")(function* (
   ]);
   const total = countRow?.total ?? 0;
   const docs = yield* Effect.forEach(rows, (row) => toWork(row));
+  return toListResponse(docs, total, current, limit);
+});
+
+/**
+ * Slim work list for indexes and sitemaps: no body columns, no Tiptap
+ * parse. Full reads (single work, editor) keep listWorks.
+ */
+export const listWorkSummaries = Effect.fn("CmsService.listWorkSummaries")(function* (
+  db: CmsD1Binding,
+  paging: CmsPaging,
+  status: CmsStatusFilter,
+) {
+  const { limit, current, offset } = yield* normalizePaging(paging, "list_work_summaries");
+  const [rows, countRow] = yield* Effect.all([
+    queryAll<WorkSummaryRow>(
+      db,
+      `SELECT ${POST_SUMMARY_COLUMNS} FROM works p WHERE (? = 'all' OR p.status = ?) ` +
+        "ORDER BY p.title COLLATE NOCASE ASC LIMIT ? OFFSET ?",
+      [status, status, limit, offset],
+      "list_work_summaries",
+    ),
+    queryFirst<{ total: number }>(
+      db,
+      "SELECT COUNT(*) AS total FROM works WHERE (? = 'all' OR status = ?)",
+      [status, status],
+      "count_work_summaries",
+    ),
+  ]);
+  const total = countRow?.total ?? 0;
+  const docs = yield* Effect.forEach(rows, (row) => toWorkSummary(row));
   return toListResponse(docs, total, current, limit);
 });
 
@@ -565,10 +749,12 @@ export type {
   CmsListResponse,
   CmsMedia,
   CmsPost,
+  CmsPostSummary,
   CmsRevisionEntity,
   CmsRevisionMeta,
   CmsRevisionSnapshot,
   CmsWork,
+  CmsWorkSummary,
 };
 
 export type MediaUpload = {
@@ -962,6 +1148,7 @@ export const createPost = Effect.fn("CmsService.createPost")(function* (
   actor: string,
   adapterUrl: string,
 ) {
+  yield* rejectReservedSlug(input.slug, "create_post");
   const taken = yield* findRowBySlug<PostRow>(db, "posts", input.slug, "create_post");
   if (taken) {
     return yield* new CmsError({
@@ -986,6 +1173,7 @@ export const updatePost = Effect.fn("CmsService.updatePost")(function* (
   actor: string,
   adapterUrl: string,
 ) {
+  yield* rejectReservedSlug(slug, "update_post");
   if (input.slug !== slug) {
     return yield* new CmsError({
       message: "Post slug is immutable",
@@ -1062,6 +1250,7 @@ export const createWork = Effect.fn("CmsService.createWork")(function* (
   actor: string,
   adapterUrl: string,
 ) {
+  yield* rejectReservedSlug(input.slug, "create_work");
   const taken = yield* findRowBySlug<WorkRow>(db, "works", input.slug, "create_work");
   if (taken) {
     return yield* new CmsError({
@@ -1085,6 +1274,7 @@ export const updateWork = Effect.fn("CmsService.updateWork")(function* (
   actor: string,
   adapterUrl: string,
 ) {
+  yield* rejectReservedSlug(slug, "update_work");
   if (input.slug !== slug) {
     return yield* new CmsError({
       message: "Work slug is immutable",

--- a/apps/simulator/src/cms.ts
+++ b/apps/simulator/src/cms.ts
@@ -1,6 +1,11 @@
 import { Elysia } from "elysia";
 import { Schema } from "effect";
-import { CmsPostSchema, CmsWorkSchema } from "@tom/schemas/cms";
+import {
+  CmsPostSchema,
+  CmsPostSummarySchema,
+  CmsWorkSchema,
+  CmsWorkSummarySchema,
+} from "@tom/schemas/cms";
 import type { CmsPost, CmsWork } from "@tom/schemas/cms";
 import postFixtures from "../fixtures/cms-posts.json" with { type: "json" };
 import workFixtures from "../fixtures/cms-works.json" with { type: "json" };
@@ -14,24 +19,39 @@ import workFixtures from "../fixtures/cms-works.json" with { type: "json" };
 const posts = Schema.decodeUnknownSync(Schema.Array(CmsPostSchema))(postFixtures);
 const works = Schema.decodeUnknownSync(Schema.Array(CmsWorkSchema))(workFixtures);
 
+/**
+ * Slim list items, mirroring the real summary endpoints: the same fixtures
+ * decoded through the summary schemas, so the body never leaves the
+ * simulator and shape drift fails at boot.
+ */
+const postSummaries = Schema.decodeUnknownSync(Schema.Array(CmsPostSummarySchema))(posts);
+const workSummaries = Schema.decodeUnknownSync(Schema.Array(CmsWorkSummarySchema))(works);
+
 type CmsDoc = CmsPost | CmsWork;
 
-const byPublishedDesc = (a: CmsDoc, b: CmsDoc): number =>
+type ListableDoc = {
+  readonly status: string;
+  readonly title: string;
+  readonly publishedAt: string | null;
+};
+
+const byPublishedDesc = (a: ListableDoc, b: ListableDoc): number =>
   (b.publishedAt ?? "").localeCompare(a.publishedAt ?? "");
 
-const byTitleAsc = (a: CmsDoc, b: CmsDoc): number =>
+const byTitleAsc = (a: ListableDoc, b: ListableDoc): number =>
   a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
 
 /**
  * Minimal CMS list shape ({ docs, totalDocs, ... }). Serves published docs
  * only — posts newest first, works alphabetical — the same contract as the
- * real API (apps/api).
+ * real API (apps/api). Filter params are accepted and ignored: the fixture
+ * store holds published docs only, so there is nothing to scope.
  */
 const listResponse = (
-  docs: ReadonlyArray<CmsDoc>,
+  docs: ReadonlyArray<ListableDoc>,
   page: number,
   limit: number,
-  sort: (a: CmsDoc, b: CmsDoc) => number,
+  sort: (a: ListableDoc, b: ListableDoc) => number,
 ) => {
   const published = docs.filter((doc) => doc.status === "published").sort(sort);
   const totalDocs = published.length;
@@ -55,6 +75,9 @@ const listQuery = Schema.toStandardSchemaV1(
     page: Schema.optional(Schema.NumberFromString),
     pageSize: Schema.optional(Schema.NumberFromString),
     limit: Schema.optional(Schema.NumberFromString),
+    status: Schema.optional(Schema.String),
+    category: Schema.optional(Schema.String),
+    excludeCategory: Schema.optional(Schema.String),
   }),
 );
 
@@ -84,6 +107,21 @@ export const cmsSimulator = new Elysia({ name: "cms-simulator" })
       detail: { description: "Simulated CMS posts", tags: ["cms"] },
     },
   )
+  // Static before dynamic: "/posts/summary" must not read as a slug.
+  .get(
+    "/posts/summary",
+    ({ query }) =>
+      listResponse(
+        postSummaries,
+        query.page ?? 1,
+        query.pageSize ?? query.limit ?? 10,
+        byPublishedDesc,
+      ),
+    {
+      query: listQuery,
+      detail: { description: "Simulated CMS post summaries, no body", tags: ["cms"] },
+    },
+  )
   .get("/posts/:slug", ({ params, set }) => single(findPublished(posts, params.slug), set), {
     params: slugParams,
     detail: { description: "Simulated CMS post by slug", tags: ["cms"] },
@@ -95,6 +133,16 @@ export const cmsSimulator = new Elysia({ name: "cms-simulator" })
     {
       query: listQuery,
       detail: { description: "Simulated CMS works", tags: ["cms"] },
+    },
+  )
+  // Static before dynamic: "/works/summary" must not read as a slug.
+  .get(
+    "/works/summary",
+    ({ query }) =>
+      listResponse(workSummaries, query.page ?? 1, query.pageSize ?? query.limit ?? 10, byTitleAsc),
+    {
+      query: listQuery,
+      detail: { description: "Simulated CMS work summaries, no body", tags: ["cms"] },
     },
   )
   .get("/works/:slug", ({ params, set }) => single(findPublished(works, params.slug), set), {

--- a/apps/sophie/src/App.tsx
+++ b/apps/sophie/src/App.tsx
@@ -1,9 +1,7 @@
-import { Loading, Show, createSignal } from "solid-js";
+import { Loading, Match, Show, Switch, createSignal } from "solid-js";
 import { createRouter, useParams } from "@solidjs/router";
 import { QueryClientProvider, useQuery } from "@tanstack/solid-query";
-import { HttpStatus } from "@tom/constants/http";
-import type { CmsPost } from "@tom/schemas/cms";
-import { HttpError } from "@tom/types/errors";
+import type { CmsPostSummary } from "@tom/schemas/cms";
 import { Metadata } from "@tom/ui/Meta";
 import { Banner } from "@tom/ui/banner";
 import { Breadcrumbs } from "@tom/ui/breadcrumbs";
@@ -18,7 +16,6 @@ import {
   fetchPost,
   fetchPosts,
   formatPublishedDate,
-  isPage,
 } from "./lib/posts";
 import { Nav } from "./components/Nav";
 import { CategoryFilter } from "./components/CategoryFilter";
@@ -89,11 +86,9 @@ const Posts = () => {
     queryFn: fetchCategories,
   }));
 
-  // The active filter runs server-side (?category=), so the page window and
-  // totalPages already match it. Pages stay hidden client-side: the backend
-  // has no exclusion filter and "pages" is a tiny reserved set.
-  const visible = (): ReadonlyArray<CmsPost> =>
-    (postsQuery.data?.docs ?? []).filter((post) => !isPage(post));
+  // The category filter and the reserved-pages exclusion both run
+  // server-side, so the page window and totalPages already match.
+  const visible = (): ReadonlyArray<CmsPostSummary> => postsQuery.data?.docs ?? [];
   const totalPages = (): number => postsQuery.data?.totalPages ?? 1;
 
   return (
@@ -143,60 +138,65 @@ const PostDetail = () => {
     queryKey: ["sophie-post", params.slug],
     queryFn: () => {
       const slug = params.slug;
-      if (!slug) {
-        throw new HttpError({
-          message: "Missing post slug",
-          status: HttpStatus.NotFound,
-        });
-      }
+      if (!slug) return Promise.resolve(null);
       return fetchPost(slug);
     },
     // Hold the SSR stream until the post resolves, so the <head> flushes
     // with title/og meta instead of an empty head.
     deferStream: true,
+    // Absent slugs settle as null data: evict fast so a freshly published
+    // slug refetches instead of replaying Missing from the cache.
+    gcTime: 1000 * 60,
   }));
 
   return (
     <main>
       {/* No Loading wrapper: the query promise suspends to the outer boundary
-        so the SSR stream holds until data resolves and head takes the meta. */}
-      <Show
-        when={postQuery.data}
+        so the SSR stream holds until data resolves and head takes the meta.
+        Absent posts settle as null and fall to the missing state. */}
+      <Switch
         fallback={
-          <Show
-            when={postQuery.isError}
-            fallback={
-              <p class="flex items-center gap-2">
-                <Loader size="sm" /> Loading…
-              </p>
-            }
-          >
-            <Banner variant="error" description={postQuery.error?.message ?? "Load failed"} />
-          </Show>
+          <article>
+            <h1 class="sophie-title">Missing</h1>
+            <p>No post lives here.</p>
+            <p>
+              <a href="/">Posts</a>
+            </p>
+          </article>
         }
       >
-        {(found) => (
-          <article>
-            <Metadata
-              title={found().title}
-              metaType="description"
-              metaContent={found().summary ?? SOPHIE_DESCRIPTION}
-              brand={SOPHIE_BRAND}
-              date={formatPublishedDate(found().publishedAt)}
-            />
-            <div class="sophie-crumbs">
-              <Breadcrumbs
-                size="sm"
-                items={[{ label: "Posts", href: "/" }, { label: found().title }]}
+        <Match when={postQuery.isPending}>
+          <p class="flex items-center gap-2">
+            <Loader size="sm" /> Loading…
+          </p>
+        </Match>
+        <Match when={postQuery.data}>
+          {(found) => (
+            <article>
+              <Metadata
+                title={found().title}
+                metaType="description"
+                metaContent={found().summary ?? SOPHIE_DESCRIPTION}
+                brand={SOPHIE_BRAND}
+                date={formatPublishedDate(found().publishedAt)}
               />
-            </div>
-            {/* post.html is rendered at write time from a validated Tiptap
-              doc via renderTiptapHtml (escaped, unsafe schemes dropped),
-              so innerHTML is safe here. Pinned by html.test.ts. */}
-            <div class="sophie-body" innerHTML={found().html} />
-          </article>
-        )}
-      </Show>
+              <div class="sophie-crumbs">
+                <Breadcrumbs
+                  size="sm"
+                  items={[{ label: "Posts", href: "/" }, { label: found().title }]}
+                />
+              </div>
+              {/* post.html is rendered at write time from a validated Tiptap
+                doc via renderTiptapHtml (escaped, unsafe schemes dropped),
+                so innerHTML is safe here. Pinned by html.test.ts. */}
+              <div class="sophie-body" innerHTML={found().html} />
+            </article>
+          )}
+        </Match>
+        <Match when={postQuery.isError}>
+          <Banner variant="error" description={postQuery.error?.message ?? "Load failed"} />
+        </Match>
+      </Switch>
     </main>
   );
 };

--- a/apps/sophie/src/__tests__/posts.test.ts
+++ b/apps/sophie/src/__tests__/posts.test.ts
@@ -1,28 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
 import {
   ABOUT_SLUG,
   PAGES_CATEGORY,
   formatPublishedDate,
   formatPublishedDateTime,
-  indexPosts,
   isPage,
-  postsInCategory,
+  listPosts,
 } from "../lib/posts";
 
 const post = (slug: string, categories: ReadonlyArray<string>) => ({
   slug,
   categories: categories.map((entry) => ({ slug: entry })),
-});
-
-describe("postsInCategory", () => {
-  it("returns all posts without a filter", () => {
-    expect(postsInCategory([post("a", ["x"])], null)).toHaveLength(1);
-  });
-
-  it("filters posts by category slug", () => {
-    const posts = [post("a", ["essays"]), post("b", ["notes"])];
-    expect(postsInCategory(posts, "essays").map((entry) => entry.slug)).toEqual(["a"]);
-  });
 });
 
 describe("formatPublishedDateTime", () => {
@@ -48,14 +37,6 @@ describe("isPage", () => {
   });
 });
 
-describe("indexPosts", () => {
-  it("hides pages then filters by category", () => {
-    const posts = [post("about", [PAGES_CATEGORY]), post("a", ["essays"]), post("b", ["notes"])];
-    expect(indexPosts(posts, null).map((entry) => entry.slug)).toEqual(["a", "b"]);
-    expect(indexPosts(posts, "essays").map((entry) => entry.slug)).toEqual(["a"]);
-  });
-});
-
 describe("formatPublishedDate", () => {
   it("formats a full date without time", () => {
     expect(formatPublishedDate("2026-09-01T00:00:00.000Z")).toContain("2026");
@@ -65,5 +46,90 @@ describe("formatPublishedDate", () => {
   it("renders empty for null and invalid dates", () => {
     expect(formatPublishedDate(null)).toBe("");
     expect(formatPublishedDate("not-a-date")).toBe("");
+  });
+});
+
+describe("listPosts", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  const summaryList = {
+    docs: [
+      {
+        id: "post-1",
+        slug: "hello-world",
+        title: "Hello World",
+        summary: "A summary",
+        status: "published",
+        publishedAt: "2026-09-01T00:00:00.000Z",
+        heroMediaId: null,
+        categories: [{ id: "cat-1", slug: "essays", title: "Essays" }],
+        meta: { title: null, description: null, image: null },
+        createdAt: "2026-09-01T00:00:00.000Z",
+        updatedAt: "2026-09-02T00:00:00.000Z",
+      },
+    ],
+    totalDocs: 1,
+    limit: 10,
+    page: 1,
+    totalPages: 1,
+    hasNextPage: false,
+    hasPrevPage: false,
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(summaryList), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const requestedUrl = (): string => {
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    return String(call?.[0] ?? "");
+  };
+
+  it("reads summaries and forwards a valid category slug", async () => {
+    const result = await Effect.runPromise(listPosts(1, "essays"));
+    expect(result.docs.map((doc) => doc.slug)).toEqual(["hello-world"]);
+    for (const doc of result.docs) {
+      expect("content" in doc).toBe(false);
+      expect("html" in doc).toBe(false);
+    }
+    const url = requestedUrl();
+    expect(url).toContain("/content/posts/summary");
+    expect(url).toContain("category=essays");
+  });
+
+  it("always excludes the reserved pages category server-side", async () => {
+    await Effect.runPromise(listPosts(1, null));
+    expect(requestedUrl()).toContain(`excludeCategory=${PAGES_CATEGORY}`);
+  });
+
+  it("omits the category param without a filter", async () => {
+    await Effect.runPromise(listPosts(1, null));
+    expect(requestedUrl()).not.toContain("category=essays");
+  });
+
+  it("treats an empty filter as no filter", async () => {
+    await Effect.runPromise(listPosts(1, ""));
+    const url = requestedUrl();
+    expect(url).not.toContain("category=essays");
+    expect(url).toContain(`excludeCategory=${PAGES_CATEGORY}`);
+  });
+
+  it("fails with 400 without touching the network on an invalid category", async () => {
+    await expect(Effect.runPromise(listPosts(1, "BAD SLUG!!"))).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/sophie/src/components/PostList.tsx
+++ b/apps/sophie/src/components/PostList.tsx
@@ -1,8 +1,8 @@
 import { For, Show } from "solid-js";
-import type { CmsPost } from "@tom/schemas/cms";
+import type { CmsPostSummary } from "@tom/schemas/cms";
 import { formatPublishedDateTime } from "../lib/posts";
 
-export const PostList = (props: { posts: ReadonlyArray<CmsPost> }) => (
+export const PostList = (props: { posts: ReadonlyArray<CmsPostSummary> }) => (
   <Show when={props.posts.length > 0} fallback={<p>No posts yet.</p>}>
     <For each={props.posts}>
       {(post) => (

--- a/apps/sophie/src/lib/api.ts
+++ b/apps/sophie/src/lib/api.ts
@@ -92,3 +92,17 @@ export const adapterRequest = <T>(
 /** Run a client effect as a promise at the Solid boundary. */
 export const runClient = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
   Effect.runPromise(effect);
+
+/**
+ * Run a client read, mapping a 404 to null (absent resource). Other
+ * failures still reject, so detail pages render a not-found state from
+ * settled null data instead of an error banner.
+ */
+export const runClientOrNull = <T>(effect: Effect.Effect<T, HttpError>): Promise<T | null> =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.catchTag("HttpError", (error) =>
+        error.status === HttpStatus.NotFound ? Effect.succeed(null) : Effect.fail(error),
+      ),
+    ),
+  );

--- a/apps/sophie/src/lib/posts.ts
+++ b/apps/sophie/src/lib/posts.ts
@@ -1,7 +1,9 @@
 import { Effect, Option, Schema } from "effect";
-import type { CmsCategory, CmsListResponse, CmsPost } from "@tom/schemas/cms";
-import type { HttpError } from "@tom/types/errors";
-import { adapterRequest, callSophie, runClient } from "./api";
+import { CmsSlug } from "@tom/schemas/cms";
+import type { CmsCategory, CmsListResponse, CmsPost, CmsPostSummary } from "@tom/schemas/cms";
+import { HttpStatus } from "@tom/constants/http";
+import { HttpError } from "@tom/types/errors";
+import { adapterRequest, callSophie, runClient, runClientOrNull } from "./api";
 
 const dateFormatter = new Intl.DateTimeFormat("en-NZ", {
   year: "numeric",
@@ -35,19 +37,47 @@ export const formatPublishedDate = (value: string | null): string =>
     () => "",
   );
 
-/** List published Sophie posts, newest first, optionally within a category. */
+/**
+ * Parse the category filter at the boundary. Invalid slugs fail fast with
+ * 400 before touching the network; the shape mirrors CmsSlug, not the
+ * adapter's validation body. Empty string means no filter (the picker only
+ * emits null or a real slug, so this is defensive).
+ */
+const decodeCategoryFilter = (
+  category: string | null,
+): Effect.Effect<CmsSlug | null, HttpError> => {
+  if (category === null || category === "") return Effect.succeed(null);
+  return Schema.decodeUnknownEffect(CmsSlug)(category).pipe(
+    Effect.mapError(
+      () =>
+        new HttpError({
+          message: `Invalid category: ${category}`,
+          status: HttpStatus.BadRequest,
+        }),
+    ),
+  );
+};
+
+/** Reserved category for standalone pages (about, etc.), branded for queries. */
+export const PAGES_CATEGORY: CmsSlug = Effect.runSync(Schema.decodeUnknownEffect(CmsSlug)("pages"));
+
+/** Reserved slug for the about page. Sophie edits it as a post in Camus. */
+export const ABOUT_SLUG = "about";
+
+/**
+ * List published Sophie post summaries, newest first, optionally within a
+ * category. Standalone pages stay hidden server-side (excludeCategory) so
+ * totals match the filtered window.
+ */
 export const listPosts = (
   page: number,
   category: string | null = null,
-): Effect.Effect<CmsListResponse<CmsPost>, HttpError> =>
-  adapterRequest(() =>
-    callSophie().content.posts.get({
-      query:
-        category === null || category === ""
-          ? { page, pageSize: 10 }
-          : { page, pageSize: 10, category },
-    }),
-  );
+): Effect.Effect<CmsListResponse<CmsPostSummary>, HttpError> =>
+  Effect.flatMap(decodeCategoryFilter(category), (slug) => {
+    const baseQuery = { page, pageSize: 10, excludeCategory: PAGES_CATEGORY };
+    const query = slug === null ? baseQuery : { ...baseQuery, category: slug };
+    return adapterRequest(() => callSophie().content.posts.summary.get({ query }));
+  });
 
 /** Get one published Sophie post by slug. */
 export const getPost = (slug: string): Effect.Effect<CmsPost, HttpError> =>
@@ -61,44 +91,19 @@ export const listCategories = (): Effect.Effect<ReadonlyArray<CmsCategory>, Http
 export const fetchPosts = (
   page: number,
   category: string | null = null,
-): Promise<CmsListResponse<CmsPost>> => runClient(listPosts(page, category));
+): Promise<CmsListResponse<CmsPostSummary>> => runClient(listPosts(page, category));
 
-export const fetchPost = (slug: string): Promise<CmsPost> => runClient(getPost(slug));
+export const fetchPost = (slug: string): Promise<CmsPost | null> => runClientOrNull(getPost(slug));
 
 export const fetchCategories = (): Promise<ReadonlyArray<CmsCategory>> =>
   runClient(listCategories());
 
-export const fetchAbout = (): Promise<CmsPost> => runClient(getPost(ABOUT_SLUG));
+export const fetchAbout = (): Promise<CmsPost | null> => runClientOrNull(getPost(ABOUT_SLUG));
 
 type CategorizedPost = {
   readonly categories: ReadonlyArray<{ readonly slug: string }>;
 };
 
-/** Reserved category for standalone pages (about, etc.). */
-export const PAGES_CATEGORY = "pages";
-
-/** Reserved slug for the about page. Sophie edits it as a post in Camus. */
-export const ABOUT_SLUG = "about";
-
-/** Standalone pages stay off the posts index. */
+/** Standalone pages stay off the category picker. */
 export const isPage = <P extends CategorizedPost>(post: P): boolean =>
   post.categories.some((entry) => entry.slug === PAGES_CATEGORY);
-
-/** Filter posts by category slug on the client. */
-export const postsInCategory = <P extends CategorizedPost>(
-  posts: ReadonlyArray<P>,
-  category: string | null,
-): ReadonlyArray<P> => {
-  if (category === null || category === "") return posts;
-  return posts.filter((post) => post.categories.some((entry) => entry.slug === category));
-};
-
-/** Posts for the index: standalone pages stay hidden, then category filter. */
-export const indexPosts = <P extends CategorizedPost>(
-  posts: ReadonlyArray<P>,
-  category: string | null,
-): ReadonlyArray<P> =>
-  postsInCategory(
-    posts.filter((post) => !isPage(post)),
-    category,
-  );

--- a/apps/web/src/components/DetailStates.tsx
+++ b/apps/web/src/components/DetailStates.tsx
@@ -1,0 +1,62 @@
+import { For } from "solid-js";
+import type { ArenaRef } from "@tom/schemas/cms";
+import { PageLayout } from "@tom/ui/PageLayout";
+import { Text } from "@tom/ui/text";
+import { Loader } from "@tom/ui/loader";
+import { BlurInSection } from "~/components/BlurInSection";
+import { BlurInText } from "~/components/BlurInText";
+import { ArenaCarousel } from "~/components/Arena";
+
+/** Loading shell for post/work detail pages while the query is pending. */
+export const DetailLoading = () => (
+  <main id="main" class="mx-auto p-8 max-w-[750px]">
+    <Loader />
+  </main>
+);
+
+/** Not-found state for settled-null detail reads (the fetcher maps 404s to null). */
+export const DetailNotFound = (props: { kind: "post" | "work"; slug: string | undefined }) => (
+  <PageLayout title="Not found" description="The page you are looking for does not exist.">
+    <article>
+      <BlurInText text="Not found" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.3}>
+        <Text>
+          The {props.kind} "{props.slug}" does not exist.
+        </Text>
+      </BlurInSection>
+    </article>
+  </PageLayout>
+);
+
+/** Error banner for settled-error detail reads (500s, timeouts). */
+export const DetailError = (props: { kind: "post" | "work"; message: string }) => (
+  <PageLayout title="Error" description={`Something went wrong loading this ${props.kind}.`}>
+    <article>
+      <BlurInText text="Error" tag="h1" baseDelay={0.1} step={0.025} />
+      <BlurInSection delay={0.3}>
+        <div class="banner" role="alert">
+          <Text class="banner-title">Error loading {props.kind}</Text>
+          <Text>{props.message}</Text>
+        </div>
+      </BlurInSection>
+    </article>
+  </PageLayout>
+);
+
+/** Arena channel embeds for a detail page, staggered after the body. */
+export const DetailArenaBlocks = (props: {
+  blocks: ReadonlyArray<ArenaRef>;
+  baseDelay: number;
+}) => (
+  <For each={props.blocks}>
+    {(block, index) => (
+      <BlurInSection delay={props.baseDelay + index() * 0.2}>
+        <ArenaCarousel
+          slug={block.slug}
+          // exactOptionalPropertyTypes: omit the prop instead of passing undefined.
+          {...(block.title ? { title: block.title } : {})}
+        />
+      </BlurInSection>
+    )}
+  </For>
+);

--- a/apps/web/src/libs/adapter.ts
+++ b/apps/web/src/libs/adapter.ts
@@ -125,13 +125,35 @@ export const adapterRequest = <T>(
     }),
   );
 
-/** Run an adapter request to completion, rejecting with HttpError on failure. */
-export const runAdapterRequest = <T>(request: () => Promise<EdenResult<T>>): Promise<T> => {
+/** Run a logged adapter effect to completion in the current SSR context. */
+const runLoggedAdapterRequest = <T, E>(
+  effect: Effect.Effect<T, E>,
+  operation: string,
+): Promise<T> => {
   const context = getServerLogContext();
-  return Effect.runPromise(
-    withLogging(adapterRequest(request).pipe(Effect.withSpan("web.adapterRequest")), context),
-  );
+  return Effect.runPromise(withLogging(effect.pipe(Effect.withSpan(operation)), context));
 };
+
+/** Run an adapter request to completion, rejecting with HttpError on failure. */
+export const runAdapterRequest = <T>(request: () => Promise<EdenResult<T>>): Promise<T> =>
+  runLoggedAdapterRequest(adapterRequest(request), "web.adapterRequest");
+
+/**
+ * Run an adapter read to completion, mapping a 404 to null (absent
+ * resource). Other failures still reject, so lists keep throwing while
+ * detail pages render a not-found state from settled null data.
+ */
+export const runAdapterRequestOrNull = <T>(
+  request: () => Promise<EdenResult<T>>,
+): Promise<T | null> =>
+  runLoggedAdapterRequest(
+    adapterRequest(request).pipe(
+      Effect.catchTag("HttpError", (error) =>
+        error.status === HttpStatus.NotFound ? Effect.succeed(null) : Effect.fail(error),
+      ),
+    ),
+    "web.adapterRequestOrNull",
+  );
 
 /** Logging context for the current SSR request, if any. */
 const getServerLogContext = (): LogContext => {

--- a/apps/web/src/libs/query-client.ts
+++ b/apps/web/src/libs/query-client.ts
@@ -1,13 +1,22 @@
 import { QueryClient } from "@tanstack/solid-query";
 import { getRequestEvent } from "@solidjs/web";
 
+/** List freshness: indexes refetch after 5 minutes stale. */
+const STALE_MS = 1000 * 60 * 5;
+/** Shared-client retention: entries survive 30 minutes after unmount. */
+const GC_MS = 1000 * 60 * 30;
+
 const DEFAULT_OPTIONS = {
   queries: {
-    staleTime: 1000 * 60 * 5,
+    staleTime: STALE_MS,
+    gcTime: GC_MS,
+    // Detail reads map 404s to settled null data (see
+    // runAdapterRequestOrNull), so absent slugs never enter the error
+    // channel; other failures retry once.
     retry: 1,
     refetchOnWindowFocus: false,
   },
-} as const;
+};
 
 /**
  * Fallback client: unit tests and code outside a request scope (client

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,6 +1,12 @@
 import { createRouter } from "@solidjs/router";
 import { getQueryClient } from "~/libs/query-client";
-import { fetchPostBySlug, fetchPosts, fetchWorks, fetchWorkBySlug } from "~/server/adapter";
+import {
+  POSTS_PAGE_SIZE,
+  fetchPostBySlug,
+  fetchPosts,
+  fetchWorks,
+  fetchWorkBySlug,
+} from "~/server/adapter";
 import NotFound from "~/routes/[...404]";
 import About from "~/routes/about";
 import Accessibility from "~/routes/accessibility";
@@ -32,19 +38,21 @@ export const Router = createRouter({
     {
       path: "/guestbook",
       component: Guestbook,
-      preload: () => {
+      preload: () =>
         getQueryClient()
           .prefetchQuery({ queryKey: ["guestbook-entries"], queryFn: fetchEntries })
-          .catch(ignoredPrefetchError);
-      },
+          .catch(ignoredPrefetchError),
     },
     {
       path: "/posts",
       component: PostsHome,
       preload: ({ location }) => {
-        const page = Number(location.query.page) || 1;
-        getQueryClient()
-          .prefetchQuery({ queryKey: ["posts", page], queryFn: () => fetchPosts(page, 5) })
+        const page = Math.max(1, Math.floor(Number(location.query.page) || 1));
+        return getQueryClient()
+          .prefetchQuery({
+            queryKey: ["posts", page],
+            queryFn: () => fetchPosts(page, POSTS_PAGE_SIZE),
+          })
           .catch(ignoredPrefetchError);
       },
     },
@@ -52,37 +60,36 @@ export const Router = createRouter({
       path: "/posts/:slug",
       component: PostPage,
       preload: ({ params }) => {
-        if (params.slug) {
-          getQueryClient()
-            .prefetchQuery({
-              queryKey: ["post", params.slug],
-              queryFn: () => fetchPostBySlug(params.slug as string),
-            })
-            .catch(ignoredPrefetchError);
-        }
+        const slug = params.slug;
+        if (!slug) return undefined;
+        return getQueryClient()
+          .prefetchQuery({
+            queryKey: ["post", slug],
+            queryFn: () => fetchPostBySlug(slug),
+          })
+          .catch(ignoredPrefetchError);
       },
     },
     {
       path: "/work",
       component: WorkHome,
-      preload: () => {
+      preload: () =>
         getQueryClient()
           .prefetchQuery({ queryKey: ["works"], queryFn: () => fetchWorks() })
-          .catch(ignoredPrefetchError);
-      },
+          .catch(ignoredPrefetchError),
     },
     {
       path: "/work/:slug",
       component: WorkPage,
       preload: ({ params }) => {
-        if (params.slug) {
-          getQueryClient()
-            .prefetchQuery({
-              queryKey: ["work", params.slug],
-              queryFn: () => fetchWorkBySlug(params.slug as string),
-            })
-            .catch(ignoredPrefetchError);
-        }
+        const slug = params.slug;
+        if (!slug) return undefined;
+        return getQueryClient()
+          .prefetchQuery({
+            queryKey: ["work", slug],
+            queryFn: () => fetchWorkBySlug(slug),
+          })
+          .catch(ignoredPrefetchError);
       },
     },
     { path: "/work/wwwork/hold", component: Hold },

--- a/apps/web/src/routes/__tests__/post-meta.test.tsx
+++ b/apps/web/src/routes/__tests__/post-meta.test.tsx
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { createRouter, memoryHistory } from "@solidjs/router";
-import { QueryClientProvider } from "@tanstack/solid-query";
-import { queryClient } from "~/libs/query-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import { HttpError } from "@tom/types/errors";
 import PostPage from "~/routes/posts/[slug]";
 
 vi.mock("~/server/adapter", () => ({
@@ -30,18 +30,21 @@ const TestRouter = createRouter({
   routes: [{ path: "/posts/:slug", component: PostPage }],
 });
 
-const renderPostPage = () =>
-  render(() => (
-    <QueryClientProvider client={queryClient}>
+const renderPostPage = () => {
+  // Fresh client per test: no shared cache between cases, and no retries so
+  // error states settle within the default waitFor timeout.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(() => (
+    <QueryClientProvider client={client}>
       <TestRouter />
     </QueryClientProvider>
   ));
+};
 
 const headMeta = (selector: string): string | null | undefined =>
   document.head.querySelector(selector)?.getAttribute("content");
 
 beforeEach(() => {
-  queryClient.clear();
   mockedFetchPostBySlug.mockReset();
 });
 
@@ -89,5 +92,30 @@ describe("post page meta tags", () => {
     await waitFor(() => expect(screen.getByText("A pattern language")).toBeTruthy());
 
     expect(headMeta('meta[property="og:title"]')).toBe("A pattern language | Tom Hackshaw");
+  });
+
+  it("shows a spinner — not Not found — while the post is loading", async () => {
+    mockedFetchPostBySlug.mockReturnValue(new Promise(() => {}));
+    renderPostPage();
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(screen.queryByText("Not found")).toBeNull();
+  });
+
+  it("shows Not found once a missing slug settles to null", async () => {
+    mockedFetchPostBySlug.mockResolvedValue(null);
+    renderPostPage();
+    await waitFor(() => expect(screen.getByText("Not found")).toBeTruthy());
+    expect(screen.getByText('The post "a-pattern-language" does not exist.')).toBeTruthy();
+    expect(document.head.querySelector("title")?.textContent).toBe("Not found | Tom Hackshaw");
+  });
+
+  it("shows an error banner — not Not found — on a server error", async () => {
+    mockedFetchPostBySlug.mockRejectedValue(
+      new HttpError({ message: "Adapter request failed", status: 500 }),
+    );
+    renderPostPage();
+    await waitFor(() => expect(screen.getByText("Error loading post")).toBeTruthy());
+    expect(screen.queryByText("Not found")).toBeNull();
+    expect(document.head.querySelector("title")?.textContent).toBe("Error | Tom Hackshaw");
   });
 });

--- a/apps/web/src/routes/__tests__/posts.test.tsx
+++ b/apps/web/src/routes/__tests__/posts.test.tsx
@@ -6,6 +6,7 @@ import { queryClient } from "~/libs/query-client";
 import PostsHome from "~/routes/posts/index";
 
 vi.mock("~/server/adapter", () => ({
+  POSTS_PAGE_SIZE: 5,
   fetchPosts: vi.fn(),
 }));
 

--- a/apps/web/src/routes/__tests__/posts.test.tsx
+++ b/apps/web/src/routes/__tests__/posts.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createRouter, memoryHistory } from "@solidjs/router";
 import { QueryClientProvider } from "@tanstack/solid-query";
 import { queryClient } from "~/libs/query-client";
@@ -92,4 +92,38 @@ describe("posts page", () => {
     renderPosts();
     await waitFor(() => expect(screen.getByText("No posts found.")).toBeTruthy());
   });
+
+  it("swaps to page 2 on client navigation", async () => {
+    // Placeholder data wedged this flow (the new page never replaced the
+    // old one), so pin the swap: click Next, page 2 renders, page 1 clears.
+    const oldest = {
+      id: "post-9",
+      title: "Oldest post",
+      summary: "The oldest",
+      slug: "oldest-post",
+      publishedAt: "2020-01-01T00:00:00.000Z",
+      meta: { description: "Old" },
+    };
+    mockedFetchPosts.mockImplementation((page: number) =>
+      Promise.resolve(
+        page === 2
+          ? { ...postsData, docs: [oldest], page: 2, totalPages: 2 }
+          : { ...postsData, totalPages: 2 },
+      ),
+    );
+    const NavRouter = createRouter({
+      history: memoryHistory("/posts"),
+      routes: [{ path: "/posts", component: PostsHome }],
+    });
+    render(() => (
+      <QueryClientProvider client={queryClient}>
+        <NavRouter />
+      </QueryClientProvider>
+    ));
+    await waitFor(() => expect(screen.getByText("A pattern language")).toBeTruthy());
+    fireEvent.click(screen.getByRole("link", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("Oldest post")).toBeTruthy());
+    expect(screen.queryByText("A pattern language")).toBeNull();
+    expect(mockedFetchPosts).toHaveBeenCalledWith(2, 5);
+  }, 10000);
 });

--- a/apps/web/src/routes/__tests__/work-meta.test.tsx
+++ b/apps/web/src/routes/__tests__/work-meta.test.tsx
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { createRouter, memoryHistory } from "@solidjs/router";
-import { QueryClientProvider } from "@tanstack/solid-query";
-import { queryClient } from "~/libs/query-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import { HttpError } from "@tom/types/errors";
 import WorkPage from "~/routes/work/[slug]";
 
 vi.mock("~/server/adapter", () => ({
@@ -28,18 +28,21 @@ const TestRouter = createRouter({
   routes: [{ path: "/work/:slug", component: WorkPage }],
 });
 
-const renderWorkPage = () =>
-  render(() => (
-    <QueryClientProvider client={queryClient}>
+const renderWorkPage = () => {
+  // Fresh client per test: no shared cache between cases, and no retries so
+  // error states settle within the default waitFor timeout.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(() => (
+    <QueryClientProvider client={client}>
       <TestRouter />
     </QueryClientProvider>
   ));
+};
 
 const headMeta = (selector: string): string | null | undefined =>
   document.head.querySelector(selector)?.getAttribute("content");
 
 beforeEach(() => {
-  queryClient.clear();
   mockedFetchWorkBySlug.mockReset();
 });
 
@@ -72,5 +75,30 @@ describe("work page meta tags", () => {
 
     expect(headMeta('meta[property="og:image"]')).toBe(imageUrl);
     expect(headMeta('meta[name="twitter:image"]')).toBe(imageUrl);
+  });
+
+  it("shows a spinner — not Not found — while the work is loading", async () => {
+    mockedFetchWorkBySlug.mockReturnValue(new Promise(() => {}));
+    renderWorkPage();
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(screen.queryByText("Not found")).toBeNull();
+  });
+
+  it("shows Not found once a missing slug settles to null", async () => {
+    mockedFetchWorkBySlug.mockResolvedValue(null);
+    renderWorkPage();
+    await waitFor(() => expect(screen.getByText("Not found")).toBeTruthy());
+    expect(screen.getByText('The work "an-idea-for-a-performance" does not exist.')).toBeTruthy();
+    expect(document.head.querySelector("title")?.textContent).toBe("Not found | Tom Hackshaw");
+  });
+
+  it("shows an error banner — not Not found — on a server error", async () => {
+    mockedFetchWorkBySlug.mockRejectedValue(
+      new HttpError({ message: "Adapter request failed", status: 500 }),
+    );
+    renderWorkPage();
+    await waitFor(() => expect(screen.getByText("Error loading work")).toBeTruthy());
+    expect(screen.queryByText("Not found")).toBeNull();
+    expect(document.head.querySelector("title")?.textContent).toBe("Error | Tom Hackshaw");
   });
 });

--- a/apps/web/src/routes/posts/[slug].tsx
+++ b/apps/web/src/routes/posts/[slug].tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo } from "solid-js";
+import { Match, Switch, createMemo } from "solid-js";
 import { useParams } from "@solidjs/router";
 import { httpHeader } from "@solidjs/web";
 import { useQuery } from "@tanstack/solid-query";
@@ -7,18 +7,12 @@ import { PageLayout } from "@tom/ui/PageLayout";
 import { Text } from "@tom/ui/text";
 import { BlurInSection } from "~/components/BlurInSection";
 import { BlurInText } from "~/components/BlurInText";
-import { ArenaCarousel } from "~/components/Arena";
-
-const PostNotFound = ({ slug }: { slug: string | undefined }) => (
-  <PageLayout title="Not found" description="The page you are looking for does not exist.">
-    <article>
-      <BlurInText text="Not found" tag="h1" baseDelay={0.1} step={0.025} />
-      <BlurInSection delay={0.3}>
-        <Text>The post "{slug}" does not exist.</Text>
-      </BlurInSection>
-    </article>
-  </PageLayout>
-);
+import {
+  DetailArenaBlocks,
+  DetailError,
+  DetailLoading,
+  DetailNotFound,
+} from "~/components/DetailStates";
 
 export default function PostPage() {
   const params = useParams();
@@ -30,74 +24,76 @@ export default function PostPage() {
   const postQuery = useQuery(() => ({
     queryKey: ["post", slug()],
     queryFn: () => {
-      const s = slug();
-      if (!s) return Promise.reject(new Error("No slug"));
-      return fetchPostBySlug(s);
+      const currentSlug = slug();
+      if (!currentSlug) return Promise.resolve(null);
+      return fetchPostBySlug(currentSlug);
     },
     // Hold the SSR stream until the post resolves, so the <head> is flushed
     // with title/og meta instead of an empty head.
     deferStream: true,
+    // Absent slugs settle as null data: evict fast so a freshly published
+    // slug refetches instead of replaying Not found from the cache.
+    gcTime: 1000 * 60,
   }));
 
   return (
-    // Unknown slugs resolve the post query to null; without a fallback the
-    // page renders nothing (or crashes on a missing title) instead of a
-    // not-found state.
-    <Show when={postQuery.data} fallback={<PostNotFound slug={slug()} />}>
-      {(data) => {
-        const d = data();
-        if (!d.title) return <PostNotFound slug={slug()} />;
-        return (
-          <PageLayout
-            title={d.title}
-            description={d.summary || d.meta?.description || ""}
-            canonical={`https://tom.so/posts/${slug()}`}
-            jsonLd={{
-              "@context": "https://schema.org",
-              "@type": "BlogPosting",
-              headline: d.title,
-              description: d.summary || d.meta?.description || "",
-              datePublished: d.publishedAt ?? "",
-              dateModified: d.updatedAt ?? "",
-              url: `https://tom.so/posts/${slug()}`,
-              author: { "@type": "Person", name: "Tom Hackshaw" },
-            }}
-          >
-            <article>
-              <BlurInText text={d.title} tag="h1" baseDelay={0.1} step={0.025} />
-              <BlurInSection delay={0.3}>
-                <Text variant="heading" as="h2">
-                  {d.meta?.description ?? ""}
-                </Text>
-              </BlurInSection>
-              <BlurInSection delay={0.5}>
-                {d.publishedAt ? (
-                  <Text variant="secondary" size="sm" as="time">
-                    {new Date(d.publishedAt ?? "").toLocaleDateString("en-NZ", {
-                      year: "numeric",
-                      month: "long",
-                      day: "numeric",
-                    })}
+    // Absent posts settle as null data (the fetcher maps 404s in the Effect
+    // layer): pending renders loading, settled data renders content,
+    // settled error renders the banner, settled null falls to not-found.
+    <Switch fallback={<DetailNotFound kind="post" slug={slug()} />}>
+      <Match when={postQuery.isPending}>
+        <DetailLoading />
+      </Match>
+      <Match when={postQuery.data}>
+        {(data) => {
+          const post = data();
+          return (
+            <PageLayout
+              title={post.title}
+              // An empty summary falls back to the meta description.
+              description={post.summary || post.meta?.description || ""}
+              canonical={`https://tom.so/posts/${slug()}`}
+              jsonLd={{
+                "@context": "https://schema.org",
+                "@type": "BlogPosting",
+                headline: post.title,
+                description: post.summary || post.meta?.description || "",
+                datePublished: post.publishedAt ?? "",
+                dateModified: post.updatedAt ?? "",
+                url: `https://tom.so/posts/${slug()}`,
+                author: { "@type": "Person", name: "Tom Hackshaw" },
+              }}
+            >
+              <article>
+                <BlurInText text={post.title} tag="h1" baseDelay={0.1} step={0.025} />
+                <BlurInSection delay={0.3}>
+                  <Text variant="heading" as="h2">
+                    {post.meta?.description ?? ""}
                   </Text>
-                ) : null}
-              </BlurInSection>
-              <BlurInSection delay={0.7}>
-                <div class="pt-8" innerHTML={d.html ?? ""} />
-              </BlurInSection>
-              <For each={d.arenaBlocks ?? []}>
-                {(block, index) => (
-                  <BlurInSection delay={0.9 + index() * 0.2}>
-                    <ArenaCarousel
-                      slug={block.slug}
-                      {...(block.title ? { title: block.title } : {})}
-                    />
-                  </BlurInSection>
-                )}
-              </For>
-            </article>
-          </PageLayout>
-        );
-      }}
-    </Show>
+                </BlurInSection>
+                <BlurInSection delay={0.5}>
+                  {post.publishedAt ? (
+                    <Text variant="secondary" size="sm" as="time">
+                      {new Date(post.publishedAt).toLocaleDateString("en-NZ", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </Text>
+                  ) : null}
+                </BlurInSection>
+                <BlurInSection delay={0.7}>
+                  <div class="pt-8" innerHTML={post.html ?? ""} />
+                </BlurInSection>
+                <DetailArenaBlocks blocks={post.arenaBlocks ?? []} baseDelay={0.9} />
+              </article>
+            </PageLayout>
+          );
+        }}
+      </Match>
+      <Match when={postQuery.isError}>
+        <DetailError kind="post" message={postQuery.error?.message ?? "Load failed"} />
+      </Match>
+    </Switch>
   );
 }

--- a/apps/web/src/routes/posts/index.tsx
+++ b/apps/web/src/routes/posts/index.tsx
@@ -1,7 +1,7 @@
 import { httpHeader } from "@solidjs/web";
 import { useLocation } from "@solidjs/router";
-import { useQuery } from "@tanstack/solid-query";
-import { fetchPosts } from "~/server/adapter";
+import { keepPreviousData, useQuery } from "@tanstack/solid-query";
+import { POSTS_PAGE_SIZE, fetchPosts } from "~/server/adapter";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { Text } from "@tom/ui/text";
 import { Loading, Show, For } from "solid-js";
@@ -15,11 +15,16 @@ export default function PostsHome() {
   httpHeader("CDN-Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
 
   const location = useLocation();
-  const currentPage = () => Number(location.query.page) || 1;
+  const currentPage = () => Math.max(1, Math.floor(Number(location.query.page) || 1));
 
   const postsQuery = useQuery(() => ({
     queryKey: ["posts", currentPage()],
-    queryFn: () => fetchPosts(currentPage(), 5),
+    queryFn: () => fetchPosts(currentPage(), POSTS_PAGE_SIZE),
+    // Hold the SSR stream until the list resolves, so a direct load paints
+    // with items instead of a blank spinner. keepPreviousData keeps the
+    // previous page visible while the next page fetches.
+    deferStream: true,
+    placeholderData: keepPreviousData,
   }));
 
   return (
@@ -49,11 +54,14 @@ export default function PostsHome() {
           </Show>
           <Show when={postsQuery.data}>
             {(result) => {
-              const r = result();
+              const postsPage = result();
               return (
                 <>
-                  <Show when={r.docs && r.docs.length > 0}>
-                    <For each={r.docs}>
+                  <Show
+                    when={postsPage.docs.length > 0}
+                    fallback={<Text variant="secondary">No posts found.</Text>}
+                  >
+                    <For each={postsPage.docs}>
                       {(post) => (
                         <Link
                           variant="current"
@@ -78,17 +86,18 @@ export default function PostsHome() {
                       )}
                     </For>
                   </Show>
-                  <Show when={!r.docs || r.docs.length === 0}>
-                    <Text variant="secondary">No posts found.</Text>
-                  </Show>
                   <div class="justify-between flex item-center">
-                    <Show when={r.page > 1}>
-                      <Link variant="current" preload={true} href={`/posts?page=${r.page - 1}`}>
+                    <Show when={postsPage.page > 1}>
+                      <Link
+                        variant="current"
+                        preload={true}
+                        href={`/posts?page=${postsPage.page - 1}`}
+                      >
                         Previous
                       </Link>
                     </Show>
-                    <Show when={r.page < r.totalPages}>
-                      <Link variant="current" href={`/posts?page=${r.page + 1}`}>
+                    <Show when={postsPage.page < postsPage.totalPages}>
+                      <Link variant="current" href={`/posts?page=${postsPage.page + 1}`}>
                         Next
                       </Link>
                     </Show>

--- a/apps/web/src/routes/posts/index.tsx
+++ b/apps/web/src/routes/posts/index.tsx
@@ -1,6 +1,6 @@
 import { httpHeader } from "@solidjs/web";
 import { useLocation } from "@solidjs/router";
-import { keepPreviousData, useQuery } from "@tanstack/solid-query";
+import { useQuery } from "@tanstack/solid-query";
 import { POSTS_PAGE_SIZE, fetchPosts } from "~/server/adapter";
 import { PageLayout } from "@tom/ui/PageLayout";
 import { Text } from "@tom/ui/text";
@@ -21,10 +21,11 @@ export default function PostsHome() {
     queryKey: ["posts", currentPage()],
     queryFn: () => fetchPosts(currentPage(), POSTS_PAGE_SIZE),
     // Hold the SSR stream until the list resolves, so a direct load paints
-    // with items instead of a blank spinner. keepPreviousData keeps the
-    // previous page visible while the next page fetches.
+    // with items instead of a blank spinner. No placeholderData: keeping the
+    // previous page as placeholder wedges key-change navigation on this
+    // Query version — the new page never replaces it (pinned by the
+    // pagination test below).
     deferStream: true,
-    placeholderData: keepPreviousData,
   }));
 
   return (

--- a/apps/web/src/routes/work/[slug].tsx
+++ b/apps/web/src/routes/work/[slug].tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo } from "solid-js";
+import { Match, Switch, createMemo } from "solid-js";
 import { useParams } from "@solidjs/router";
 import { httpHeader } from "@solidjs/web";
 import { useQuery } from "@tanstack/solid-query";
@@ -7,18 +7,12 @@ import { PageLayout } from "@tom/ui/PageLayout";
 import { Text } from "@tom/ui/text";
 import { BlurInSection } from "~/components/BlurInSection";
 import { BlurInText } from "~/components/BlurInText";
-import { ArenaCarousel } from "~/components/Arena";
-
-const WorkNotFound = ({ slug }: { slug: string | undefined }) => (
-  <PageLayout title="Not found" description="The page you are looking for does not exist.">
-    <article>
-      <BlurInText text="Not found" tag="h1" baseDelay={0.1} step={0.025} />
-      <BlurInSection delay={0.3}>
-        <Text>The work "{slug}" does not exist.</Text>
-      </BlurInSection>
-    </article>
-  </PageLayout>
-);
+import {
+  DetailArenaBlocks,
+  DetailError,
+  DetailLoading,
+  DetailNotFound,
+} from "~/components/DetailStates";
 
 export default function WorkPage() {
   const params = useParams();
@@ -30,59 +24,61 @@ export default function WorkPage() {
   const workQuery = useQuery(() => ({
     queryKey: ["work", slug()],
     queryFn: () => {
-      const s = slug();
-      if (!s) return Promise.reject(new Error("No slug"));
-      return fetchWorkBySlug(s);
+      const currentSlug = slug();
+      if (!currentSlug) return Promise.resolve(null);
+      return fetchWorkBySlug(currentSlug);
     },
     // Hold the SSR stream until the work resolves, so the <head> is flushed
     // with title/og meta instead of an empty head.
     deferStream: true,
+    // Absent slugs settle as null data: evict fast so a freshly published
+    // slug refetches instead of replaying Not found from the cache.
+    gcTime: 1000 * 60,
   }));
 
   return (
-    // Unknown slugs resolve the work query to null; without a fallback the
-    // page renders nothing (or crashes on a missing title) instead of a
-    // not-found state.
-    <Show when={workQuery.data} fallback={<WorkNotFound slug={slug()} />}>
-      {(data) => {
-        const d = data();
-        if (!d.title) return <WorkNotFound slug={slug()} />;
-        return (
-          <PageLayout
-            title={d.title}
-            description={d.summary || d.meta?.description || ""}
-            canonical={`https://tom.so/work/${slug()}`}
-            jsonLd={{
-              "@context": "https://schema.org",
-              "@type": "CreativeWork",
-              name: d.title,
-              description: d.summary || d.meta?.description || "",
-              url: `https://tom.so/work/${slug()}`,
-              author: { "@type": "Person", name: "Tom Hackshaw" },
-            }}
-          >
-            <article>
-              <BlurInText text={d.title} tag="h1" baseDelay={0.1} step={0.025} />
-              <BlurInSection delay={0.3}>
-                <Text>{d.summary ?? ""}</Text>
-              </BlurInSection>
-              <BlurInSection delay={0.5}>
-                <div innerHTML={d.html ?? ""} />
-              </BlurInSection>
-              <For each={d.arenaBlocks ?? []}>
-                {(block, index) => (
-                  <BlurInSection delay={0.7 + index() * 0.2}>
-                    <ArenaCarousel
-                      slug={block.slug}
-                      {...(block.title ? { title: block.title } : {})}
-                    />
-                  </BlurInSection>
-                )}
-              </For>
-            </article>
-          </PageLayout>
-        );
-      }}
-    </Show>
+    // Absent works settle as null data (the fetcher maps 404s in the Effect
+    // layer): pending renders loading, settled data renders content,
+    // settled error renders the banner, settled null falls to not-found.
+    <Switch fallback={<DetailNotFound kind="work" slug={slug()} />}>
+      <Match when={workQuery.isPending}>
+        <DetailLoading />
+      </Match>
+      <Match when={workQuery.data}>
+        {(data) => {
+          const work = data();
+          return (
+            <PageLayout
+              title={work.title}
+              // An empty summary falls back to the meta description.
+              description={work.summary || work.meta?.description || ""}
+              canonical={`https://tom.so/work/${slug()}`}
+              jsonLd={{
+                "@context": "https://schema.org",
+                "@type": "CreativeWork",
+                name: work.title,
+                description: work.summary || work.meta?.description || "",
+                url: `https://tom.so/work/${slug()}`,
+                author: { "@type": "Person", name: "Tom Hackshaw" },
+              }}
+            >
+              <article>
+                <BlurInText text={work.title} tag="h1" baseDelay={0.1} step={0.025} />
+                <BlurInSection delay={0.3}>
+                  <Text>{work.summary ?? ""}</Text>
+                </BlurInSection>
+                <BlurInSection delay={0.5}>
+                  <div innerHTML={work.html ?? ""} />
+                </BlurInSection>
+                <DetailArenaBlocks blocks={work.arenaBlocks ?? []} baseDelay={0.7} />
+              </article>
+            </PageLayout>
+          );
+        }}
+      </Match>
+      <Match when={workQuery.isError}>
+        <DetailError kind="work" message={workQuery.error?.message ?? "Load failed"} />
+      </Match>
+    </Switch>
   );
 }

--- a/apps/web/src/routes/work/index.tsx
+++ b/apps/web/src/routes/work/index.tsx
@@ -16,6 +16,9 @@ export default function WorkHome() {
   const worksQuery = useQuery(() => ({
     queryKey: ["works"],
     queryFn: () => fetchWorks(),
+    // Hold the SSR stream until the list resolves, so a direct load paints
+    // with items instead of a blank spinner.
+    deferStream: true,
   }));
 
   return (

--- a/apps/web/src/server/__tests__/adapter.test.ts
+++ b/apps/web/src/server/__tests__/adapter.test.ts
@@ -31,13 +31,13 @@ afterEach(() => {
 
 describe("server functions", () => {
   describe("fetchPosts", () => {
-    it("calls the adapter posts endpoint with pagination and returns the list", async () => {
+    it("calls the adapter post summaries endpoint with pagination and returns the list", async () => {
       const body = { docs: [{ id: "post-1" }], totalDocs: 1, page: 2, totalPages: 1 };
       fetchMock.mockResolvedValue(jsonResponse(body));
       const result = await fetchPosts(2, 5);
       expect(result).toEqual(body);
       expect(fetchMock).toHaveBeenCalledWith(
-        "http://localhost:8788/content/posts?page=2&pageSize=5",
+        "http://localhost:8788/content/posts/summary?page=2&pageSize=5",
         expect.anything(),
       );
     });
@@ -55,7 +55,7 @@ describe("server functions", () => {
       );
     });
 
-    it("throws an HttpError carrying the adapter status and message", async () => {
+    it("resolves null for a 404 problem response", async () => {
       fetchMock.mockResolvedValue(
         jsonResponse(
           {
@@ -66,24 +66,38 @@ describe("server functions", () => {
           404,
         ),
       );
+      await expect(fetchPostBySlug("missing")).resolves.toBeNull();
+    });
+
+    it("throws an HttpError carrying the adapter status and message", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          {
+            type: "https://errors.tom.so/internal",
+            status: 500,
+            title: "Internal error",
+          },
+          500,
+        ),
+      );
       try {
-        await fetchPostBySlug("missing");
+        await fetchPostBySlug("broken");
         expect.unreachable();
       } catch (error) {
         expect(error).toBeInstanceOf(HttpError);
-        expect(error).toMatchObject({ status: 404, message: "Not found" });
+        expect(error).toMatchObject({ status: 500, message: "Internal error" });
       }
     });
   });
 
   describe("fetchWorks", () => {
-    it("calls the adapter works endpoint", async () => {
+    it("calls the adapter work summaries endpoint", async () => {
       const works = { docs: [{ id: "work-1", title: "Hyperjam" }], totalDocs: 1 };
       fetchMock.mockResolvedValue(jsonResponse(works));
       const result = await fetchWorks();
       expect(result).toEqual(works);
       expect(fetchMock).toHaveBeenCalledWith(
-        "http://localhost:8788/content/works",
+        "http://localhost:8788/content/works/summary",
         expect.anything(),
       );
     });
@@ -99,6 +113,40 @@ describe("server functions", () => {
         "http://localhost:8788/content/works/hyperjam",
         expect.anything(),
       );
+    });
+
+    it("resolves null for a 404 problem response", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          {
+            type: "https://errors.tom.so/not-found",
+            status: 404,
+            title: "Not found",
+          },
+          404,
+        ),
+      );
+      await expect(fetchWorkBySlug("missing")).resolves.toBeNull();
+    });
+
+    it("throws an HttpError carrying the adapter status and message", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(
+          {
+            type: "https://errors.tom.so/internal",
+            status: 500,
+            title: "Internal error",
+          },
+          500,
+        ),
+      );
+      try {
+        await fetchWorkBySlug("broken");
+        expect.unreachable();
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error).toMatchObject({ status: 500, message: "Internal error" });
+      }
     });
   });
 

--- a/apps/web/src/server/adapter.ts
+++ b/apps/web/src/server/adapter.ts
@@ -1,19 +1,41 @@
-import { callAdapter, runAdapterRequest } from "~/libs/adapter";
+import { callAdapter, runAdapterRequest, runAdapterRequestOrNull } from "~/libs/adapter";
+import type {
+  ArenaRef,
+  CmsListResponse,
+  CmsPost,
+  CmsPostSummary,
+  CmsWork,
+  CmsWorkSummary,
+} from "@tom/schemas/cms";
 
-export function fetchPosts(page: number, pageSize: number) {
-  return runAdapterRequest(() => callAdapter().content.posts.get({ query: { page, pageSize } }));
+/** Posts index page size, shared by the route and its router preload. */
+export const POSTS_PAGE_SIZE = 5;
+
+/** Single post reads carry the adapter-appended arena embeds. */
+export type PostWithArena = CmsPost & { readonly arenaBlocks: ReadonlyArray<ArenaRef> };
+
+/** Single work reads carry the adapter-appended arena embeds. */
+export type WorkWithArena = CmsWork & { readonly arenaBlocks: ReadonlyArray<ArenaRef> };
+
+export function fetchPosts(
+  page: number,
+  pageSize: number,
+): Promise<CmsListResponse<CmsPostSummary>> {
+  return runAdapterRequest(() =>
+    callAdapter().content.posts.summary.get({ query: { page, pageSize } }),
+  );
 }
 
-export function fetchPostBySlug(slug: string) {
-  return runAdapterRequest(() => callAdapter().content.posts({ slug }).get());
+export function fetchPostBySlug(slug: string): Promise<PostWithArena | null> {
+  return runAdapterRequestOrNull(() => callAdapter().content.posts({ slug }).get());
 }
 
-export function fetchWorks() {
-  return runAdapterRequest(() => callAdapter().content.works.get());
+export function fetchWorks(): Promise<CmsListResponse<CmsWorkSummary>> {
+  return runAdapterRequest(() => callAdapter().content.works.summary.get());
 }
 
-export function fetchWorkBySlug(slug: string) {
-  return runAdapterRequest(() => callAdapter().content.works({ slug }).get());
+export function fetchWorkBySlug(slug: string): Promise<WorkWithArena | null> {
+  return runAdapterRequestOrNull(() => callAdapter().content.works({ slug }).get());
 }
 
 export function fetchProducts() {

--- a/apps/web/src/server/static-routes.ts
+++ b/apps/web/src/server/static-routes.ts
@@ -56,8 +56,10 @@ export const handleFeed = () =>
 export const handleSitemap = () =>
   Effect.runPromise(
     Effect.all([
-      adapterRequest(() => callAdapter().content.posts.get({ query: { page: 1, pageSize: 500 } })),
-      adapterRequest(() => callAdapter().content.works.get()),
+      adapterRequest(() =>
+        callAdapter().content.posts.summary.get({ query: { page: 1, pageSize: 500 } }),
+      ),
+      adapterRequest(() => callAdapter().content.works.summary.get()),
     ]).pipe(
       Effect.map(([postsResult, worksResult]) => {
         const posts = postsResult.docs;

--- a/packages/schemas/src/cms.ts
+++ b/packages/schemas/src/cms.ts
@@ -183,6 +183,13 @@ export type TiptapInline = Schema.Schema.Type<typeof TiptapInlineSchema>;
 export type TiptapBlock = Schema.Schema.Type<typeof TiptapBlockSchema>;
 export type TiptapDoc = Schema.Schema.Type<typeof TiptapDocSchema>;
 
+/** Arena channel reference embedded in a Tiptap document, in order. */
+export const ArenaRefSchema = Schema.Struct({
+  slug: Schema.String,
+  title: Schema.optional(Schema.String),
+});
+export type ArenaRef = typeof ArenaRefSchema.Type;
+
 export const CmsMetaSchema = Schema.Struct({
   title: Schema.NullOr(Schema.String),
   description: Schema.NullOr(Schema.String),
@@ -250,6 +257,45 @@ export const CmsWorkSchema = Schema.Struct({
   updatedAt: Schema.String,
 });
 export type CmsWork = typeof CmsWorkSchema.Type;
+
+/**
+ * Slim list item: every CmsPost field except the heavy body (content +
+ * html). List views (indexes, sitemaps) never render the body; the summary
+ * endpoints serve this shape so list payloads stay small over the
+ * client → adapter → api hops. Single-item reads keep the full schema.
+ *
+ * Kept in sync with CmsPostSchema by hand (Effect 4 has no Schema.omit);
+ * cms-summary.test.ts pins the key parity.
+ */
+export const CmsPostSummarySchema = Schema.Struct({
+  id: CmsPostId,
+  slug: CmsSlug,
+  title: Schema.String,
+  summary: Schema.NullOr(Schema.String),
+  status: CmsStatusSchema,
+  publishedAt: Schema.NullOr(Schema.String),
+  heroMediaId: Schema.NullOr(CmsMediaId),
+  categories: Schema.Array(CmsCategorySchema),
+  meta: CmsMetaSchema,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+});
+export type CmsPostSummary = typeof CmsPostSummarySchema.Type;
+
+/** Slim list item for works, same rationale as CmsPostSummary. */
+export const CmsWorkSummarySchema = Schema.Struct({
+  id: CmsWorkId,
+  slug: CmsSlug,
+  title: Schema.String,
+  summary: Schema.NullOr(Schema.String),
+  status: CmsStatusSchema,
+  publishedAt: Schema.NullOr(Schema.String),
+  heroMediaId: Schema.NullOr(CmsMediaId),
+  meta: CmsMetaSchema,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+});
+export type CmsWorkSummary = typeof CmsWorkSummarySchema.Type;
 
 export const CmsPostInputSchema = Schema.Struct({
   slug: CmsSlug,
@@ -321,6 +367,13 @@ export const CmsPagingSchema = Schema.Struct({
   pageSize: Schema.optional(PagingNumber),
   status: Schema.optional(CmsStatusFilterSchema),
   category: Schema.optional(CmsSlug),
+  /**
+   * Exclude one category server-side (Sophie hides its reserved "pages"
+   * category from the index without skewing totalDocs/totalPages, which a
+   * client-side filter would). Works routes reject paging carrying either
+   * category key — works have no categories.
+   */
+  excludeCategory: Schema.optional(CmsSlug),
 });
 export type CmsPaging = typeof CmsPagingSchema.Type;
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,6 +9,7 @@
     "./services/config": "./src/services/config.ts",
     "./services/logging": "./src/services/logging.ts",
     "./services/queue": "./src/services/queue.ts",
+    "./services/session": "./src/services/session.ts",
     "./services/worker": "./src/services/worker.ts",
     "./telegram": "./src/telegram.ts",
     "./tiptap-html": "./src/tiptap-html.ts"

--- a/packages/utils/src/services/session.ts
+++ b/packages/utils/src/services/session.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared session-credential gate for CMS reads. Anonymous readers fetch
+ * published-only content and their responses are edge-cacheable; a live
+ * session unlocks drafts and must never store. The API (skip the auth/D1
+ * lookup) and the adapter (cache headers, header forwarding) key off this
+ * one check so the two hops cannot drift.
+ */
+
+/**
+ * better-auth session cookie names (default cookiePrefix). Matched by name,
+ * not substring, so OAuth nonce cookies (better-auth.state-*) never count
+ * as a session. Reads the name before `=` so cookie values cannot smuggle
+ * a match.
+ */
+const SESSION_COOKIE_PATTERN =
+  /(?:^|;\s*)(?:__Secure-)?better-auth\.(?:session_token|session_data)=/;
+
+/** A request carries a session credential when it can unlock drafts. */
+export const hasSessionCredential = (request: Request): boolean => {
+  const cookie = request.headers.get("cookie") ?? "";
+  if (SESSION_COOKIE_PATTERN.test(cookie)) return true;
+  const authorization = request.headers.get("authorization") ?? "";
+  return authorization.toLowerCase().startsWith("bearer ");
+};


### PR DESCRIPTION
Slim summary endpoints (no body columns, no Tiptap parse) for lists and sitemaps. Edge-cache anonymous CMS reads; error responses never store. Session fast-path skips auth/D1 lookup on public reads via shared hasSessionCredential. Detail 404s settle as null data with dedicated loading/not-found/error states (Switch/Match). Reserve the summary slug, reject category filters on works, exclude Sophie pages server-side, and dedupe the list pipeline, mappers, and slug pages.

Verified: web 74, api 130, adapter 113, sophie 14, utils 79, ui 7, editor 96 tests pass; lint 15/15; format clean; typecheck clean except pre-existing @tom/simulator GuestbookEntryJson failure (untouched by this diff).