### PR TITLE
fix(ci,db,e2e,sophie): resolve 5 typecheck errors and gate CI on typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
           pnpm exec oxfmt --write packages/types/src/db.ts
           git diff --exit-code packages/types/src/db.ts
 
+      # Typecheck is a hard merge gate: every workspace with a `typecheck`
+      # script must pass (tsc --noEmit via Turbo) before unit tests run.
+      # It lives in the same required job on purpose, so existing branch
+      # protection keeps enforcing it without settings changes.
+      - name: Run typecheck
+        env:
+          TURBO_API: https://turbo.infra.tom.so
+          TURBO_TOKEN: ${{ secrets.TURBO_CACHE_TOKEN }}
+          TURBO_TEAM: wwwtom
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_CACHE_SIGNATURE_KEY }}
+        run: pnpm turbo run typecheck
+
       # Unit tests run in every workspace with a `test` script: @tom/web,
       # @tom/api, @tom/adapter, @tom/arena and @tom/utils. Turbo builds each
       # package's workspace dependencies first. Task artifacts are shared

--- a/apps/e2e/tests/store.spec.ts
+++ b/apps/e2e/tests/store.spec.ts
@@ -25,7 +25,9 @@ test.describe("store", () => {
 
     for (const product of fixturePolarProducts) {
       await expect(page.getByRole("heading", { name: product.name, level: 2 })).toBeVisible();
-      await expect(page.getByText(product.description)).toBeVisible();
+      if (product.description !== null) {
+        await expect(page.getByText(product.description)).toBeVisible();
+      }
       const price = product.prices?.[0]?.price_amount;
       if (price !== undefined) {
         await expect(page.getByText(`$${price / 100}`)).toBeVisible();
@@ -42,7 +44,9 @@ test.describe("store", () => {
     await expect(
       page.getByRole("heading", { name: "Complete your purchase", level: 1 }),
     ).toBeVisible();
-    await expect(page.getByText(product.description)).toBeVisible();
+    if (product.description !== null) {
+      await expect(page.getByText(product.description)).toBeVisible();
+    }
   });
 
   test("purchase form validates the email", async ({ page }) => {

--- a/apps/sophie/src/lib/posts.ts
+++ b/apps/sophie/src/lib/posts.ts
@@ -1,5 +1,5 @@
 import { Effect, Option, Schema } from "effect";
-import type { CmsCategory, CmsListResponse, CmsPost } from "@tom/schemas/cms";
+import { CmsSlug, type CmsCategory, type CmsListResponse, type CmsPost } from "@tom/schemas/cms";
 import type { HttpError } from "@tom/types/errors";
 import { adapterRequest, callSophie, runClient } from "./api";
 
@@ -39,15 +39,19 @@ export const formatPublishedDate = (value: string | null): string =>
 export const listPosts = (
   page: number,
   category: string | null = null,
-): Effect.Effect<CmsListResponse<CmsPost>, HttpError> =>
-  adapterRequest(() =>
+): Effect.Effect<CmsListResponse<CmsPost>, HttpError> => {
+  const categoryOption =
+    category === null || category === ""
+      ? Option.none<CmsSlug>()
+      : Schema.decodeUnknownOption(CmsSlug)(category);
+  return adapterRequest(() =>
     callSophie().content.posts.get({
-      query:
-        category === null || category === ""
-          ? { page, pageSize: 10 }
-          : { page, pageSize: 10, category },
+      query: Option.isNone(categoryOption)
+        ? { page, pageSize: 10 }
+        : { page, pageSize: 10, category: categoryOption.value },
     }),
   );
+};
 
 /** Get one published Sophie post by slug. */
 export const getPost = (slug: string): Effect.Effect<CmsPost, HttpError> =>

--- a/packages/db/src/generate.ts
+++ b/packages/db/src/generate.ts
@@ -65,6 +65,21 @@ const header = `/**
 const footer = `
 /** Alias keeping the historic @tom/types/db import path stable. */
 export type Database = DB;
+
+/**
+ * Guestbook entry as served over JSON (dates serialized). The simulator and
+ * e2e fixture stores speak this shape; the database row uses Date objects.
+ */
+export type GuestbookEntryJson = {
+  readonly id: number;
+  readonly fediverse_username: string;
+  readonly fediverse_instance: string;
+  readonly display_name: string | null;
+  readonly avatar_url: string | null;
+  readonly message: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
 `;
 const outFile = path.join(import.meta.dirname, "../../types/src/db.ts");
 await fs.writeFile(outFile, `${header}\n${output}${footer}`);

--- a/packages/types/src/db.ts
+++ b/packages/types/src/db.ts
@@ -48,3 +48,18 @@ export interface DB {
 
 /** Alias keeping the historic @tom/types/db import path stable. */
 export type Database = DB;
+
+/**
+ * Guestbook entry as served over JSON (dates serialized). The simulator and
+ * e2e fixture stores speak this shape; the database row uses Date objects.
+ */
+export type GuestbookEntryJson = {
+  readonly id: number;
+  readonly fediverse_username: string;
+  readonly fediverse_instance: string;
+  readonly display_name: string | null;
+  readonly avatar_url: string | null;
+  readonly message: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};


### PR DESCRIPTION
Full typecheck reported 5 errors in 3 packages. This change fixes all 5 and makes typecheck a hard CI gate.

Fixes:
- Restore GuestbookEntryJson through the db generate footer so regeneration keeps it (simulator + e2e fixture store, TS2724)
- Guard null product descriptions in the e2e store spec (TS2345)
- Decode category through branded CmsSlug in Sophie listPosts; invalid slugs fall back to the unfiltered list (TS2322)

CI:
- Run pnpm turbo run typecheck in the existing required test job, before unit tests

Verify:
- pnpm turbo run typecheck passes in all 17 packages
- Sophie tests pass (12 tests, 3 files); lint and format checks pass