### PR TITLE
fix(web,sophie): fail loud on missing request-scoped query client

### DIFF
--- a/apps/sophie/src/lib/query-client.ts
+++ b/apps/sophie/src/lib/query-client.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/solid-query";
-import { getRequestEvent } from "@solidjs/web";
+import { getRequestEvent, isServer } from "@solidjs/web";
+import { RequestScopeMissingError } from "@tom/types/errors";
 
 const DEFAULT_OPTIONS = {
   queries: {
@@ -19,6 +20,19 @@ export const queryClient = new QueryClient({ defaultOptions: DEFAULT_OPTIONS });
 export const createRequestQueryClient = (): QueryClient =>
   new QueryClient({ defaultOptions: DEFAULT_OPTIONS });
 
-/** The client for the current scope: the per-request client on the server, the shared client everywhere else. */
-export const getQueryClient = (): QueryClient =>
-  getRequestEvent()?.locals.queryClient ?? queryClient;
+/**
+ * The client for the current scope: the per-request client on the server,
+ * the shared client everywhere else. A server call without a request client
+ * is a bug — falling back would share one cache across requests — so fail
+ * loud instead of leaking.
+ */
+export const getQueryClient = (): QueryClient => {
+  const client = getRequestEvent()?.locals.queryClient as QueryClient | undefined;
+  if (client) return client;
+  if (isServer) {
+    throw new RequestScopeMissingError({
+      message: "getQueryClient() ran outside a request scope on the server",
+    });
+  }
+  return queryClient;
+};

--- a/apps/web/src/libs/query-client.ts
+++ b/apps/web/src/libs/query-client.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/solid-query";
-import { getRequestEvent } from "@solidjs/web";
+import { getRequestEvent, isServer } from "@solidjs/web";
+import { RequestScopeMissingError } from "@tom/types/errors";
 
 /** List freshness: indexes refetch after 5 minutes stale. */
 const STALE_MS = 1000 * 60 * 5;
@@ -28,6 +29,19 @@ export const queryClient = new QueryClient({ defaultOptions: DEFAULT_OPTIONS });
 export const createRequestQueryClient = (): QueryClient =>
   new QueryClient({ defaultOptions: DEFAULT_OPTIONS });
 
-/** The client for the current scope: the per-request client on the server, the shared client everywhere else. */
-export const getQueryClient = (): QueryClient =>
-  getRequestEvent()?.locals.queryClient ?? queryClient;
+/**
+ * The client for the current scope: the per-request client on the server,
+ * the shared client everywhere else. A server call without a request client
+ * is a bug — falling back would share one cache across requests — so fail
+ * loud instead of leaking.
+ */
+export const getQueryClient = (): QueryClient => {
+  const client = getRequestEvent()?.locals.queryClient as QueryClient | undefined;
+  if (client) return client;
+  if (isServer) {
+    throw new RequestScopeMissingError({
+      message: "getQueryClient() ran outside a request scope on the server",
+    });
+  }
+  return queryClient;
+};

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -130,6 +130,11 @@ export class WorkerEnvMissingError extends Schema.TaggedError<WorkerEnvMissingEr
   messageFields,
 ) {}
 
+export class RequestScopeMissingError extends Schema.TaggedError<RequestScopeMissingError>()(
+  "RequestScopeMissingError",
+  messageFields,
+) {}
+
 export class QueueError extends Schema.TaggedError<QueueError>()(
   "QueueError",
   messageCauseFields,


### PR DESCRIPTION
`getQueryClient()` fell back to the shared module-level client whenever a request event was absent, including on the server. If the SSR request scope ever drops, that silently shares one query cache across requests.

This makes that path fail loud instead of leaking, while the client keeps the shared client.

### Changes

- Add `RequestScopeMissingError` in `@tom/types/errors` (tagged error, matches `WorkerEnvMissingError`).
- `web` and `sophie` `getQueryClient()` throw `RequestScopeMissingError` on the server when no request-scoped client exists.
- The shared module-level client remains the fallback on the client and in tests.

### Checklist

- [x] I've left instructions in this PR for reviewers (where necessary).
- [ ] I've created appropriate, meaningful tests if necessary.
- [x] I've added documentation and/or comments where we are introducing new patterns that aren't already established.
- [x] My changes have (passing) tests.
- [x] I'm confident this PR resolves the issue it is linked to in GitHub.

No new test: the `isServer` branch is a compile-time constant, so it is not reachable in the jsdom test environment. Existing `web` and `sophie` suites cover the accessor path.